### PR TITLE
Update the CUDA Thrust/CUB libraries.

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -890,10 +890,27 @@ libraries:
     cub:
       type: github
       method: clone_branch
-      repo: NVlabs/cub
+      repo: NVIDIA/cub
       check_file: cub/cub.cuh
       targets:
         - 1.8.0
+    thrustcub:
+      type: github
+      method: clone_branch
+      repo: NVIDIA/thrust
+      check_file: dependencies/cub/cub/cub.cuh
+      targets:
+        - 1.9.9
+        - 1.9.10
+        - 1.9.10-1
+        - 1.10.0
+    thrustcub-nightly:
+      type: github
+      method: nightlyclone
+      repo: NVIDIA/thrust
+      check_file: dependencies/cub/cub/cub.cuh
+      targets:
+        - trunk
     libcudacxx:
       type: github
       method: nightlyclone


### PR DESCRIPTION
Add new versions of the Thrust/CUB libraries for CUDA.

These libraries are now distributed together and version locked, so this PR adds both under a `Thrust + CUB` label. The old standalone 1.8.0 version of CUB is now explicitly labeled as legacy.

Question for the maintainers: will git submodules be fetched and updated automatically? The CUB component lives in a `dependencies/cub` submodule and is needed for the libraries to work properly.
