### PR TITLE
updated OSACA version

### DIFF
--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -21,7 +21,7 @@ tools:
     check_exe: bin/osaca --version
     targets:
       - 0.3.14
-      - 0.4.6
+      - 0.4.7
   rustfmt:
     type: tarballs
     dir: rustfmt-{name}

--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -21,6 +21,7 @@ tools:
     check_exe: bin/osaca --version
     targets:
       - 0.3.14
+      - 0.4.6
       - 0.4.7
   rustfmt:
     type: tarballs


### PR DESCRIPTION
Added new OSACA version 0.4.7 to godbolt.
This version fixes some minor bugs and introduces support for Cortex A72.

See also [PR 3098](https://github.com/compiler-explorer/compiler-explorer/pull/3098) in compiler-explorer/compiler-explorer.