### PR TITLE
Add latest KVX release

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -288,6 +288,7 @@ compilers:
             - 4.2.0-rc5
             - 4.3.0
             - 4.4.0
+            - 4.6.0
         powerpc:
           arch_prefix: "{subdir}-unknown-linux-gnu"
           check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"


### PR DESCRIPTION
ACB 4.6.0 is available at:

https://github.com/kalray/build-scripts/releases/tag/v4.6.0

With GCC 9.4.1.