### PR TITLE
Add JsonCpp 1.9.4 with CMake

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -232,6 +232,16 @@ libraries:
         - 2.1.1
         - 3.1.2
         - 3.6.0
+    jsoncpp:
+      type: github
+      repo: open-source-parsers/jsoncpp
+      check_file: README.md
+      targets:
+        - 1.9.4
+      build_type: cmake
+      lib_type: static
+      extra_cmake_arg:
+        - -DBUILD_STATIC_LIBS=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_OBJECT_LIBS=OFF -DBUILD_TESTING=OFF -DJSONCPP_WITH_TESTS=OFF -DJSONCPP_WITH_POST_BUILD_UNITTEST=OFF -DJSONCPP_WITH_CMAKE_PACKAGE=OFF -DJSONCPP_WITH_STRICT_ISO=OFF -DJSONCPP_WITH_PKGCONFIG_SUPPORT=OFF
     nsimd:
       type: s3tarballs
       s3_path_prefix: nsimd-{name}

--- a/windows/msvce-config.json
+++ b/windows/msvce-config.json
@@ -219,6 +219,10 @@
         "url": "https://github.com/nlohmann/json",
         "pretty_name": "nlohmann::json"
       },
+      "jsoncpp": {
+        "url": "https://github.com/open-source-parsers/jsoncpp",
+        "pretty_name": "JsonCpp"
+      },
       "ned14-outcome": null,
       "pegtl": {
         "url": "https://github.com/taocpp/PEGTL",


### PR DESCRIPTION
Add JsonCpp 1.9.4 with CMake (passing arguments to build nothing but the static lib)

cf https://github.com/compiler-explorer/compiler-explorer/issues/2534