### PR TITLE
updated OSACA version to v0.4.6

### DIFF
--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -21,7 +21,7 @@ tools:
     check_exe: bin/osaca --version
     targets:
       - 0.3.14
-      - 0.4.5
+      - 0.4.6
   rustfmt:
     type: tarballs
     dir: rustfmt-{name}


### PR DESCRIPTION
Added new OSACA version 0.4.6 to godbolt.
See also [PR #3020](https://github.com/compiler-explorer/compiler-explorer/pull/3020) in compiler-explorer/compiler-explorer.