### PR TITLE
remove icc beta, add icc 2021.1.2

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -375,25 +375,14 @@ compilers:
       check_exe: compiler/latest/linux/bin/intel64/icc -V
       script_filename: install.sh
       targets:
-        - name: 2021.1.8.1883
+        - name: 2021.1.2.63
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/irc_nas/16856/l_HPCKit_b_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/irc_nas/17513/l_dpcpp-cpp-compiler_p_{name}_offline.sh install.sh
           script: |
             rm -Rf ~/.intel
             rm -Rf ~/intel
             rm -Rf /var/intel/installercache
-            bash {script_filename} -s -a -s --action install --eula accept --components intel.oneapi.lin.cpp-compiler:intel.oneapi.lin.ifort-compiler --install-dir {staging}/{dir}
-            rm -Rf ~/.intel
-            rm -Rf ~/intel
-            rm -Rf /var/intel/installercache
-        - name: 2021.1.9.2205
-          fetch:
-            - https://registrationcenter-download.intel.com/akdlm/irc_nas/16949/l_HPCKit_b_{name}_offline.sh install.sh
-          script: |
-            rm -Rf ~/.intel
-            rm -Rf ~/intel
-            rm -Rf /var/intel/installercache
-            bash {script_filename} -s -a -s --action install --eula accept --components intel.oneapi.lin.dpcpp-cpp-compiler-pro:intel.oneapi.lin.ifort-compiler --install-dir {staging}/{dir}
+            bash {script_filename} -s -a -s --action install --eula accept --install-dir {staging}/{dir}
             rm -Rf ~/.intel
             rm -Rf ~/intel
             rm -Rf /var/intel/installercache

--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -369,15 +369,32 @@ compilers:
       check_exe: bin/tcc -v
       targets:
         - 0.9.27
-    icc:
+    intel-cpp:
       type: script
-      dir: "intel-{name}"
+      dir: "intel-cpp-{name}"
       check_exe: compiler/latest/linux/bin/intel64/icc -V
       script_filename: install.sh
       targets:
         - name: 2021.1.2.63
           fetch:
             - https://registrationcenter-download.intel.com/akdlm/irc_nas/17513/l_dpcpp-cpp-compiler_p_{name}_offline.sh install.sh
+          script: |
+            rm -Rf ~/.intel
+            rm -Rf ~/intel
+            rm -Rf /var/intel/installercache
+            bash {script_filename} -s -a -s --action install --eula accept --install-dir {staging}/{dir}
+            rm -Rf ~/.intel
+            rm -Rf ~/intel
+            rm -Rf /var/intel/installercache
+    intel-fortran:
+      type: script
+      dir: "intel-fortran-{name}"
+      check_exe: compiler/latest/linux/bin/intel64/ifort -V
+      script_filename: install.sh
+      targets:
+        - name: 2021.1.2.62
+          fetch:
+            - https://registrationcenter-download.intel.com/akdlm/irc_nas/17508/l_fortran-compiler_p_{name}_offline.sh install.sh
           script: |
             rm -Rf ~/.intel
             rm -Rf ~/intel


### PR DESCRIPTION
Add latest icc release 2021.1.2

I deleted 2021.1.8 & 2021.1.9. They were product quality releases of icc, but were distributed as part of a beta package. They are fine to use, but I think it will be confusing that 2021.1.2 is newer than 2021.1.8 and deleting them would be a simple way to avoid the confusion.

 Thanks for adding the yaml interface for updating the compilers. It makes it very simple.