### PR TITLE
Add support for cproc C11 compiler

### DIFF
--- a/admin-daily-builds.sh
+++ b/admin-daily-builds.sh
@@ -132,6 +132,7 @@ build_latest go go build.sh trunk
 build_latest misc tinycc build-tinycc.sh trunk
 build_latest misc cc65 buildcc65.sh trunk
 build_latest misc mrustc build-mrustc.sh master
+build_latest misc cproc build-cproc.sh master
 build_latest misc rustc-cg-gcc_master build-rustc-cg-gcc.sh master
 
 build_latest_cross gcc arm32 build.sh arm trunk

--- a/bin/yaml/c.yaml
+++ b/bin/yaml/c.yaml
@@ -1,5 +1,10 @@
 compilers:
   c:
+    cproc:
+      type: nightly
+      check_exe: "bin/cproc -h"
+      targets:
+        - master
     ppci:
       type: tarballs
       compression: gz

--- a/remove_old_compilers.sh
+++ b/remove_old_compilers.sh
@@ -45,6 +45,7 @@ remove_older go
 remove_older tinycc
 remove_older cc65
 remove_older_master mrustc
+remove_older_master cproc
 remove_older_master rustc-cg-gcc
 remove_older arm32
 remove_older arm64


### PR DESCRIPTION
cproc does not have any release, so only tracking its master branch.

https://github.com/compiler-explorer/compiler-explorer/issues/2755