### PR TITLE
Add CNL targets for recent releases

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -151,7 +151,9 @@ libraries:
       build_type: none
       target_prefix: v
       targets:
+        - 1.x
         - 1.0.0
+        - 1.1.5
     cppitertools:
       type: github
       repo: ryanhaining/cppitertools


### PR DESCRIPTION
I'm guessing this is a necessary accompaniment to this [library version update](https://github.com/compiler-explorer/compiler-explorer/pull/2401/files), although 'trunk' isn't featured here.