### PR TITLE
Installer for standalone rustfmt

### DIFF
--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -22,3 +22,13 @@ tools:
     targets:
       - 0.3.14
       - 0.4.5
+  rustfmt:
+    type: tarballs
+    dir: rustfmt-{name}
+    compression: gz
+    check_exe: rustfmt --version
+    targets:
+      - name: 1.4.36
+        url: https://github.com/rust-lang/rustfmt/releases/download/v1.4.36/rustfmt_linux-x86_64_v1.4.36.tar.gz
+        strip_components: 1
+        create_untar_dir: true


### PR DESCRIPTION
Because CE doesn't use Cargo at the moment we can install and use the standalone rustfmt versions from the release tarballs.

CE: https://github.com/compiler-explorer/compiler-explorer/pull/2798