### PR TITLE
Add Lock3 gcc contract labels

### DIFF
--- a/admin-daily-builds.sh
+++ b/admin-daily-builds.sh
@@ -111,6 +111,7 @@ build_latest clang llvm build.sh llvm-trunk
 
 build_latest gcc gcc build.sh trunk
 build_latest gcc gcc_contracts build.sh lock3-contracts-trunk
+build_latest gcc gcc_contract_labels build.sh lock3-contract-labels-trunk
 build_latest gcc gcc_modules build.sh cxx-modules-trunk
 build_latest gcc gcc_coroutines build.sh cxx-coroutines-trunk
 build_latest gcc gcc_static_analysis build.sh static-analysis-trunk

--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -451,6 +451,7 @@ compilers:
           - name: trunk
             symlink: gcc-snapshot
           - lock3-contracts-trunk
+          - lock3-contract-labels-trunk
           - cxx-modules-trunk
           - cxx-coroutines-trunk
           - static-analysis-trunk

--- a/remove_old_compilers.sh
+++ b/remove_old_compilers.sh
@@ -15,6 +15,7 @@ remove_older() {
 remove_older llvm
 remove_older gcc
 remove_older gcc-lock3-contracts
+remove_older gcc-lock3-contract-labels
 remove_older gcc-cxx-modules
 remove_older gcc-cxx-coroutines
 remove_older gcc-embed


### PR DESCRIPTION
This is one of three PRs adding support for the `contract-labels` branch of https://github.com/lock3/gcc . This likely depends on a related PR in gcc-builder: https://github.com/compiler-explorer/gcc-builder/pull/4 .

Please let me know if anything needs addressed :)
