### PR TITLE
Add LLVM/Clang 12.0.0 toolchain

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -357,6 +357,7 @@ compilers:
           - 10.0.1
           - 11.0.0
           - 11.0.1
+          - 12.0.0
     ellccs:
       check_exe: bin/clang++ --version
       dir: ellcc-{name}

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -52,6 +52,7 @@ libraries:
         - 10.0.0
         - 10.0.1
         - 11.0.0
+        - 12.0.0
     fmt:
       type: github
       repo: fmtlib/fmt


### PR DESCRIPTION
Adds LLVM 12.0.0's toolchain to the Compiler Explorer compiler list. First time submitting a patch, let me know if there's anything missing!

The patch is currently untested as the release is not out yet.

Compiler Explorer: https://github.com/compiler-explorer/compiler-explorer/pull/2588