### PR TITLE
Add kotlin 1.5.30

### DIFF
--- a/bin/yaml/kotlin-native.yaml
+++ b/bin/yaml/kotlin-native.yaml
@@ -30,3 +30,6 @@ compilers:
         url: https://github.com/JetBrains/kotlin/releases/download/v1.5.20/kotlin-native-linux-1.5.20.tar.gz
       - name: 1.5.21
         url: https://github.com/JetBrains/kotlin/releases/download/v1.5.21/kotlin-native-linux-1.5.21.tar.gz
+      - name: 1.5.30
+        url: https://github.com/JetBrains/kotlin/releases/download/v1.5.30/kotlin-native-linux-x86_64-1.5.30.tar.gz
+        configure_command: [mv, kotlin-native-linux-x86_64-1.5.30, kotlin-native-linux-1.5.30]

--- a/bin/yaml/kotlin.yaml
+++ b/bin/yaml/kotlin.yaml
@@ -27,3 +27,5 @@ compilers:
         url: https://github.com/JetBrains/kotlin/releases/download/v1.5.20/kotlin-compiler-1.5.20.zip
       - name: 1.5.21
         url: https://github.com/JetBrains/kotlin/releases/download/v1.5.21/kotlin-compiler-1.5.21.zip
+      - name: 1.5.30
+        url: https://github.com/JetBrains/kotlin/releases/download/v1.5.30/kotlin-compiler-1.5.30.zip


### PR DESCRIPTION
Compilers for the most recent Kotlin release

The name of the release executable had a `-x86-64` appended to it to mark target triple. I am unsure if we'd like to change it to match on CE or not. Any ideas?

CE: https://github.com/compiler-explorer/compiler-explorer/pull/2871