### PR TITLE
Add GCC compiler for MRISC32

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -238,16 +238,18 @@ compilers:
             - name: 5.4.0
               subdir: mips64el
         mrisc32:
-          type: tarballs
-          subdir: mrisc32
-          arch_prefix: "mrisc32-elf"
-          check_exe: "mrisc32-gnu-toolchain/bin/{arch_prefix}-g++ --version"
-          dir: mrisc32-{name}
-          create_untar_dir: true
-          url: https://github.com/mrisc32/mrisc32-gnu-toolchain/releases/download/v{name}/mrisc32-gnu-toolchain-linux-x86_64.tar.gz
-          compression: gz
-          targets:
-            - 12.0-20211220
+          nightly:
+            if: nightly
+            type: nightlytarballs
+            subdir: mrisc32
+            arch_prefix: "mrisc32-elf"
+            check_exe: "mrisc32-gnu-toolchain/bin/{arch_prefix}-g++ --version"
+            dir: mrisc32-{name}
+            create_untar_dir: true
+            url: https://github.com/mrisc32/mrisc32-gnu-toolchain/releases/latest/download/mrisc32-gnu-toolchain-linux-x86_64.tar.gz
+            compression: gz
+            targets:
+              - trunk
         msp430:
           arch_prefix: msp430
           subdir: msp430

--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -237,6 +237,17 @@ compilers:
               subdir: mips64
             - name: 5.4.0
               subdir: mips64el
+        mrisc32:
+          type: tarballs
+          subdir: mrisc32
+          arch_prefix: "mrisc32-elf"
+          check_exe: "mrisc32-gnu-toolchain/bin/{arch_prefix}-g++ --version"
+          dir: mrisc32-{name}
+          create_untar_dir: true
+          url: https://github.com/mrisc32/mrisc32-gnu-toolchain/releases/download/v{name}/mrisc32-gnu-toolchain-linux-x86_64.tar.gz
+          compression: gz
+          targets:
+            - 12.0-20211220
         msp430:
           arch_prefix: msp430
           subdir: msp430


### PR DESCRIPTION
*This is my first contribution to the compiler-explorer project.*

## About MRISC32

MRISC32 is an open Vector/RISC ISA (inspired by architectures such as Cray and MIPS). More information here:

* https://mrisc32.bitsnbites.eu
* https://github.com/mrisc32
* https://www.bitsnbites.eu/category/hardware-development/mrisc32

## About this patch

This adds the MRISC32 GNU toolchain as a new cross compiler (running on Linux). The toolchain is built automatically by GitHub Actions and made available as a release at https://github.com/mrisc32/mrisc32-gnu-toolchain .

I have currently only picked the latest release, [v12.0-20211220](https://github.com/mrisc32/mrisc32-gnu-toolchain/releases/tag/v12.0-20211220), which is essentially a trunk build.

Perhaps a "nightly" solution would be better (i.e. download the latest release from a canonical "latest" URL)? I didn't implement or test that, though.