### PR TITLE
Add compilers for Kotlin 1.5.21

### DIFF
--- a/bin/yaml/kotlin-native.yaml
+++ b/bin/yaml/kotlin-native.yaml
@@ -28,3 +28,5 @@ compilers:
         url: https://github.com/JetBrains/kotlin/releases/download/v1.5.10/kotlin-native-linux-1.5.10.tar.gz
       - name: 1.5.20
         url: https://github.com/JetBrains/kotlin/releases/download/v1.5.20/kotlin-native-linux-1.5.20.tar.gz
+      - name: 1.5.21
+        url: https://github.com/JetBrains/kotlin/releases/download/v1.5.21/kotlin-native-linux-1.5.21.tar.gz

--- a/bin/yaml/kotlin.yaml
+++ b/bin/yaml/kotlin.yaml
@@ -25,3 +25,5 @@ compilers:
         url: https://github.com/JetBrains/kotlin/releases/download/v1.5.10/kotlin-compiler-1.5.10.zip
       - name: 1.5.20
         url: https://github.com/JetBrains/kotlin/releases/download/v1.5.20/kotlin-compiler-1.5.20.zip
+      - name: 1.5.21
+        url: https://github.com/JetBrains/kotlin/releases/download/v1.5.21/kotlin-compiler-1.5.21.zip


### PR DESCRIPTION
Compiler update for the most recent Kotlin release

CE: https://github.com/compiler-explorer/compiler-explorer/pull/2781