### PR TITLE
install newest OSACA version (and removed unused versions)

### DIFF
--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -20,9 +20,4 @@ tools:
     package: osaca=={name}
     check_exe: bin/osaca --version
     targets:
-      - 0.3.6
-      - 0.3.7
-      - 0.3.9
-      - 0.3.10
-      - 0.3.11
-      - 0.3.12
+      - 0.3.14


### PR DESCRIPTION
Updated OSACA to version 0.3.14.
I also removed the old versions since they aren't used (and shouldn't, to be honest). Please let me know if I'm wrong here and they are actually needed!

Related to [PR in `compiler-explorer/compiler-explorer`](https://github.com/compiler-explorer/compiler-explorer/pull/2352) repository.