### PR TITLE
Fix shortlinks with nginx

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -52,6 +52,10 @@ http {
         location / {
             proxy_pass http://localhost:10240;
             proxy_set_header Host $host;
+
+            # uncomment the following line if you run your own instance
+            # proxy_set_header X-Forwarded-Proto $scheme;
+
             # See https://ma.ttias.be/nginx-proxy-upstream-sent-big-header-reading-response-header-upstream/
             # and https://github.com/mattgodbolt/compiler-explorer/issues/1423
             proxy_buffer_size          128k;


### PR DESCRIPTION
I recently set up a private CE instance with nginx and realized the shortlinks we're not working with the nginx configuration provided when using HTTPS. As it turned out this was due to nginx not setting the X-Forwarded-Proto header.

This PR changes the nginx configuration so that it adds this header.