### PR TITLE
Add TTS to Compiler Explorer

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -324,6 +324,12 @@ libraries:
       check_file: README.md
       targets:
         - 0.0.3
+    tts:
+      type: github
+      repo: jfalcou/tts
+      check_file: README.md
+      targets:
+        - 0.1
     hedley:
       type: github
       repo: nemequ/hedley
@@ -668,6 +674,14 @@ libraries:
         type: github
         method: nightlyclone
         repo: jfalcou/spy
+        check_file: README.md
+        build_type: none
+        targets:
+          - trunk
+      tts:
+        type: github
+        method: nightlyclone
+        repo: jfalcou/tts
         check_file: README.md
         build_type: none
         targets:


### PR DESCRIPTION
TTS is a C++20 testing library. 
Version 0.1 has been released and I wish to add it to the list of supported libraries in CE
