### PR TITLE
[MS] Use and support newer CE commit

### DIFF
--- a/windows/Msvce.psm1
+++ b/windows/Msvce.psm1
@@ -1565,8 +1565,31 @@ function Install-MsvceConfigurationFile {
     return $includeDirectories -join ';'
   }
 
+  function GetLastStableVersion {
+    Param([array] $Versions)
+
+    $c = @($Versions).Count;
+    if ($c -eq 0) {
+      return "";
+    }
+    $c--
+
+    Do {
+      $versionNumber = $Versions[$c]
+
+      $name = Get-MsvceToolsetPrettyName $versionNumber
+      if (-not $name.Contains("latest")) {
+        return $versionNumber
+      }
+
+      $c--
+    } Until ($c -lt 0)
+
+    return $Versions[-1]
+  }
+
   if ($compilerVersions -is [array]) {
-    $lastVersion = $compilerVersions[-1]
+    $lastVersion = GetLastStableVersion $compilerVersions
   } else {
     $lastVersion = $compilerVersions
   }

--- a/windows/Msvce.psm1
+++ b/windows/Msvce.psm1
@@ -1589,15 +1589,15 @@ function Install-MsvceConfigurationFile {
   }
 
   if ($compilerVersions -is [array]) {
-    $lastVersion = GetLastStableVersion $compilerVersions
+    $demanglerVersion = GetLastStableVersion $compilerVersions
   } else {
-    $lastVersion = $compilerVersions
+    $demanglerVersion = $compilerVersions
   }
 
   [string[]] $file = @()
 
   if (-not $CProperties) {
-    $file += "demangler=C:/data/msvc/$lastVersion/bin/Hostx64/x64/undname.exe"
+    $file += "demangler=C:/data/msvc/$demanglerVersion/bin/Hostx64/x64/undname.exe"
   } else {
     $file += "demangler="
     $file += "supportsBinary=false"

--- a/windows/Msvce.psm1
+++ b/windows/Msvce.psm1
@@ -1600,9 +1600,9 @@ function Install-MsvceConfigurationFile {
     $file += "demangler=C:/data/msvc/$demanglerVersion/bin/Hostx64/x64/undname.exe"
   } else {
     $file += "demangler="
-    $file += "supportsBinary=false"
   }
 
+  $file += "supportsBinary=false"
   $file += "compilers=&${compilerIdPrefix}vcpp_x86:&${compilerIdPrefix}vcpp_x64"
   $file += ""
 

--- a/windows/Msvce.psm1
+++ b/windows/Msvce.psm1
@@ -1571,10 +1571,17 @@ function Install-MsvceConfigurationFile {
     $lastVersion = $compilerVersions
   }
 
-  [string[]] $file = @(
-    "demangler=C:/data/msvc/$lastVersion/bin/Hostx64/x64/undname.exe",
-    "compilers=&${compilerIdPrefix}vcpp_x86:&${compilerIdPrefix}vcpp_x64",
-    '')
+  [string[]] $file = @()
+
+  if (-not $CProperties) {
+    $file += "demangler=C:/data/msvc/$lastVersion/bin/Hostx64/x64/undname.exe"
+  } else {
+    $file += "demangler="
+    $file += "supportsBinary=false"
+  }
+
+  $file += "compilers=&${compilerIdPrefix}vcpp_x86:&${compilerIdPrefix}vcpp_x64"
+  $file += ""
 
   function InternalName {
     Param([string]$Arch, [string]$Version)

--- a/windows/files/Dockerfile.template
+++ b/windows/files/Dockerfile.template
@@ -41,4 +41,4 @@ RUN mklink `
   C:\compiler-explorer\static\policies\cookies.html `
   C:\Data\compiler-explorer\cookies.html
 
-CMD C:\node\npx.cmd cross-env NODE_ENV=production C:\node\node app.js --static ./static --port 80 --languages c++ --dist
+CMD C:\node\npx.cmd cross-env NODE_ENV=production C:\node\node -r esm -- app.js --static ./static --port 80 --languages c++ --dist

--- a/windows/msvce-config.json
+++ b/windows/msvce-config.json
@@ -81,10 +81,10 @@
       "2019-08-01": "452193112016D5C8D7E7D69BA39326CBD39C3842",
       "2020-01-29": "4D9E24882EE936DCA6FF31BA1853A0035AD8F81C",
       "2020-05-07": "D04A8CBBCB9578ABDFA494B5CBF054581BBED83D",
-      "2020-11-03": "75ba44c8fd0478882a282fc2d289959aef960837"
+      "2021-02-23": "5ccfd590130616adf770c42fc1d467a61313c92c"
     },
     "git_url": "https://github.com/compiler-explorer/compiler-explorer.git",
-    "git_commit": "75ba44c8fd0478882a282fc2d289959aef960837"
+    "git_commit": "5ccfd590130616adf770c42fc1d467a61313c92c"
   },
   "windows_sdk": {
     "$comment": [

--- a/windows/msvce-config.json
+++ b/windows/msvce-config.json
@@ -80,10 +80,11 @@
       "2018-09-24": "71217A047540FF645B7F5D63B3BD14E8E03B9142",
       "2019-08-01": "452193112016D5C8D7E7D69BA39326CBD39C3842",
       "2020-01-29": "4D9E24882EE936DCA6FF31BA1853A0035AD8F81C",
-      "2020-05-07": "D04A8CBBCB9578ABDFA494B5CBF054581BBED83D"
+      "2020-05-07": "D04A8CBBCB9578ABDFA494B5CBF054581BBED83D",
+      "2020-11-03": "75ba44c8fd0478882a282fc2d289959aef960837"
     },
-    "git_url": "https://github.com/mattgodbolt/compiler-explorer.git",
-    "git_commit": "D04A8CBBCB9578ABDFA494B5CBF054581BBED83D"
+    "git_url": "https://github.com/compiler-explorer/compiler-explorer.git",
+    "git_commit": "75ba44c8fd0478882a282fc2d289959aef960837"
   },
   "windows_sdk": {
     "$comment": [


### PR DESCRIPTION
TODO
* [x] Start CE with the right node params
* [x] Make undname not use latest MSVC, but a more stable version

Probably something about changing https://github.com/compiler-explorer/infra/blob/main/windows/files/Dockerfile.template#L44 to include `-r esm` ? Like we do here https://github.com/compiler-explorer/infra/blob/main/init/start.sh#L76
