### PR TITLE
Support for GNAT Ada compilers built from the Alire project

### DIFF
--- a/bin/yaml/ada.yaml
+++ b/bin/yaml/ada.yaml
@@ -1,0 +1,23 @@
+compilers:
+  ada:
+    gnat:
+      type: tarballs
+      dir: gnat-{target}-linux64-{name}
+      url: https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-{version}/gnat-{target}-linux64-{version}.tar.gz
+      compression: gz
+      check_exe: bin/{toolprefix}gcc -v
+      check_stderr_on_stdout: true
+      name: "{version}"
+
+      arm:
+        target: arm-elf
+        toolprefix: arm-eabi-
+        targets:
+          - version: 11.2.0-3
+          - version: 10.3.0-2
+      riscv64:
+        target: riscv64-elf
+        toolprefix: riscv64-elf
+        targets:
+          - version: 11.2.0-3
+          - version: 10.3.0-2


### PR DESCRIPTION
Use compilers built by the Alire project for cross compilers. Currently arm and riscv64.

https://github.com/alire-project
https://github.com/alire-project/GNAT-FSF-builds

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>