### PR TITLE
Add Highway 0.12.2

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -226,6 +226,17 @@ libraries:
       target_prefix: v
       targets:
         - 0.1.0
+    highway:
+      type: github
+      repo: google/highway
+      check_file: hwy/highway.h
+      build_type: cmake
+      lib_type: static
+      make_targets:
+        - hwy
+        - hwy_contrib
+      targets:
+        - 0.12.2
     nlohmann_json:
       type: github
       repo: nlohmann/json


### PR DESCRIPTION
Hi, would be nice to add the Highway SIMD library. It's mostly (not entirely) header-only, but builds with CMake, so I've copied lines from other similar cases.

Was unfortunately unable to test because requests is not found, although I pip installed it from within a venv and then ran ./ce_install . Any advice on how to fix that?