### PR TITLE
Page load stats lambda support.

### DIFF
--- a/lambda/requirements.txt
+++ b/lambda/requirements.txt
@@ -1,1 +1,2 @@
 requests==2.24.0
+aws-embedded-metrics

--- a/lambda/stats.py
+++ b/lambda/stats.py
@@ -53,7 +53,7 @@ def handle_http(
     sqs_client = sqs_client or boto3.client('sqs')
     now = now or datetime.datetime.utcnow()
 
-    if event['path'] == '/pageload':
+    if event['path'] == '/pageload' and event['httpMethod'] == 'POST':
         return handle_pageload(event, metrics, now, os.environ['SQS_STATS_QUEUE'], sqs_client)
 
     return dict(

--- a/lambda/stats.py
+++ b/lambda/stats.py
@@ -11,7 +11,8 @@ from aws_embedded_metrics.logger.metrics_logger import MetricsLogger
 
 STATIC_HEADERS = {
     "Content-Type": "text/plain; charset=utf-8",
-    "Cache-Control": "no-cache"
+    "Cache-Control": "no-cache",
+    "Access-Control-Allow-Origin": "*"
 }
 
 RECORD_KEY = "Records"
@@ -76,7 +77,7 @@ def handle_pageload(
     sqs_client.send_message(
         QueueUrl=queue_url,
         MessageBody=json.dumps(dict(type='PageLoad', date=date, time=time, value=''), sort_keys=True))
-    sponsors = list(filter(lambda x: x, event['queryStringParameters'].get('sponsors', '').split(',')))
+    sponsors = list(filter(lambda x: x, event['queryStringParameters'].get('icons', '').split(',')))
     for sponsor in sponsors:
         sqs_client.send_message(
             QueueUrl=queue_url,

--- a/lambda/stats.py
+++ b/lambda/stats.py
@@ -1,0 +1,92 @@
+import datetime
+import json
+import logging
+import os
+from typing import Optional, Dict
+
+import aws_embedded_metrics
+import boto3
+import botocore.client
+from aws_embedded_metrics.logger.metrics_logger import MetricsLogger
+
+STATIC_HEADERS = {
+    "Content-Type": "text/plain; charset=utf-8",
+    "Cache-Control": "no-cache"
+}
+
+RECORD_KEY = "Records"
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+@aws_embedded_metrics.metric_scope
+def lambda_handler(event, context, metrics):
+    metrics.set_namespace("CompilerExplorer")
+    logger.info("Received new lambda event %s", event)
+    if RECORD_KEY in event:
+        return handle_sqs(event, context)
+    return handle_http(event, metrics)
+
+
+def handle_sqs(
+        event: Dict,
+        context,
+        s3_client: Optional[botocore.client.BaseClient] = None,
+        now: Optional[datetime.datetime] = None):
+    s3_client = s3_client or boto3.client('s3')
+    now = now or datetime.datetime.utcnow()
+
+    logger.info("Handling %d messages", len(event[RECORD_KEY]))
+    key = f"stats/{context.function_name}-{now.strftime('%Y-%m-%d-%H:%M:%S.%f')}.log"
+    body = "\n".join(r["body"] for r in event[RECORD_KEY])
+    bucket_name = os.environ['S3_BUCKET_NAME']
+    logger.info("writing to %s with key %s", bucket_name, key)
+    s3_client.put_object(Bucket=bucket_name, Body=body, Key=key)
+
+
+def handle_http(
+        event: Dict,
+        metrics: MetricsLogger,
+        sqs_client: Optional[botocore.client.BaseClient] = None,
+        now: Optional[datetime.datetime] = None):
+    sqs_client = sqs_client or boto3.client('sqs')
+    now = now or datetime.datetime.utcnow()
+
+    if event['path'] == '/pageload':
+        return handle_pageload(event, metrics, now, os.environ['SQS_STATS_QUEUE'], sqs_client)
+
+    return dict(
+        statusCode=404,
+        statusDescription="404 Not Found",
+        isBase64Encoded=False,
+        headers=STATIC_HEADERS,
+        body="Not found"
+    )
+
+
+def handle_pageload(
+        event: Dict,
+        metrics: MetricsLogger,
+        now: datetime.datetime,
+        queue_url: str,
+        sqs_client: botocore.client.BaseClient):
+    date = str(now.date())
+    time = str(now.time())
+    sqs_client.send_message(
+        QueueUrl=queue_url,
+        MessageBody=json.dumps(dict(type='PageLoad', date=date, time=time, value=''), sort_keys=True))
+    sponsors = list(filter(lambda x: x, event['queryStringParameters'].get('sponsors', '').split(',')))
+    for sponsor in sponsors:
+        sqs_client.send_message(
+            QueueUrl=queue_url,
+            MessageBody=json.dumps(dict(type='SponsorView', date=date, time=time, value=sponsor), sort_keys=True))
+    metrics.set_property("sponsors", sponsors)
+    metrics.put_metric("PageLoad", 1)
+    return dict(
+        statusCode=200,
+        statusDescription="200 OK",
+        isBase64Encoded=False,
+        headers=STATIC_HEADERS,
+        body="Ok"
+    )

--- a/lambda/stats.py
+++ b/lambda/stats.py
@@ -72,8 +72,8 @@ def handle_pageload(
         now: datetime.datetime,
         queue_url: str,
         sqs_client: botocore.client.BaseClient):
-    date = str(now.date())
-    time = str(now.time())
+    date = now.strftime('%Y-%m-%d')
+    time = now.strftime('%H:%M:%S')
     sqs_client.send_message(
         QueueUrl=queue_url,
         MessageBody=json.dumps(dict(type='PageLoad', date=date, time=time, value=''), sort_keys=True))

--- a/lambda/stats_test.py
+++ b/lambda/stats_test.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name
 import datetime
 import os
 from unittest import mock

--- a/lambda/stats_test.py
+++ b/lambda/stats_test.py
@@ -24,7 +24,7 @@ def s3_client():
 
 
 def make_expected_body(msg_type: str, value: str):
-    return f'{{"date": "2020-01-02", "time": "03:04:05.012312", "type": "{msg_type}", "value": "{value}"}}'
+    return f'{{"date": "2020-01-02", "time": "03:04:05", "type": "{msg_type}", "value": "{value}"}}'
 
 
 @mock.patch.dict(os.environ, dict(S3_BUCKET_NAME="not-a-real-bucket"))

--- a/lambda/stats_test.py
+++ b/lambda/stats_test.py
@@ -80,7 +80,7 @@ def test_should_handle_pageloads_with_empty_sponsors(sqs_client):
             {},
             dict(QueueUrl=queue_url, MessageBody=make_expected_body('PageLoad', ''))
         )
-        handle_pageload(dict(queryStringParameters=dict(sponsors='')), metrics, SOME_DATE, queue_url, sqs_client)
+        handle_pageload(dict(queryStringParameters=dict(icons='')), metrics, SOME_DATE, queue_url, sqs_client)
     metrics.set_property.assert_called_once_with('sponsors', [])
 
 
@@ -94,7 +94,7 @@ def test_should_handle_pageloads_with_one_sponsor(sqs_client):
             {},
             dict(QueueUrl=queue_url, MessageBody=make_expected_body('SponsorView', 'bob'))
         )
-        handle_pageload(dict(queryStringParameters=dict(sponsors='bob')), metrics, SOME_DATE, queue_url, sqs_client)
+        handle_pageload(dict(queryStringParameters=dict(icons='bob')), metrics, SOME_DATE, queue_url, sqs_client)
     metrics.set_property.assert_called_once_with('sponsors', ['bob'])
 
 
@@ -109,7 +109,7 @@ def test_should_handle_pageloads_with_many_sponsors(sqs_client):
                 {},
                 dict(QueueUrl=queue_url, MessageBody=make_expected_body('SponsorView', expectation)))
         handle_pageload(
-            dict(queryStringParameters=dict(sponsors='bob,alice,crystal')),
+            dict(queryStringParameters=dict(icons='bob,alice,crystal')),
             metrics,
             SOME_DATE,
             queue_url,

--- a/lambda/stats_test.py
+++ b/lambda/stats_test.py
@@ -3,6 +3,7 @@ import os
 from unittest import mock
 
 import botocore.session
+import pytest as pytest
 from aws_embedded_metrics.logger.metrics_logger import MetricsLogger
 from botocore.stub import Stubber, ANY
 
@@ -11,17 +12,26 @@ from stats import handle_sqs, handle_pageload
 SOME_DATE = datetime.datetime(2020, 1, 2, 3, 4, 5, 12312)
 
 
+@pytest.fixture
+def sqs_client():
+    return botocore.session.get_session().create_client('sqs', region_name='not-real')
+
+
+@pytest.fixture
+def s3_client():
+    return botocore.session.get_session().create_client('s3', region_name='not-real')
+
+
 def make_expected_body(msg_type: str, value: str):
     return f'{{"date": "2020-01-02", "time": "03:04:05.012312", "type": "{msg_type}", "value": "{value}"}}'
 
 
 @mock.patch.dict(os.environ, dict(S3_BUCKET_NAME="not-a-real-bucket"))
-def test_should_store_results_from_sqs_correctly():
+def test_should_store_results_from_sqs_correctly(s3_client):
     context = mock.Mock(function_name="some_func")
     event = dict(Records=[dict(body="first"), dict(body="second")])
-    s3 = botocore.session.get_session().create_client('s3')
 
-    with Stubber(s3) as stubber:
+    with Stubber(s3_client) as stubber:
         stubber.add_response(
             'put_object',
             {},
@@ -31,7 +41,7 @@ def test_should_store_results_from_sqs_correctly():
                 Key='stats/some_func-2020-01-02-03:04:05.012312.log'
             )
         )
-        handle_sqs(event, context, s3, SOME_DATE)
+        handle_sqs(event, context, s3_client, SOME_DATE)
 
 
 def test_pageloads_should_return_a_200_doc():
@@ -43,9 +53,8 @@ def test_pageloads_should_return_a_200_doc():
     metrics.put_metric.assert_called_once_with('PageLoad', 1)
 
 
-def test_should_handle_pageloads_with_no_sponsors():
+def test_should_handle_pageloads_with_no_sponsors(sqs_client):
     metrics = mock.Mock(spec_set=MetricsLogger)
-    sqs_client = botocore.session.get_session().create_client('sqs')
     queue_url = 'some-queue-url'
     with Stubber(sqs_client) as stubber:
         stubber.add_response(
@@ -61,9 +70,8 @@ def test_should_handle_pageloads_with_no_sponsors():
     metrics.put_metric.assert_called_once_with('PageLoad', 1)
 
 
-def test_should_handle_pageloads_with_empty_sponsors():
+def test_should_handle_pageloads_with_empty_sponsors(sqs_client):
     metrics = mock.Mock(spec_set=MetricsLogger)
-    sqs_client = botocore.session.get_session().create_client('sqs')
     queue_url = 'some-queue-url'
     with Stubber(sqs_client) as stubber:
         stubber.add_response(
@@ -75,9 +83,8 @@ def test_should_handle_pageloads_with_empty_sponsors():
     metrics.set_property.assert_called_once_with('sponsors', [])
 
 
-def test_should_handle_pageloads_with_one_sponsor():
+def test_should_handle_pageloads_with_one_sponsor(sqs_client):
     metrics = mock.Mock(spec_set=MetricsLogger)
-    sqs_client = botocore.session.get_session().create_client('sqs')
     queue_url = 'some-queue-url'
     with Stubber(sqs_client) as stubber:
         stubber.add_response('send_message', {}, dict(QueueUrl=queue_url, MessageBody=ANY))
@@ -90,9 +97,8 @@ def test_should_handle_pageloads_with_one_sponsor():
     metrics.set_property.assert_called_once_with('sponsors', ['bob'])
 
 
-def test_should_handle_pageloads_with_many_sponsors():
+def test_should_handle_pageloads_with_many_sponsors(sqs_client):
     metrics = mock.Mock(spec_set=MetricsLogger)
-    sqs_client = botocore.session.get_session().create_client('sqs')
     queue_url = 'some-queue-url'
     with Stubber(sqs_client) as stubber:
         stubber.add_response('send_message', {}, dict(QueueUrl=queue_url, MessageBody=ANY))

--- a/lambda/stats_test.py
+++ b/lambda/stats_test.py
@@ -1,0 +1,110 @@
+import datetime
+import os
+from unittest import mock
+
+import botocore.session
+from aws_embedded_metrics.logger.metrics_logger import MetricsLogger
+from botocore.stub import Stubber, ANY
+
+from stats import handle_sqs, handle_pageload
+
+SOME_DATE = datetime.datetime(2020, 1, 2, 3, 4, 5, 12312)
+
+
+def make_expected_body(msg_type: str, value: str):
+    return f'{{"date": "2020-01-02", "time": "03:04:05.012312", "type": "{msg_type}", "value": "{value}"}}'
+
+
+@mock.patch.dict(os.environ, dict(S3_BUCKET_NAME="not-a-real-bucket"))
+def test_should_store_results_from_sqs_correctly():
+    context = mock.Mock(function_name="some_func")
+    event = dict(Records=[dict(body="first"), dict(body="second")])
+    s3 = botocore.session.get_session().create_client('s3')
+
+    with Stubber(s3) as stubber:
+        stubber.add_response(
+            'put_object',
+            {},
+            dict(
+                Body='first\nsecond',
+                Bucket='not-a-real-bucket',
+                Key='stats/some_func-2020-01-02-03:04:05.012312.log'
+            )
+        )
+        handle_sqs(event, context, s3, SOME_DATE)
+
+
+def test_pageloads_should_return_a_200_doc():
+    metrics = mock.Mock(spec_set=MetricsLogger)
+    queue_url = 'some-queue-url'
+    result = handle_pageload(dict(queryStringParameters={}), metrics, SOME_DATE, queue_url, mock.Mock())
+    assert result['statusCode'] == 200
+    assert result['body'] == 'Ok'
+    metrics.put_metric.assert_called_once_with('PageLoad', 1)
+
+
+def test_should_handle_pageloads_with_no_sponsors():
+    metrics = mock.Mock(spec_set=MetricsLogger)
+    sqs_client = botocore.session.get_session().create_client('sqs')
+    queue_url = 'some-queue-url'
+    with Stubber(sqs_client) as stubber:
+        stubber.add_response(
+            'send_message',
+            {},
+            dict(
+                QueueUrl=queue_url,
+                MessageBody=make_expected_body('PageLoad', '')
+            )
+        )
+        handle_pageload(dict(queryStringParameters={}), metrics, SOME_DATE, queue_url, sqs_client)
+    metrics.set_property.assert_called_once_with('sponsors', [])
+    metrics.put_metric.assert_called_once_with('PageLoad', 1)
+
+
+def test_should_handle_pageloads_with_empty_sponsors():
+    metrics = mock.Mock(spec_set=MetricsLogger)
+    sqs_client = botocore.session.get_session().create_client('sqs')
+    queue_url = 'some-queue-url'
+    with Stubber(sqs_client) as stubber:
+        stubber.add_response(
+            'send_message',
+            {},
+            dict(QueueUrl=queue_url, MessageBody=make_expected_body('PageLoad', ''))
+        )
+        handle_pageload(dict(queryStringParameters=dict(sponsors='')), metrics, SOME_DATE, queue_url, sqs_client)
+    metrics.set_property.assert_called_once_with('sponsors', [])
+
+
+def test_should_handle_pageloads_with_one_sponsor():
+    metrics = mock.Mock(spec_set=MetricsLogger)
+    sqs_client = botocore.session.get_session().create_client('sqs')
+    queue_url = 'some-queue-url'
+    with Stubber(sqs_client) as stubber:
+        stubber.add_response('send_message', {}, dict(QueueUrl=queue_url, MessageBody=ANY))
+        stubber.add_response(
+            'send_message',
+            {},
+            dict(QueueUrl=queue_url, MessageBody=make_expected_body('SponsorView', 'bob'))
+        )
+        handle_pageload(dict(queryStringParameters=dict(sponsors='bob')), metrics, SOME_DATE, queue_url, sqs_client)
+    metrics.set_property.assert_called_once_with('sponsors', ['bob'])
+
+
+def test_should_handle_pageloads_with_many_sponsors():
+    metrics = mock.Mock(spec_set=MetricsLogger)
+    sqs_client = botocore.session.get_session().create_client('sqs')
+    queue_url = 'some-queue-url'
+    with Stubber(sqs_client) as stubber:
+        stubber.add_response('send_message', {}, dict(QueueUrl=queue_url, MessageBody=ANY))
+        for expectation in ('bob', 'alice', 'crystal'):
+            stubber.add_response(
+                'send_message',
+                {},
+                dict(QueueUrl=queue_url, MessageBody=make_expected_body('SponsorView', expectation)))
+        handle_pageload(
+            dict(queryStringParameters=dict(sponsors='bob,alice,crystal')),
+            metrics,
+            SOME_DATE,
+            queue_url,
+            sqs_client)
+    metrics.set_property.assert_called_once_with('sponsors', ['bob', 'alice', 'crystal'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ types-PyYAML
 types-pkg_resources
 types-requests
 types-toml
+aws-embedded-metrics  # only needed by lambda tests really

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -145,3 +145,28 @@ resource "aws_alb_listener_rule" "auth-alb-listen-https" {
   }
   listener_arn = aws_alb_listener.compiler-explorer-alb-listen-https.arn
 }
+
+resource "aws_alb_target_group" "lambda" {
+  name        = "AwsLambdaTargetGroup"
+  target_type = "lambda"
+}
+
+resource "aws_alb_target_group_attachment" "lambda-stats-endpoint" {
+  target_group_arn = aws_alb_target_group.lambda.arn
+  target_id        = aws_lambda_function.stats.arn
+  depends_on       = [aws_lambda_permission.from_alb]
+}
+
+resource "aws_alb_listener_rule" "compiler-explorer-alb-listen-https-lambda" {
+  priority     = 4
+  action {
+    type             = "forward"
+    target_group_arn = aws_alb_target_group.lambda.arn
+  }
+  condition {
+    host_header {
+      values = ["lambda.compiler-explorer.com"]
+    }
+  }
+  listener_arn = aws_alb_listener.compiler-explorer-alb-listen-https.arn
+}

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -8,15 +8,44 @@ data "aws_iam_policy_document" "aws_lambda_trust_policy" {
     }
   }
 }
+
 resource "aws_iam_role" "iam_for_lambda" {
   name               = "iam_for_lambda"
   assume_role_policy = data.aws_iam_policy_document.aws_lambda_trust_policy.json
 }
 
-
 resource "aws_iam_role_policy_attachment" "terraform_lambda_policy" {
   role       = aws_iam_role.iam_for_lambda.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+data "aws_iam_policy_document" "aws_lambda_stats_logs" {
+  statement {
+    sid       = "WriteStatsLog"
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.compiler-explorer-logs.arn}/stats/*"]
+  }
+  statement {
+    sid       = "AccessSQS"
+    actions   = [
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+      "sqs:SendMessage"
+    ]
+    resources = [aws_sqs_queue.stats_queue.arn]
+  }
+}
+
+resource "aws_iam_policy" "aws_lambda_stats_logs" {
+  name        = "aws_lambda_stats_logs"
+  description = "Allow lambda to write to stats logs"
+  policy      = data.aws_iam_policy_document.aws_lambda_stats_logs.json
+}
+
+resource "aws_iam_role_policy_attachment" "aws_lambda_stats_logs" {
+  role       = aws_iam_role.iam_for_lambda.name
+  policy_arn = aws_iam_policy.aws_lambda_stats_logs.arn
 }
 
 data "aws_ssm_parameter" "discord_webhook_url" {
@@ -53,10 +82,62 @@ resource "aws_lambda_function" "cloudwatch_to_discord" {
   }
 }
 
+
 resource "aws_lambda_permission" "with_sns" {
   statement_id  = "AllowExecutionFromSNS"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.cloudwatch_to_discord.arn
   principal     = "sns.amazonaws.com"
   source_arn    = data.aws_sns_topic.alert.arn
+}
+
+resource "aws_lambda_function" "stats" {
+  description       = "Respond to various CE-specific stats records"
+  s3_bucket         = data.aws_s3_bucket_object.lambda_zip.bucket
+  s3_key            = data.aws_s3_bucket_object.lambda_zip.key
+  s3_object_version = data.aws_s3_bucket_object.lambda_zip.version_id
+  # TODO not this
+  source_code_hash  = data.aws_s3_bucket_object.lambda_zip.etag
+  function_name     = "stats"
+  role              = aws_iam_role.iam_for_lambda.arn
+  handler           = "stats.lambda_handler"
+  timeout           = 10
+
+  runtime = "python3.8"
+
+  environment {
+    variables = {
+      S3_BUCKET_NAME  = aws_s3_bucket.compiler-explorer-logs.bucket
+      SQS_STATS_QUEUE = aws_sqs_queue.stats_queue.id
+    }
+  }
+}
+
+resource "aws_sqs_queue" "stats_queue" {
+  name                      = "CompilerExplorerStats"
+  max_message_size          = 1024
+  message_retention_seconds = 600
+}
+
+resource "aws_lambda_permission" "from_alb" {
+  statement_id  = "AllowExecutionFromALB"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.stats.arn
+  principal     = "elasticloadbalancing.amazonaws.com"
+  source_arn    = aws_alb_target_group.lambda.arn
+}
+
+resource "aws_lambda_permission" "from_sqs" {
+  statement_id  = "AllowExecutionFromSQS"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.stats.arn
+  principal     = "sqs.amazonaws.com"
+  source_arn    = aws_sqs_queue.stats_queue.arn
+}
+
+resource "aws_lambda_event_source_mapping" "sqs_to_lambda" {
+  event_source_arn                   = aws_sqs_queue.stats_queue.arn
+  function_name                      = aws_lambda_function.stats.arn
+  batch_size                         = 100
+  maximum_batching_window_in_seconds = 300
 }

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -96,8 +96,8 @@ resource "aws_lambda_function" "stats" {
   s3_bucket         = data.aws_s3_bucket_object.lambda_zip.bucket
   s3_key            = data.aws_s3_bucket_object.lambda_zip.key
   s3_object_version = data.aws_s3_bucket_object.lambda_zip.version_id
-  # TODO not this
-  source_code_hash  = data.aws_s3_bucket_object.lambda_zip.etag
+  // Comment this in if you want to force a deploy every time... TODO ideally fix this
+  //  source_code_hash  = data.aws_s3_bucket_object.lambda_zip.etag
   function_name     = "stats"
   role              = aws_iam_role.iam_for_lambda.arn
   handler           = "stats.lambda_handler"

--- a/terraform/security.tf
+++ b/terraform/security.tf
@@ -267,7 +267,7 @@ data "aws_iam_policy_document" "ReadS3Minimal" {
 
 resource "aws_iam_policy" "ReadS3Minimal" {
   name        = "ReadS3Minimal"
-  description = "Minimum possible read acces to S3 to boot an instance"
+  description = "Minimum possible read access to S3 to boot an instance"
   policy      = data.aws_iam_policy_document.ReadS3Minimal.json
 }
 


### PR DESCRIPTION
* Mounts a lambda.compiler-explorer.com endpoint directly
  from the ALB (no API gateway)
* Supports just /pageload
* Pageload goes to AWS metrics (for live analysis)
  and is also sent on an SQS queue (to itself)
* SQS queue aggregates 5m worth of things and writes
  results to S3
* S3 logs can be easily queried with AWS Athena for
  total page loads, and also statistics on sponsors

NB no PII is tracked at all. Ripe for abuse, so we might
want to think about our options here.