### PR TITLE
Add circle 129 build

### DIFF
--- a/bin/yaml/circle.yaml
+++ b/bin/yaml/circle.yaml
@@ -9,6 +9,7 @@ compilers:
     dir: circle-{name}
     targets:
       - '128'
+      - '129'
     nightly:
       if: nightly
       install_always: true


### PR DESCRIPTION
Adds circle 129 build, which introduce Intel ASM syntax.