### PR TITLE
Adds Haskell 8.10.5 & 9.0.1

### DIFF
--- a/bin/yaml/haskell.yaml
+++ b/bin/yaml/haskell.yaml
@@ -4,8 +4,9 @@ compilers:
       type: tarballs
       compression: xz
       dir: ghc-{name}
-      url: https://downloads.haskell.org/~ghc/{name}/ghc-{name}-x86_64-deb8-linux.tar.xz
+      url: https://downloads.haskell.org/~ghc/{name}/ghc-{name}-x86_64-deb{deb}-linux.tar.xz
       check_exe: bin/ghc --version
+      deb: 8
       after_stage_script:
         - mkdir install
         - cd {dir}
@@ -28,3 +29,7 @@ compilers:
         - 8.6.1
         - 8.6.2
         - 8.6.3
+        - name: 8.10.5
+          deb: 10
+        - name: 9.0.1
+          deb: 10


### PR DESCRIPTION
Issue https://github.com/compiler-explorer/compiler-explorer/issues/2786

This is a PR because I don't know if deb 10 is an ok choice here (As there are no bins for 8 for newer ghcs)