### PR TITLE
Add Swift 5.3

### DIFF
--- a/bin/yaml/swift.yaml
+++ b/bin/yaml/swift.yaml
@@ -23,6 +23,7 @@ compilers:
       - '5.0'
       - '5.1'
       - '5.2'
+      - '5.3'
     nightly:
       if: nightly
       type: restQueryTarballs


### PR DESCRIPTION
Adds Swift 5.3 as a compiler. Explorer pr: https://github.com/compiler-explorer/compiler-explorer/pull/2205