### PR TITLE
Fix lexy check_file

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -759,7 +759,7 @@ libraries:
         type: github
         method: nightlyclone
         repo: foonathan/lexy
-        check_file: include/lexy/parse.hpp
+        check_file: include/lexy/dsl.hpp
         path_name: libs/lexy/trunk
         targets:
           - trunk


### PR DESCRIPTION
The header `include/lexy/parse.hpp` is actually deprecated.