### PR TITLE
Add cross GCC 11.2.0 for several targets

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -228,15 +228,24 @@ compilers:
         mips:
           - arch_prefix: "{subdir}-unknown-linux-gnu"
             check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
-            targets:
-              - name: 5.4.0
-                subdir: mips
-              - name: 5.4.0
-                subdir: mipsel
-              - name: 5.4.0
-                subdir: mips64
-              - name: 5.4.0
-                subdir: mips64el
+            mips:
+              subdir: mips
+              targets:
+                - 5.4.0
+                - 11.2.0
+            mipsel:
+              subdir: mipsel
+              targets:
+                - 5.4.0
+            mips64:
+              subdir: mips64
+              targets:
+                - 5.4.0
+                - 11.2.0
+            mips64el:
+              subdir: mips64el
+              targets:
+                - 5.4.0
           - type: tarballs
             subdir: mips
             check_exe: "bin/mips-mti-elf-g++ --version"
@@ -327,23 +336,34 @@ compilers:
             - 4.3.0
             - 4.4.0
             - 4.6.0
+        s390x:
+          arch_prefix: "{subdir}-ibm-linux-gnu"
+          check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          subdir: s390x
+          targets:
+            - 11.2.0
         powerpc:
           arch_prefix: "{subdir}-unknown-linux-gnu"
           check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
-          targets:
-            - name: 4.8.5
-              subdir: powerpc
-              check_exe: "{arch_prefix}/bin/g++ --version"
-            - name: at12
-              subdir: powerpc64
-            - name: at13
-              subdir: powerpc64
-            - name: 6.3.0
-              subdir: powerpc64le
-            - name: at12
-              subdir: powerpc64le
-            - name: at13
-              subdir: powerpc64le
+          powerpc:
+            subdir: powerpc
+            targets:
+              - name: 4.8.5
+                check_exe: "{arch_prefix}/bin/g++ --version"
+              - name: 11.2.0
+          powerpc64:
+            subdir: powerpc64
+            targets:
+              - at12
+              - at13
+              - 11.2.0
+          powerpc64le:
+            subdir: powerpc64le
+            targets:
+              - 6.3.0
+              - at12
+              - at13
+              - 11.2.0
         xtensa:
           esp32:
             arch_prefix: xtensa-esp32-elf


### PR DESCRIPTION
Add cross GCC 11.2.0 for : s390x-linux, mips-linux, mips64-linux, ppc, ppc64 and
ppc64le for C, C++ and Ada.

Also try to refactor a little how arch/subarch are described.

refs https://github.com/compiler-explorer/compiler-explorer/issues/3282
refs https://github.com/compiler-explorer/compiler-explorer/issues/2470

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>