### PR TITLE
Add Go 1.15

### DIFF
--- a/bin/yaml/go.yaml
+++ b/bin/yaml/go.yaml
@@ -23,6 +23,7 @@ compilers:
         - "1.12"
         - "1.13"
         - "1.14"
+        - "1.15"
     nightly:
       if: nightly
       type: nightly


### PR DESCRIPTION
TL;DR golang 1.15 is out

see also https://golang.org/dl/, https://groups.google.com/forum/#!topic/golang-announce/Z-cY6ZdGdEU, https://golang.org/doc/go1.15

I noticed the `etc/config/go.amazon.properties` in compiler-explorer got more comprehensive since the last time I touched it, so I'm still digesting all the architectures, the changes in go1.14→1.15, and try to figure out what can't be copy&pasted from 1.14 to 1.15