### PR TITLE
Add Eigen 3.3.9 release

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -182,6 +182,8 @@ libraries:
         - 3.3.4
         - 3.3.5
         - 3.3.7
+        - 3.3.8
+        - 3.3.9
     glm:
       type: github
       repo: g-truc/glm

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -182,7 +182,6 @@ libraries:
         - 3.3.4
         - 3.3.5
         - 3.3.7
-        - 3.3.8
         - 3.3.9
     glm:
       type: github


### PR DESCRIPTION
Add the latest releases of the Eigen 3 branch. 
Afaiu 3.3.8 could be left out again, as 3.3.9 is a minimal bugfix release for issues with OpenMP and C++20 in 3.3.8. So it could be treated the same as 3.3.6 and left out. For now I've added it for completeness but have no preference either way. ([Upstream Changelog](https://eigen.tuxfamily.org/index.php?title=ChangeLog#Eigen_3.3.9))