### PR TITLE
Add Catch2 v3.0.0-preview3 to installed libraries

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -132,6 +132,7 @@ libraries:
       target_prefix: v
       targets:
         - 3.0.0-preview2
+        - 3.0.0-preview3
     cctz:
       type: github
       repo: google/cctz


### PR DESCRIPTION
The new preview was [tagged + released yesterday](https://github.com/catchorg/Catch2/releases/tag/v3.0.0-preview3).


As I understand it, I need to do this before adding it to the list over at compiler-explorer proper.