### PR TITLE
Add SerenityOS's Lagom libraries

### DIFF
--- a/bin/lib/library_build_config.py
+++ b/bin/lib/library_build_config.py
@@ -16,6 +16,7 @@ class LibraryBuildConfig:
         self.extra_cmake_arg = self.config_get("extra_cmake_arg", [])
         self.extra_make_arg = self.config_get("extra_make_arg", [])
         self.make_targets = self.config_get("make_targets", [])
+        self.make_utility = self.config_get("make_utility", "make")
         self.package_extra_copy = self.config_get("package_extra_copy", [])
         self.skip_compilers = self.config_get("skip_compilers", [])
 

--- a/bin/lib/library_builder.py
+++ b/bin/lib/library_builder.py
@@ -335,13 +335,15 @@ class LibraryBuilder:
                 for arg in self.buildconfig.extra_make_arg
             ])
 
+            make_utility = self.buildconfig.make_utility
+
             if len(self.buildconfig.make_targets) != 0:
                 for lognum, target in enumerate(self.buildconfig.make_targets):
-                    f.write(f'make {extramakeargs} {target} > cemakelog_{lognum}.txt 2>&1\n')
+                    f.write(f'{make_utility} {extramakeargs} {target} > cemakelog_{lognum}.txt 2>&1\n')
             else:
                 lognum = 0
                 for lib in itertools.chain(self.buildconfig.staticliblink, self.buildconfig.sharedliblink):
-                    f.write(f'make {extramakeargs} {lib} > cemakelog_{lognum}.txt 2>&1\n')
+                    f.write(f'{make_utility} {extramakeargs} {lib} > cemakelog_{lognum}.txt 2>&1\n')
                     lognum += 1
 
                 if len(self.buildconfig.staticliblink) != 0:
@@ -350,7 +352,7 @@ class LibraryBuilder:
                     f.write('libsfound=$(find . -iname \'lib*.so*\')\n')
 
                 f.write('if [ "$libsfound" = "" ]; then\n')
-                f.write(f'  make {extramakeargs} all > cemakelog_{lognum}.txt 2>&1\n')
+                f.write(f'  {make_utility} {extramakeargs} all > cemakelog_{lognum}.txt 2>&1\n')
                 f.write('fi\n')
 
             for lib in self.buildconfig.staticliblink:

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -620,6 +620,63 @@ libraries:
         - 1.6.1
         - 1.7.0
         - 1.8.0
+    lagom:
+      type: github
+      repo: SerenityOS/serenity
+      method: nightlyclone
+      check_file: CMakeLists.txt
+      build_type: cmake
+      lib_type: shared
+      make_targets:
+        - all
+      make_utility: ninja
+      extra_cmake_arg:
+        - -DBUILD_LAGOM=ON
+        - -DENABLE_COMPILER_EXPLORER_BUILD=ON
+        - -GNinja
+        - -DENABLE_UNICODE_DATABASE_DOWNLOAD=NO
+        - -DENABLE_COMMONMARK_SPEC_DOWNLOAD=NO
+        - -DCMAKE_EXE_LINKER_FLAGS=-latomic
+      targets:
+        - trunk
+      after_stage_script:
+        # Just build Lagom, no touchy serenity itself.
+        - echo "cmake_minimum_required(VERSION 3.16)" > CMakeLists.txt
+        # \x7b...\x7d for braces, because config_expand.py doesn't understand the meaning of escaping.
+        - echo -e "list(APPEND CMAKE_MODULE_PATH \"\$\\x7bCMAKE_CURRENT_LIST_DIR\\x7d/Meta/CMake\")" >> CMakeLists.txt
+        - echo "project(SerenityOS CXX)" >> CMakeLists.txt
+        - echo "add_subdirectory(Meta/Lagom)" >> CMakeLists.txt
+        # Patch out the 'CMAKE_BUILD_TYPE' check with a non-fatal set(CMAKE_BUILD_TYPE "")
+        - sed -i 's/if(NOT "..CMAKE_BUILD_TYPE." STREQUAL "")/set(CMAKE_BUILD_TYPE "")\nif(FALSE)/' Meta/Lagom/CMakeLists.txt
+        # Generate a AK/Debug.h for CE to use
+        - sed 's/cmakedefine01 \(\w\+\)/define \1 0/' AK/Debug.h.in > AK/Debug.h
+      sharedliblink:
+        - lagom-archive
+        - lagom-audio
+        - lagom-compress
+        - lagom-core
+        - lagom-crypto
+        - lagom-elf
+        - lagom-gemini
+        - lagom-gfx
+        - lagom-gl
+        - lagom-gml
+        - lagom-http
+        - lagom-imap
+        - lagom-ipc
+        - lagom-js
+        - lagom-line
+        - lagom-main
+        - lagom-markdown
+        - lagom-pdf
+        - lagom-regex
+        - lagom-shell
+        - lagom-sql
+        - lagom-textcodec
+        - lagom-tls
+        - lagom-unicode
+        - lagom-wasm
+        - lagom-x86
     date:
       type: github
       repo: HowardHinnant/date


