### PR TITLE
Update vectorclass library 2

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -370,7 +370,8 @@ libraries:
       subdir: vcl
       target_prefix: v
       targets:
-        - 2.00.01
+        - 2.00
+        - 2.01.03
     openssl:
       type: github
       repo: openssl/openssl

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -370,7 +370,7 @@ libraries:
       subdir: vcl
       target_prefix: v
       targets:
-        - 2.00
+        - 2.00.01
         - 2.01.03
     openssl:
       type: github


### PR DESCRIPTION
This is the second attempt to update the VCL to 2.01.03. I am sorry for the earlier mistake in PR #430 , I got confused by the slight inconsistencies in tagging and naming of releases upstream: https://github.com/vectorclass/version2/releases