### PR TITLE
Add Crystal 1.2.2, fix library paths

### DIFF
--- a/bin/yaml/crystal.yaml
+++ b/bin/yaml/crystal.yaml
@@ -8,10 +8,14 @@ compilers:
     dir: crystal-{name}
     check_exe: bin/crystal --version
     after_stage_script:
-      - cd lib/crystal/lib
-      - ln -s /opt/compiler-explorer/libs/libpcre/8.45/x86_64/lib/libpcre.a
+      - cd lib/crystal
+      - ln -s /opt/compiler-explorer/libs/libpcre/8.45/x86_64/lib/libpcre.a # for 1.2.0 and onward
+      - ln -s /opt/compiler-explorer/libs/libevent/2.1.12/x86_64/lib/libevent.a
+      - cd lib
+      - ln -s /opt/compiler-explorer/libs/libpcre/8.45/x86_64/lib/libpcre.a # for 1.1.1 and before
       - ln -s /opt/compiler-explorer/libs/libevent/2.1.12/x86_64/lib/libevent.a
     targets:
+      - 1.2.2
       - 1.2.0
       - 1.1.1
       - 1.0.0


### PR DESCRIPTION
The library path has changed to `/opt/compiler-explorer/crystal-x.y.z/lib/crystal` since Crystal 1.2.0 which caused the compiler to fail during linking. This PR adds extra symlinks for that.