### PR TITLE
Add mrustc to nightly build compiler

### DIFF
--- a/admin-daily-builds.sh
+++ b/admin-daily-builds.sh
@@ -131,6 +131,7 @@ build_latest clang clang_embed build.sh embed-trunk
 build_latest go go build.sh trunk
 build_latest misc tinycc build-tinycc.sh trunk
 build_latest misc cc65 buildcc65.sh trunk
+build_latest misc mrustc build-mrustc.sh master
 
 build_latest_cross gcc arm32 build.sh arm trunk
 build_latest_cross gcc arm64 build.sh arm64 trunk

--- a/remove_old_compilers.sh
+++ b/remove_old_compilers.sh
@@ -44,5 +44,6 @@ remove_older clang-embed
 remove_older go
 remove_older tinycc
 remove_older cc65
+remove_older_master mrustc
 remove_older arm32
 remove_older arm64


### PR DESCRIPTION
Initially wanted to add existing versions, but small issues would require some
workaround to make it work. Instead, use nightly, at least until a new release
is published.

refs #2643