### PR TITLE
Enable gemmlowp C++ header-only lib on CE site

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -603,6 +603,14 @@ libraries:
       build_type: none
       targets:
         - v3.2.1
+    gemmlowp:
+      type: github
+      method: nightlyclone
+      repo: google/gemmlowp
+      check_file: fixedpoint/fixedpoint.h
+      build_type: none
+      targets:
+        - trunk
     spdlog:
       type: github
       repo: gabime/spdlog


### PR DESCRIPTION
Adds support for a useful C++ header-only library from Google that provides a low/fixed-precision general matrix multiplication routine alongside miscellaneous transcendental functions.