### PR TITLE
A fix and new version for ISPC

### DIFF
--- a/bin/yaml/ispc.yaml
+++ b/bin/yaml/ispc.yaml
@@ -29,7 +29,7 @@ compilers:
     nightly:
       if: nightly
       type: nightlytarballs
-      url: "https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build/ispc-trunk-linux.tar.gz?job=Environment: APPVEYOR_BUILD_WORKER_IMAGE=Ubuntu1604, LLVM_VERSION=latest"
+      url: "https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build/ispc-trunk-linux.tar.gz?job=Environment: APPVEYOR_BUILD_WORKER_IMAGE=Ubuntu1804, LLVM_VERSION=latest"
       dir: ispc-{name}
       untar_dir: ispc-{name}-linux
       targets:

--- a/bin/yaml/ispc.yaml
+++ b/bin/yaml/ispc.yaml
@@ -8,6 +8,7 @@ compilers:
     untar_dir: ispc-v{name}-linux
     check_exe: bin/ispc --version
     targets:
+      - 1.17.0
       - 1.16.1
       - 1.16.0
       - 1.15.0


### PR DESCRIPTION
- fix download link for ISPC trunk, Appveyor image move from Ubuntu1604 to Ubuntu1804 and the link changed accordingly
- add ISPC 1.17.0