### PR TITLE
updated OSACA version to v0.4.2

### DIFF
--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -21,4 +21,4 @@ tools:
     check_exe: bin/osaca --version
     targets:
       - 0.3.14
-      - 0.4.0
+      - 0.4.2


### PR DESCRIPTION
To integrate newer OSACA version since version 0.4.0 has a bug with ARM assembly.
Also improves runtime and more instruction support.