### PR TITLE
Add compiler for Kotlin 1.5.20

### DIFF
--- a/bin/yaml/kotlin.yaml
+++ b/bin/yaml/kotlin.yaml
@@ -23,3 +23,5 @@ compilers:
         url: https://github.com/JetBrains/kotlin/releases/download/v1.5.0/kotlin-compiler-1.5.0.zip
       - name: 1.5.10
         url: https://github.com/JetBrains/kotlin/releases/download/v1.5.10/kotlin-compiler-1.5.10.zip
+      - name: 1.5.20
+        url: https://github.com/JetBrains/kotlin/releases/download/v1.5.20/kotlin-compiler-1.5.20.zip


### PR DESCRIPTION
Compiler update for the most recent Kotlin release: https://github.com/JetBrains/kotlin/releases/tag/v1.5.20

CE: https://github.com/compiler-explorer/compiler-explorer/pull/2736