### PR DESCRIPTION
In preparation for adding Lagom (see https://github.com/compiler-explorer/compiler-explorer/issues/3050).
This is not exactly in a ready state, need to resolve:
- [x] Building for specific compilers, Lagom does not support GCC older than 10.3, etc. (current idea is `accept_compilers`, haven't thought much about it yet though)
- [x] No idea how to actually build this without `--dry`, conan seems very unhappy at the very least
- [x] The generated files seem to suggest that shared libs cannot be built (conanfile.py lists `liblagom*.a` and not `liblagom*.so*`)
- [x] Anything else that I might hit while resolving these...

<details>
<summary>Said conan error</summary>

```
ERROR: Invalid setting 'g103' is not a valid 'settings.compiler.version' value.
Possible values are ['4.1', '4.4', '4.5', '4.6', '4.7', '4.8', '4.9', '5', '5.1', '5.2', '5.3', '5.4', '5.5', '6', '6.1', '6.2', '6.3', '6.4', '6.5', '7', '7.1', '7.2', '7.3', '7.4', '7.5', '8', '8.1', '8.2', '8.3', '8.4', '9', '9.1', '9.2', '9.3', '10', '10.1', '10.2', '10.3', '11', '11.1', '11.2']
Read "http://docs.conan.io/en/latest/faq/troubleshooting.html#error-invalid-setting"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/Test/Documents/playground/infra/bin/lib/ce_install.py", line 231, in main
    [num_installed, num_skipped, num_failed] = installable.build(args.buildfor)
  File "/home/Test/Documents/playground/infra/bin/lib/installation.py", line 419, in build
    return builder.makebuild(buildfor)
  File "/home/Test/Documents/playground/infra/bin/lib/library_builder.py", line 808, in makebuild
    buildstatus = self.makebuildfor(compiler, options, exe, compilerType, toolchain,
  File "/home/Test/Documents/playground/infra/bin/lib/library_builder.py", line 656, in makebuildfor
    if self.is_already_uploaded(build_folder):
  File "/home/Test/Documents/playground/infra/bin/lib/library_builder.py", line 594, in is_already_uploaded
    annotations = self.get_build_annotations(buildfolder)
  File "/home/Test/Documents/playground/infra/bin/lib/library_builder.py", line 553, in get_build_annotations
    conanhash = self.get_conan_hash(buildfolder)
  File "/home/Test/Documents/playground/infra/bin/lib/library_builder.py", line 499, in get_conan_hash
    conaninfo = subprocess.check_output(['conan', 'info', '-r', 'ceserver', '.'] + self.current_buildparameters,
  File "/usr/lib/python3.10/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['conan', 'info', '-r', 'ceserver', '.', '-s', 'os=Linux', '-s', 'build_type=Debug', '-s', 'compiler=gcc', '-s', 'compiler.version=g103', '-s', 'compiler.libcxx=libstdc++', '-s', 'arch=x86_64', '-s', 'stdver=', '-s', 'flagcollection=']' returned non-zero exit status 1.
```

</details>