### PR TITLE
Update for GCC 11.1

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -46,6 +46,7 @@ compilers:
           - 10.1.0
           - 10.2.0
           - 10.3.0
+          - 11.1.0
     cross:
       type: s3tarballs
       arch_prefix:


### PR DESCRIPTION
Adds the new GCC 11.1 compiler toolchain

CE: https://github.com/compiler-explorer/compiler-explorer/pull/2624