### PR TITLE
Fix nim nightly install

### DIFF
--- a/bin/yaml/nim.yaml
+++ b/bin/yaml/nim.yaml
@@ -12,15 +12,12 @@ compilers:
       - 1.0.6
       - 1.2.0
       - 1.4.2
-#    nightly:
-#      type: restQueryTarballs
-#      install_always: true
-#      if: nightly
-#      url: https://api.github.com/repos/nim-lang/nightlies/releases/latest
-#      query: ([doc['browser_download_url'] for doc in document['assets'] if 'x86_64' in doc['name']] or [None])[0]
-#      targets:
-#        - linux_x64-nightlies
-# todo: fetch 
-# look for [.assets[] | select(.name | contains(\"${target}\"))][0].browser_download_url
-# download and unpack that
-# See issue #31 for details why this isn't working currently.
+    nightly:
+      install_always: true
+      if: nightly
+      url: https://github.com/nim-lang/nightlies/releases/download/latest-{name}/linux_x64.tar.xz
+      untar_dir: nim-{name}
+      create_untar_dir: true
+      strip_components: 1
+      targets:
+        - devel


### PR DESCRIPTION
See #340

This finally implements the fixes on our end to take advantage of the work done in https://github.com/nim-lang/nightlies/issues/31

The install path of the nightly changes as a result of this, but I think its probably better than trying to maintain backwards naming convention here since what we really want is the latest nightly "devel" build. nim builds many branches nightly.

We will need a matching PR in the main repo to fix the path.