### PR TITLE
Add Thrust/CUB 1.12.0 to CUDA.

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1053,6 +1053,7 @@ libraries:
         - 1.9.10-1
         - 1.10.0
         - 1.11.0
+        - 1.12.0
     nvtx:
       type: github
       method: clone_branch


### PR DESCRIPTION
Adds version 1.12.0 of the Thrust/CUB CUDA library bundle.

Goes with https://github.com/compiler-explorer/compiler-explorer/pull/2472.