### PR TITLE
Add ARM gcc 10.2.1 (arm-none-eabi)

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -108,6 +108,15 @@ compilers:
             targets:
               - gcc-arm-none-eabi-9-2019-q4 # name unused in this case
           - type: tarballs
+            check_exe: bin/arm-none-eabi-g++ --version
+            subdir: arm
+            dir: arm/gcc-arm-none-eabi-10-2020-q4-major
+            untar_dir: gcc-arm-none-eabi-10-2020-q4-major
+            url: https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2
+            compression: bz2
+            targets:
+              - gcc-arm-none-eabi-10-2020-q4 # name unused in this case
+          - type: tarballs
             # Not in a subdir
             check_exe: bin/arm-none-eabi-g++ --version
             dir: gcc-arm-none-eabi-5_4-2016q3


### PR DESCRIPTION
Adds a gcc version 10.2.1 option for embedded ARM (arm-none-eabi) targets, which corresponds to the 2020-q4-major release from ARM.

I have also opened a matching request for the main compiler-explorer project.