### PR TITLE
Add ZipArchiveInstallable and Kotlin/JVM Compilers

### DIFF
--- a/bin/yaml/kotlin.yaml
+++ b/bin/yaml/kotlin.yaml
@@ -1,0 +1,23 @@
+compilers:
+  kotlin:
+    type: ziparchive
+    dir: kotlin-jvm-{name}
+    folder: kotlinc
+    check_exe: bin/kotlinc-jvm -version
+    targets:
+      - name: 1.4.0
+        url: https://github.com/JetBrains/kotlin/releases/download/v1.4.0/kotlin-compiler-1.4.0.zip
+      - name: 1.4.10
+        url: https://github.com/JetBrains/kotlin/releases/download/v1.4.10/kotlin-compiler-1.4.10.zip
+      - name: 1.4.20
+        url: https://github.com/JetBrains/kotlin/releases/download/v1.4.20/kotlin-compiler-1.4.20.zip
+      - name: 1.4.21
+        url: https://github.com/JetBrains/kotlin/releases/download/v1.4.21/kotlin-compiler-1.4.21.zip
+      - name: 1.4.30
+        url: https://github.com/JetBrains/kotlin/releases/download/v1.4.30/kotlin-compiler-1.4.30.zip
+      - name: 1.4.31
+        url: https://github.com/JetBrains/kotlin/releases/download/v1.4.31/kotlin-compiler-1.4.31.zip
+      - name: 1.4.32
+        url: https://github.com/JetBrains/kotlin/releases/download/v1.4.32/kotlin-compiler-1.4.32.zip
+      - name: 1.5.0
+        url: https://github.com/JetBrains/kotlin/releases/download/v1.5.0/kotlin-compiler-1.5.0.zip


### PR DESCRIPTION
This patch contains a new Installable kind for zip archives which are unarchived using `unzip`, and configuration for Kotlin/JVM. I added the most recent 1.5.0 compiler and all of the 1.4.x compilers.

A new installer was necessary because the Kotlin/JVM compiler ships as .zip archives. 

The kotlinc-jvm compiler is a bash script which delegates to a Java program. Java 8 or later is necessary on the system with the JAVA_HOME environment variable set for the compiler to work.

Tested to work locally on my machine with Debian UnZip 6.0.0 and OpenJDK 11.0.11

This is a follow-up for https://github.com/compiler-explorer/compiler-explorer/pull/2637