### PR TITLE
Add installers for Crystal

### DIFF
--- a/bin/yaml/crystal.yaml
+++ b/bin/yaml/crystal.yaml
@@ -1,0 +1,19 @@
+compilers:
+  crystal:
+    type: tarballs
+    url: https://github.com/crystal-lang/crystal/releases/download/{name}/crystal-{name}-1-linux-x86_64.tar.gz
+    compression: gz
+    create_untar_dir: true
+    strip_components: 1
+    dir: crystal-{name}
+    check_exe: bin/crystal --version
+    targets:
+      - 1.0.0
+      - 0.36.1
+      - 0.35.1
+      - 0.34.0
+      - 0.33.0
+      - 0.32.1
+      - 0.31.1
+      - 0.30.1
+      - 0.29.0

--- a/bin/yaml/crystal.yaml
+++ b/bin/yaml/crystal.yaml
@@ -7,6 +7,10 @@ compilers:
     strip_components: 1
     dir: crystal-{name}
     check_exe: bin/crystal --version
+    after_stage_script:
+      - cd lib/crystal/lib
+      - ln -s /opt/compiler-explorer/libs/libpcre/8.45/x86_64/lib/libpcre.a
+      - ln -s /opt/compiler-explorer/libs/libevent/2.1.12/x86_64/lib/libevent.a
     targets:
       - 1.0.0
       - 0.36.1

--- a/update_compilers/install_libraries.sh
+++ b/update_compilers/install_libraries.sh
@@ -185,3 +185,56 @@ install_lua() {
 }
 
 install_lua v5.3.5 v5.4.0
+
+# Following are minimal runtime dependencies for Crystal
+
+#########################
+# pcre
+
+install_pcre() {
+    for VERSION in "$@"; do
+        local DEST1=${OPT}/libs/libpcre/${VERSION}/x86_64/lib
+        if [[ ! -d ${DEST1} ]]; then
+            rm -rf /tmp/pcre
+            mkdir -p /tmp/pcre
+            pushd /tmp/pcre
+
+            fetch https://ftp.pcre.org/pub/pcre/pcre-${VERSION}.tar.gz | tar zxf - --strip-components 1
+
+            ./configure --disable-shared --enable-utf --enable-unicode-properties
+            make
+
+            mkdir -p ${DEST1}
+            cp .libs/libpcre.a ${DEST1}
+
+            popd
+            rm -rf /tmp/pcre
+        fi
+    done
+}
+
+install_pcre 8.45
+
+install_libevent() {
+    for VERSION in "$@"; do
+        local DEST1=${OPT}/libs/libevent/${VERSION}/x86_64/lib
+        if [[ ! -d ${DEST1} ]]; then
+            rm -rf /tmp/libevent
+            mkdir -p /tmp/libevent
+            pushd /tmp/libevent
+
+            fetch https://github.com/libevent/libevent/releases/download/release-${VERSION}-stable/libevent-${VERSION}-stable.tar.gz | tar zxf - --strip-components 1
+
+            ./configure --disable-shared
+            make
+
+            mkdir -p ${DEST1}
+            cp .libs/libevent.a ${DEST1}
+
+            popd
+            rm -rf /tmp/libevent
+        fi
+    done
+}
+
+install_libevent 2.1.12

--- a/update_compilers/install_libraries.sh
+++ b/update_compilers/install_libraries.sh
@@ -225,6 +225,7 @@ install_libevent() {
 
             fetch https://github.com/libevent/libevent/releases/download/release-${VERSION}-stable/libevent-${VERSION}-stable.tar.gz | tar zxf - --strip-components 1
 
+            export PKG_CONFIG_PATH=/opt/compiler-explorer/libs/openssl/openssl_1_1_1g/x86_64/opt/lib/pkgconfig
             ./configure --disable-shared
             make
 


### PR DESCRIPTION
Adds stable releases from 1.0 down to 0.29 for [Crystal](https://crystal-lang.org), plus the minimal runtime dependencies (pcre and libevent).

Related: compiler-explorer/compiler-explorer#2732