### PR TITLE
Updating SPY version to 0.0.4

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -323,7 +323,7 @@ libraries:
       repo: jfalcou/spy
       check_file: README.md
       targets:
-        - 0.0.3
+        - 0.0.4
     hedley:
       type: github
       repo: nemequ/hedley


### PR DESCRIPTION
SPY 0.0.4 is available and I shamelessly forgot to upgrade it here.
