### PR TITLE
Install Rust 1.58.0

### DIFF
--- a/bin/yaml/rust.yaml
+++ b/bin/yaml/rust.yaml
@@ -69,6 +69,7 @@ compilers:
         - 1.55.0
         - 1.56.0
         - 1.57.0
+        - 1.58.0
       nightly:
         if: nightly
         targets:


### PR DESCRIPTION
Installer for https://blog.rust-lang.org/2022/01/13/Rust-1.58.0.html

CE: https://github.com/compiler-explorer/compiler-explorer/pull/3255