### PR TITLE
Add Zig

### DIFF
--- a/update_compilers/install_compilers.sh
+++ b/update_compilers/install_compilers.sh
@@ -757,3 +757,33 @@ for version in \
 ; do
     get_nasm $version
 done
+
+#########################
+# Zig
+
+install_zig() {
+    local VERSION=$1
+    local AUTOMATED_BUILD=$2
+    local DIR=zig-${VERSION}
+    if [[ -d ${DIR} ]]; then
+        echo Zig $VERSION already installed, skipping
+        return
+    fi
+    mkdir ${DIR}
+    pushd ${DIR}
+
+    if [ -z "$AUTOMATED_BUILD" ]; then
+        fetch https://ziglang.org/download/${VERSION}/zig-linux-x86_64-${VERSION}.tar.xz | tar Jxf - --strip-components 1
+    else
+        fetch https://ziglang.org/builds/zig-linux-x86_64-${VERSION}.tar.xz | tar Jxf - --strip-components 1
+    fi
+
+    rm -f langref.html
+
+    popd
+    do_strip ${DIR}
+}
+
+if install_nightly; then
+    install_zig master 1
+fi


### PR DESCRIPTION
See https://github.com/mattgodbolt/compiler-explorer/pull/1069.

We always install master even if nightly isn't specifically requested as we are a fairly fast moving target currently and this tends to be the go-to version.

0.3.0 will be released in a few weeks and this version can be added at that time. 0.2.0 is omitted for now since it is quite outdated and not really representative.