### PR TITLE
Update settings.yml

### DIFF
--- a/init/settings.yml
+++ b/init/settings.yml
@@ -17,6 +17,9 @@ compiler:
     ellcc:
         version: ANY
         libcxx: ANY
+    zigcxx:
+        version: ANY
+        libcxx: ANY
 
 build_type: [Debug]
 

--- a/init/settings.yml
+++ b/init/settings.yml
@@ -27,6 +27,6 @@ flagcollection: ANY
 
 stdlib: ['', libc++]
 
-stdver: ['', c++11, c++14, c++17, c++2a, gnu++11, gnu++14, gnu++17, gnu++2a]
+stdver: ['', c++11, c++14, c++17, c++2a, c++20, c++2b, gnu++11, gnu++14, gnu++17, gnu++2a]
 
 toolchain: ANY


### PR DESCRIPTION
In response to error during library-builder process:
```
2021-07-05 17:04:24,536 lib.installation INFO     Building benchmark for [zcxx060,,/opt/compiler-explorer,Linux,Debug,,,,]
ERROR: Invalid setting 'zigcxx' is not a valid 'settings.compiler' value.
Possible values are ['clang', 'ellcc', 'gcc']
Read "http://docs.conan.io/en/latest/faq/troubleshooting.html#error-invalid-setting"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/tmp/build/infra/bin/lib/ce_install.py", line 230, in main
    [num_installed, num_skipped, num_failed] = installable.build(args.buildfor)
  File "/tmp/build/infra/bin/lib/installation.py", line 414, in build
    return builder.makebuild(buildfor)
  File "/tmp/build/infra/bin/lib/library_builder.py", line 801, in makebuild
    buildstatus = self.makebuildfor(compiler, options, exe, compilerType, toolchain,
  File "/tmp/build/infra/bin/lib/library_builder.py", line 652, in makebuildfor
    if self.is_already_uploaded(build_folder):
  File "/tmp/build/infra/bin/lib/library_builder.py", line 590, in is_already_uploaded
    annotations = self.get_build_annotations(buildfolder)
  File "/tmp/build/infra/bin/lib/library_builder.py", line 549, in get_build_annotations
    conanhash = self.get_conan_hash(buildfolder)
  File "/tmp/build/infra/bin/lib/library_builder.py", line 493, in get_conan_hash
    conaninfo = subprocess.check_output(['conan', 'info', '-r', 'ceserver', '.'] + self.current_buildparameters,
  File "/usr/lib/python3.8/subprocess.py", line 411, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.8/subprocess.py", line 512, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['conan', 'info', '-r', 'ceserver', '.', '-s', 'os=Linux', '-s', 'build_type=Debug', '-s', 'compiler=zigcxx', '-s', 'compiler.version=zcxx060', '-s', 'compiler.libcxx=libstdc++', '-s', 'arch=', '-s', 'stdver=', '-s', 'flagcollection=']' returned non-zero exit status 1.
```

1. Will need to dig in my brain whether this requires AMI changes (probably, but can probably change the file locally)
2. While doing that, are there any other new compilerTypes that need to be added to this?
