### PR TITLE
Add Swift 5.4

### DIFF
--- a/bin/yaml/swift.yaml
+++ b/bin/yaml/swift.yaml
@@ -24,6 +24,7 @@ compilers:
       - '5.1'
       - '5.2'
       - '5.3'
+      - '5.4'
     nightly:
       if: nightly
       type: restQueryTarballs


### PR DESCRIPTION
Adds Swift 5.4 as a compiler. Explorer PR: https://github.com/compiler-explorer/compiler-explorer/pull/2622