### PR TITLE
Library Build timeout handling

### DIFF
--- a/.vscode/launch_debug_example.json
+++ b/.vscode/launch_debug_example.json
@@ -1,0 +1,19 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Module",
+            "type": "python",
+            "request": "launch",
+            "module": "lib.ce_install",
+            "cwd": "${workspaceFolder}/bin",
+            "args":[
+                "--dry_run",
+                "--buildfor",
+                "clang_autonsdmi",
+                "build",
+                "spdlog 1.8.0"
+            ]
+        }
+    ]
+}

--- a/bin/lib/library_builder.py
+++ b/bin/lib/library_builder.py
@@ -685,6 +685,8 @@ class LibraryBuilder:
             checkcompiler = ""
         else:
             checkcompiler = buildfor
+            if not (checkcompiler in self.compilerprops):
+                self.logger.error(f'Unknown compiler {checkcompiler}')
 
         for compiler in self.compilerprops:
             if checkcompiler != "" and compiler != checkcompiler:


### PR DESCRIPTION
Old branch, but wondering if we still shouldn't be merging this.
Don't think it will fix anything, but seems reasonable that a library shouldn't take 10 minutes to compile should that ever happen.

I know there were some compilers that were particularly while-loopy, but that was mostly already fixed by this https://github.com/compiler-explorer/infra/blob/main/bin/lib/library_builder.py#L28 which skips clang_lifetime - but there might be other experimental branches or builds that might do the same when building certain things.
