### PR TITLE
Conan Instance commands

### DIFF
--- a/bin/lib/ce.py
+++ b/bin/lib/ce.py
@@ -193,6 +193,10 @@ def admin_cmd(args):
     run_remote_shell(args, AdminInstance.instance())
 
 
+def conan_cmd(args):
+    dispatch_global('conan', args)
+
+
 def conan_login_cmd(args):
     instance = ConanInstance.instance()
     run_remote_shell(args, instance)

--- a/bin/lib/ce.py
+++ b/bin/lib/ce.py
@@ -207,9 +207,14 @@ def conan_exec_cmd(args):
     exec_remote_to_stdout(instance, args['remote_cmd'])
 
 
-def conan_reload_cmd(_):
+def conan_restart_cmd(_):
     instance = ConanInstance.instance()
     exec_remote(instance, ["sudo", "service", "ce-conan", "restart"])
+
+
+def conan_reloadwww_cmd(_):
+    instance = ConanInstance.instance()
+    exec_remote(instance, ["sudo", "git", "-C", "/home/ubuntu/ceconan/conanproxy", "pull"])
 
 
 def builder_cmd(args):
@@ -809,7 +814,8 @@ def main():
     conan_parser = subparsers.add_parser('conan')
     conan_sub = add_required_sub_parsers(conan_parser, 'conan_sub')
     conan_sub.required = True
-    conan_sub.add_parser('reload')
+    conan_sub.add_parser('restart')
+    conan_sub.add_parser('reloadwww')
     conan_sub.add_parser('login')
     conan_exec = conan_sub.add_parser('exec')
     conan_exec.add_argument('remote_cmd', nargs='+', help='command to run on conan node')

--- a/bin/lib/ce.py
+++ b/bin/lib/ce.py
@@ -22,7 +22,7 @@ from lib.amazon import target_group_arn_for, get_autoscaling_group, get_releases
     get_autoscaling_groups_for, download_release_file, download_release_fileobj, log_new_build, list_all_build_logs, \
     list_period_build_logs, get_ssm_param
 from lib.cdn import DeploymentJob
-from lib.instance import AdminInstance, BuilderInstance, Instance, print_instances
+from lib.instance import ConanInstance, AdminInstance, BuilderInstance, Instance, print_instances
 from lib.ssh import run_remote_shell, exec_remote, exec_remote_all, exec_remote_to_stdout
 
 logger = logging.getLogger('ce')
@@ -191,6 +191,21 @@ def restart_one_instance(as_group_name, instance, modified_groups):
 
 def admin_cmd(args):
     run_remote_shell(args, AdminInstance.instance())
+
+
+def conan_login_cmd(args):
+    instance = ConanInstance.instance()
+    run_remote_shell(args, instance)
+
+
+def conan_exec_cmd(args):
+    instance = ConanInstance.instance()
+    exec_remote_to_stdout(instance, args['remote_cmd'])
+
+
+def conan_reload_cmd(_):
+    instance = ConanInstance.instance()
+    exec_remote(instance, ["sudo", "service", "ce-conan", "restart"])
 
 
 def builder_cmd(args):
@@ -786,6 +801,14 @@ def main():
     builder_sub.add_parser('login')
     builder_exec = builder_sub.add_parser('exec')
     builder_exec.add_argument('remote_cmd', nargs='+', help='command to run on builder node')
+
+    conan_parser = subparsers.add_parser('conan')
+    conan_sub = add_required_sub_parsers(conan_parser, 'conan_sub')
+    conan_sub.required = True
+    conan_sub.add_parser('reload')
+    conan_sub.add_parser('login')
+    conan_exec = conan_sub.add_parser('exec')
+    conan_exec.add_argument('remote_cmd', nargs='+', help='command to run on conan node')
 
     builds_parser = subparsers.add_parser('builds')
     builds_sub = add_required_sub_parsers(builds_parser, 'builds_sub')

--- a/bin/lib/instance.py
+++ b/bin/lib/instance.py
@@ -61,6 +61,16 @@ class AdminInstance:
     def instance():
         return AdminInstance(ec2.Instance(id='i-0988cd194a4a8a2c0'))
 
+class ConanInstance:
+    def __init__(self, instance):
+        self.instance = instance
+        self.elb_health = 'unknown'
+        self.service_status = {'SubState': 'unknown'}
+        self.running_version = 'conan'
+
+    @staticmethod
+    def instance():
+        return ConanInstance(ec2.Instance(id='i-0fbc4d84c0f7994a2'))
 
 class BuilderInstance:
     def __init__(self, instance):


### PR DESCRIPTION
* `ce conan restart` - restarts the service in charge of the proxy and the conanserver, will take about half a minute to restart (no one will be able to download/upload libraries or anything else), so be sure this is Ok before executing
* `ce conan reloadwww` - just does a git pull, so we can edit the HTML page more quickly
* `ce conan login` - login to the instance
