### PR TITLE
Kindofreadlink to fix mac issue

### DIFF
--- a/bin/scripts/python_shim
+++ b/bin/scripts/python_shim
@@ -2,7 +2,12 @@
 
 set -euo pipefail
 
-ROOT_DIR=$(readlink -f "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/../..")
+function kindofreadlink() {
+  DIR="${1%/*}"
+  (cd "$DIR" && echo "$(pwd -P)")
+}
+
+ROOT_DIR=$(kindofreadlink "$(dirname "${BASH_SOURCE[0]}")/../..")
 MY_NAME=$(basename "$0")
 
 if ! make -sq -C "${ROOT_DIR}" ce; then


### PR DESCRIPTION
Fixes #479 

This seems to work on my mac (via bin/ce_install), my linux vm (via bin/ce_install and ./ce_install from bin) and on admin (from /tmp via PATH).

Any situations you can think of where this would not work?