### PR TITLE
Add spdlog (see compiler-explorer/compiler-explorer#2210)

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -453,7 +453,9 @@ libraries:
       subdir: spdlog-{name}
       path_name: libs/spdlog/{name}
       target_prefix: v
-      check_file: include/spdlog/spdlog.h
+      build_type: cmake
+      make_targets:
+        - spdlog
       targets:
         - 1.5.0
         - 1.6.0

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -447,6 +447,19 @@ libraries:
       build_type: none
       targets:
         - trunk
+    spdlog:
+      type: github
+      repo: gabime/spdlog
+      subdir: spdlog-{name}
+      path_name: libs/spdlog/{name}
+      target_prefix: v
+      check_file: include/spdlog/spdlog.h
+      targets:
+        - 1.5.0
+        - 1.6.0
+        - 1.6.1
+        - 1.7.0
+        - 1.8.0
     nightly:
       install_always: true
       if: nightly


### PR DESCRIPTION
My first foray into using the new library.yaml!! :) There _is_ a cmake build too but if I used `build_type: cmake` nothing happened. As it's also header-only I left it; how might I add it to conan so that we can link against it too?

TIA!!