### PR TITLE
✨ Dang compiler name and infrastructure!

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -585,6 +585,7 @@ compilers:
           - cppx-p2320-trunk
           - concepts-trunk
           - embed-trunk
+          - dang-main
           - relocatable-trunk
           - autonsdmi-trunk
           - lifetime-trunk

--- a/remove_old_compilers.sh
+++ b/remove_old_compilers.sh
@@ -41,6 +41,7 @@ remove_older clang-llvmflang
 remove_older clang-parmexpr
 remove_older clang-patmat
 remove_older clang-embed
+remove_older clang-dang-main
 remove_older llvm-spirv
 remove_older go
 remove_older tinycc


### PR DESCRIPTION
Add the necessary infrastructure for the Derpstorm Clang ("Dang") compiler!

In conjunction with:
- https://github.com/compiler-explorer/clang-builder/pull/30
- https://github.com/compiler-explorer/compiler-explorer/pull/3296