### PR TITLE
zig: add 0.7.0 and 0.7.1 versions

### DIFF
--- a/bin/yaml/zig.yaml
+++ b/bin/yaml/zig.yaml
@@ -14,6 +14,8 @@ compilers:
       - 0.4.0
       - 0.5.0
       - 0.6.0
+      - 0.7.0
+      - 0.7.1
     nightly:
       if: nightly
       type: restQueryTarballs


### PR DESCRIPTION
To go along with https://github.com/compiler-explorer/compiler-explorer/pull/2366