### PR TITLE
Add Swift 5.5

### DIFF
--- a/bin/yaml/swift.yaml
+++ b/bin/yaml/swift.yaml
@@ -25,6 +25,7 @@ compilers:
       - '5.2'
       - '5.3'
       - '5.4'
+      - '5.5'
     nightly:
       if: nightly
       type: restQueryTarballs


### PR DESCRIPTION
Adds Swift 5.5 as a compiler. The associated frontend PR is compiler-explorer/compiler-explorer#3007.