### PR TITLE
Add the hotels-template-library

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1185,6 +1185,14 @@ libraries:
         build_type: none
         targets:
           - trunk
+      hotels-template-library:
+        type: github
+        method: nightlyclone
+        repo: google/hotels-template-library
+        check_file: README.md
+        build_type: none
+        targets:
+          - trunk
   cuda:
     cub:
       type: github


### PR DESCRIPTION
The different sub-libraries under hotels-template-library are still under active development and don't have any version tags, so just trunk is necessary (I assume trunk means it just pulls HEAD of the default branch).

I installed the hotels-template-library from `infra` locally and everything looks good.

```
$ ./bin/ce_install install hotels-template-library --enable nightly
2021-07-19 17:34:19,028 lib.installation INFO     Making uncached requests
2021-07-19 17:34:19,847 lib.installation INFO     compilers/c++/cross/gcc/arm/nightly trunk: Most recent arm-gcc-trunk is 20210528
2021-07-19 17:34:19,928 lib.installation INFO     compilers/c++/cross/gcc/arm64/nightly trunk: Most recent arm64-gcc-trunk is 20210528
2021-07-19 17:34:20,101 lib.installation INFO     compilers/c++/nightly/gcc trunk: Most recent gcc-trunk is 20210708
2021-07-19 17:34:20,101 lib.installation INFO     compilers/c++/nightly/gcc lock3-contracts-trunk: Most recent gcc-lock3-contracts-trunk is 20210701
2021-07-19 17:34:20,101 lib.installation INFO     compilers/c++/nightly/gcc lock3-contract-labels-trunk: Most recent gcc-lock3-contract-labels-trunk is 20210428
2021-07-19 17:34:20,101 lib.installation INFO     compilers/c++/nightly/gcc cxx-modules-trunk: Most recent gcc-cxx-modules-trunk is 20210428
2021-07-19 17:34:20,101 lib.installation INFO     compilers/c++/nightly/gcc cxx-coroutines-trunk: Most recent gcc-cxx-coroutines-trunk is 20210717
2021-07-19 17:34:20,101 lib.installation INFO     compilers/c++/nightly/gcc static-analysis-trunk: Most recent gcc-static-analysis-trunk is 20210428
2021-07-19 17:34:20,101 lib.installation INFO     compilers/c++/nightly/clang trunk: Most recent clang-trunk is 20210719
2021-07-19 17:34:20,101 lib.installation INFO     compilers/c++/nightly/clang assertions-trunk: Most recent clang-assertions-trunk is 20210719
2021-07-19 17:34:20,101 lib.installation INFO     compilers/c++/nightly/clang cppx-trunk: Most recent clang-cppx-trunk is 20201117
2021-07-19 17:34:20,101 lib.installation INFO     compilers/c++/nightly/clang cppx-ext-trunk: Most recent clang-cppx-ext-trunk is 20210701
2021-07-19 17:34:20,101 lib.installation INFO     compilers/c++/nightly/clang cppx-p2320-trunk: Most recent clang-cppx-p2320-trunk is 20210416
2021-07-19 17:34:20,101 lib.installation INFO     compilers/c++/nightly/clang concepts-trunk: Most recent clang-concepts-trunk is 20200226
2021-07-19 17:34:20,101 lib.installation INFO     compilers/c++/nightly/clang embed-trunk: Most recent clang-embed-trunk is 20210620
2021-07-19 17:34:20,102 lib.installation INFO     compilers/c++/nightly/clang relocatable-trunk: Most recent clang-relocatable-trunk is 20210423
2021-07-19 17:34:20,102 lib.installation INFO     compilers/c++/nightly/clang autonsdmi-trunk: Most recent clang-autonsdmi-trunk is 20200712
2021-07-19 17:34:20,102 lib.installation INFO     compilers/c++/nightly/clang lifetime-trunk: Most recent clang-lifetime-trunk is 20200521
2021-07-19 17:34:20,102 lib.installation INFO     compilers/c++/nightly/clang parmexpr-trunk: Most recent clang-parmexpr-trunk is 20210719
2021-07-19 17:34:20,102 lib.installation INFO     compilers/c++/nightly/clang patmat-trunk: Most recent clang-patmat-trunk is 20210310
2021-07-19 17:34:20,102 lib.installation INFO     compilers/c++/nightly/clang llvmflang-trunk: Most recent clang-llvmflang-trunk is 20210511
2021-07-19 17:34:20,102 lib.installation INFO     compilers/c++/nightly/tinycc trunk: Most recent tinycc-trunk is 20210718
2021-07-19 17:34:20,544 lib.installation INFO     compilers/zig/nightly master: resolved to https://ziglang.org/builds/zig-linux-x86_64-0.9.0-dev.476+3e67ef5c9.tar.xz
2021-07-19 17:34:20,592 lib.installation INFO     compilers/c/nightly/cc65 trunk: Most recent cc65-trunk is 20210622
2021-07-19 17:34:20,592 lib.installation INFO     compilers/c/nightly/tendra trunk: Most recent tendra-trunk is 20200820
2021-07-19 17:34:20,608 lib.installation INFO     compilers/rust/newer/nightly/gcc gccrs-master: Most recent gcc-gccrs-master is 20210717
2021-07-19 17:34:20,611 lib.installation INFO     compilers/rust/newer/nightly/rustc-cg-gcc master: Most recent rustc-cg-gcc-master is 20210712
2021-07-19 17:34:20,613 lib.installation INFO     compilers/rust/newer/nightly/mrustc master: Most recent mrustc-master is 20210719
2021-07-19 17:34:20,857 lib.installation INFO     compilers/go/nightly/golang trunk: Most recent go-trunk is 20210719
2021-07-19 17:34:21,123 lib.installation INFO     compilers/swift/nightly nightly: resolved to https://swift.org/builds/development/ubuntu1604/swift-DEVELOPMENT-SNAPSHOT-2021-07-15-a/swift-DEVELOPMENT-SNAPSHOT-2021-07-15-a-ubuntu16.04.tar.gz
2021-07-19 17:34:21,366 lib.installation INFO     libraries/c++/nightly/llvm trunk: Most recent llvm-trunk is 20210720
Installing libraries/c++/nightly/hotels-template-library trunk
2021-07-19 17:34:22,505 lib.installation INFO     libraries/c++/nightly/hotels-template-library trunk installed OK
1 packages installed OK, 0 skipped, and 0 failed installation
```