### PR TITLE
Fix typo in libraries.yaml

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -475,7 +475,7 @@ libraries:
         repo: libeigen/eigen
         check_file: README.md
         targets:
-          - vtrunk
+          - trunk
       glm:
         type: github
         method: nightlyclone


### PR DESCRIPTION
While looking at adding the nightly part of #364 , I noticed eigen was the only one with a vtrunk target. Typo or intended ? 