### PR TITLE
Add Go 1.16

### DIFF
--- a/bin/yaml/go.yaml
+++ b/bin/yaml/go.yaml
@@ -24,6 +24,7 @@ compilers:
         - "1.13"
         - "1.14"
         - "1.15"
+        - "1.16"
     nightly:
       if: nightly
       type: nightly


### PR DESCRIPTION
Add Go 1.16

Go released 1.16 at Feb 2021.

ref:
- https://golang.org/dl
- https://golang.org/doc/go1.16