### PR TITLE
xsimd updates

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -378,11 +378,13 @@ libraries:
         - 0.5.3
     xsimd:
       type: github
-      repo: QuantStack/xsimd
+      repo: xtensor-stack/xsimd
       check_file: README.md
       targets:
         - 6.1.4
         - 7.0.0
+        - 7.6.0
+        - 8.0.3
     xtensor:
       type: github
       repo: QuantStack/xtensor
@@ -820,7 +822,7 @@ libraries:
       xsimd:
         type: github
         method: nightlyclone
-        repo: QuantStack/xsimd
+        repo: xtensor-stack/xsimd
         check_file: README.md
         build_type: none
         targets:


### PR DESCRIPTION
👋 

Currently Compiler Explorer has a broken trunk of xsimd (https://godbolt.org/z/x1doaq5d9). So, this MR makes the following changes:

- use current repo name
- add last v7 release (7.6.0)
- add latest v8 release (8.0.3)

This will let users have a safe v8 point from which to work, as well as updating the ages old v7 release.