### PR TITLE
remove intel installer cache before/after install

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -343,18 +343,22 @@ compilers:
           script: |
             rm -Rf ~/.intel
             rm -Rf ~/intel
+            rm -Rf /var/intel/installercache
             bash {script_filename} -s -a -s --action install --eula accept --components intel.oneapi.lin.cpp-compiler:intel.oneapi.lin.ifort-compiler --install-dir {staging}/{dir}
             rm -Rf ~/.intel
             rm -Rf ~/intel
+            rm -Rf /var/intel/installercache
         - name: 2021.1.9.2205
           fetch:
             - https://registrationcenter-download.intel.com/akdlm/irc_nas/16949/l_HPCKit_b_{name}_offline.sh install.sh
           script: |
             rm -Rf ~/.intel
             rm -Rf ~/intel
+            rm -Rf /var/intel/installercache
             bash {script_filename} -s -a -s --action install --eula accept --components intel.oneapi.lin.dpcpp-cpp-compiler-pro:intel.oneapi.lin.ifort-compiler --install-dir {staging}/{dir}
             rm -Rf ~/.intel
             rm -Rf ~/intel
+            rm -Rf /var/intel/installercache
     nightly:
       if: nightly
       gcc:


### PR DESCRIPTION
The installer saves the install root and other info in /var/intel/installercache. If you are using a different install root for each install, then you may get install errors. Delete the info between installs.