### PR TITLE
Add compilers for Kotlin 1.6.10

### DIFF
--- a/bin/yaml/kotlin-native.yaml
+++ b/bin/yaml/kotlin-native.yaml
@@ -32,3 +32,5 @@ compilers:
         filename: kotlin-native-linux-x86_64-1.5.31
       - name: 1.6.0
         filename: kotlin-native-linux-x86_64-1.6.0
+      - name: 1.6.10
+        filename: kotlin-native-linux-x86_64-1.6.10

--- a/bin/yaml/kotlin.yaml
+++ b/bin/yaml/kotlin.yaml
@@ -33,3 +33,5 @@ compilers:
         url: https://github.com/JetBrains/kotlin/releases/download/v1.5.31/kotlin-compiler-1.5.31.zip
       - name: 1.6.0
         url: https://github.com/JetBrains/kotlin/releases/download/v1.6.0/kotlin-compiler-1.6.0.zip
+      - name: 1.6.10
+        url: https://github.com/JetBrains/kotlin/releases/download/v1.6.10/kotlin-compiler-1.6.10.zip


### PR DESCRIPTION
Installers for https://github.com/JetBrains/kotlin/releases/tag/v1.6.10

CE: https://github.com/compiler-explorer/compiler-explorer/pull/3178