### PR TITLE
Add LLVM 11.0.1

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -327,6 +327,7 @@ compilers:
           - 10.0.0
           - 10.0.1
           - 11.0.0
+          - 11.0.1
     ellccs:
       check_exe: bin/clang++ --version
       dir: ellcc-{name}


### PR DESCRIPTION
I'm working on building 11.0.1 in the CE clang builder, but the build seems to be going fine so far. 