### PR TITLE
Add riscv32 gcc 10.2.0

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -224,6 +224,7 @@ compilers:
           subdir: riscv32
           targets:
             - 8.2.0
+            - 10.2.0
         k1:
           arch_prefix: "k1-unknown-elf"
           check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"


### PR DESCRIPTION
Let's add the RISC-V 32-bit GCC 10.2.0 toolchain.