### PR TITLE
Add libuv to libraries.yaml

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -206,6 +206,13 @@ libraries:
         - 2.3.5
         - 2.3.6
         - 2.3.7
+    libuv:
+      type: github
+      repo: libuv/libuv
+      build_type: make
+      target_prefix: v
+      targets:
+        - 1.37.0
     xtl:
       type: github
       repo: QuantStack/xtl

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -210,6 +210,7 @@ libraries:
       type: github
       repo: libuv/libuv
       build_type: make
+      check_file: include/uv.h
       target_prefix: v
       targets:
         - 1.37.0


### PR DESCRIPTION
Hi! I'm interested in adding [libuv](https://github.com/libuv/libuv) to the available C and C++ libraries.

I found [an old comment](https://github.com/compiler-explorer/infra/pull/49#issuecomment-347951158) that said "We don't link against libraries when we build", but based on the other available libs I'm guessing this is no longer true? Is there a way for me to test this change locally? I didn't really see any documentation about it, just found this file :)