### PR TITLE
Add a way to lock version bounces

### DIFF
--- a/bin/lib/amazon.py
+++ b/bin/lib/amazon.py
@@ -371,7 +371,7 @@ def delete_bouncelock_file(cfg: Config):
     )
 
 
-def is_bouncelock_file(cfg: Config):
+def has_bouncelock_file(cfg: Config):
     try:
         s3_client.get_object(
             Bucket='compiler-explorer',

--- a/bin/lib/cli/builds.py
+++ b/bin/lib/cli/builds.py
@@ -13,7 +13,7 @@ from lib.cli.runner import runner_discoveryexists
 
 from lib.amazon import download_release_file, download_release_fileobj, find_latest_release, find_release, \
     log_new_build, set_current_key, get_ssm_param, get_all_current, get_releases, remove_release, get_current_key, \
-    list_all_build_logs, list_period_build_logs, put_bouncelock_file, delete_bouncelock_file, is_bouncelock_file
+    list_all_build_logs, list_period_build_logs, put_bouncelock_file, delete_bouncelock_file, has_bouncelock_file
 from lib.cdn import DeploymentJob
 from lib.ce_utils import describe_current_release, are_you_sure, display_releases, confirm_branch, confirm_action
 from lib.cli import cli
@@ -67,7 +67,7 @@ def builds_set_current(cfg: Config, branch: Optional[str], version: str, raw: bo
 
     If VERSION is "latest" then the latest version (optionally filtered by --branch), is set.
     """
-    if is_bouncelock_file(cfg):
+    if has_bouncelock_file(cfg):
         print(f"{cfg.env.value} is currently bounce locked. New versions can't be set until the lock is lifted")
         sys.exit(1)
     to_set = None
@@ -168,7 +168,7 @@ def builds_history(cfg: Config, from_time: Optional[str], until_time: Optional[s
 @click.pass_obj
 def builds_is_locked(cfg: Config):
     """Check whether the current env is version bounce locked."""
-    if is_bouncelock_file(cfg):
+    if has_bouncelock_file(cfg):
         print(f"Env {cfg.env.value} is currently locked from version bounce")
     else:
         print(f"Env {cfg.env.value} is NOT locked from version bounce")


### PR DESCRIPTION
We already spoke about not pushing new versions internally, but I thought it would be a good idea to add a way to lock us from pushing new versions to environments, so this does just that.