### PR TITLE
Updated doctest library to version 2.3.8

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -206,6 +206,7 @@ libraries:
         - 2.3.5
         - 2.3.6
         - 2.3.7
+        - 2.3.8
     xtl:
       type: github
       repo: QuantStack/xtl


### PR DESCRIPTION
Requires [this](https://github.com/compiler-explorer/compiler-explorer/pull/1988) PR to be merged as well.