### PR TITLE
Add kotlin 1.6.0 compiler

### DIFF
--- a/bin/yaml/kotlin-native.yaml
+++ b/bin/yaml/kotlin-native.yaml
@@ -30,3 +30,5 @@ compilers:
         filename: kotlin-native-linux-x86_64-1.5.30
       - name: 1.5.31
         filename: kotlin-native-linux-x86_64-1.5.31
+      - name: 1.6.0
+        filename: kotlin-native-linux-x86_64-1.6.0

--- a/bin/yaml/kotlin.yaml
+++ b/bin/yaml/kotlin.yaml
@@ -31,3 +31,5 @@ compilers:
         url: https://github.com/JetBrains/kotlin/releases/download/v1.5.30/kotlin-compiler-1.5.30.zip
       - name: 1.5.31
         url: https://github.com/JetBrains/kotlin/releases/download/v1.5.31/kotlin-compiler-1.5.31.zip
+      - name: 1.6.0
+        url: https://github.com/JetBrains/kotlin/releases/download/v1.6.0/kotlin-compiler-1.6.0.zip


### PR DESCRIPTION
Adds newly released kotlin 1.6.0 compiler

related PR: https://github.com/compiler-explorer/compiler-explorer/pull/3114