### PR TITLE
Update OCaml to 4.10.2,4.11.2,4.12.0

### DIFF
--- a/update_compilers/install_ocaml_compilers.sh
+++ b/update_compilers/install_ocaml_compilers.sh
@@ -20,7 +20,10 @@ get_ocaml 4.09.0
 get_ocaml 4.09.1
 get_ocaml 4.10.0
 get_ocaml 4.10.1
+get_ocaml 4.10.2
 get_ocaml 4.11.1
+get_ocaml 4.11.2
+get_ocaml 4.12.0
 
 get_ocaml 4.07.1-flambda
 get_ocaml 4.08.1-flambda
@@ -28,4 +31,6 @@ get_ocaml 4.09.0-flambda
 get_ocaml 4.09.1-flambda
 get_ocaml 4.10.0-flambda
 get_ocaml 4.10.1-flambda
+get_ocaml 4.10.2-flambda
 get_ocaml 4.11.1-flambda
+get_ocaml 4.11.2-flambda


### PR DESCRIPTION
Since the flambda variant does not yet exist in 4.12.0, we just ignore it.