### PR TITLE
Add support for SPIR-V Tools and SPIR-V/LLVM Translator

### DIFF
--- a/admin-daily-builds.sh
+++ b/admin-daily-builds.sh
@@ -128,12 +128,14 @@ build_latest clang clang_llvmflang build.sh llvmflang-trunk
 build_latest clang clang_parmexpr build-parmexpr.sh trunk
 build_latest clang clang_patmat build.sh patmat-trunk
 build_latest clang clang_embed build.sh embed-trunk
+build_latest clang llvm_spirv build.sh llvm-spirv
 build_latest go go build.sh trunk
 build_latest misc tinycc build-tinycc.sh trunk
 build_latest misc cc65 buildcc65.sh trunk
 build_latest misc mrustc build-mrustc.sh master
 build_latest misc cproc build-cproc.sh master
 build_latest misc rustc-cg-gcc_master build-rustc-cg-gcc.sh master
+build_latest misc SPIRV-Tools build-spirv-tools.sh master
 
 build_latest_cross gcc arm32 build.sh arm trunk
 build_latest_cross gcc arm64 build.sh arm64 trunk

--- a/bin/yaml/opencl-c.yaml
+++ b/bin/yaml/opencl-c.yaml
@@ -1,0 +1,12 @@
+compilers:
+  opencl-c:
+    SPIRV-Tools:
+      type: nightly
+      check_exe: "build/tools/spirv-dis --version"
+      targets:
+        - master
+    llvm-spirv:
+      type: nightly
+      check_exe: "bin/llvm-spirv --version"
+      targets:
+        - trunk

--- a/remove_old_compilers.sh
+++ b/remove_old_compilers.sh
@@ -41,11 +41,13 @@ remove_older clang-llvmflang
 remove_older clang-parmexpr
 remove_older clang-patmat
 remove_older clang-embed
+remove_older llvm-spirv
 remove_older go
 remove_older tinycc
 remove_older cc65
 remove_older_master mrustc
 remove_older_master cproc
 remove_older_master rustc-cg-gcc
+remove_older_master SPIRV-Tools
 remove_older arm32
 remove_older arm64


### PR DESCRIPTION
This PR adds support for SPIR-V Tools and the SPIR-V LLVM Translator.

This is required for https://github.com/compiler-explorer/compiler-explorer/issues/2743