### PR TITLE
Add the hdf5 library to conan builder

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -774,6 +774,14 @@ libraries:
         - -DHDF5_BUILD_HL_LIB=OFF
         - -DHDF5_BUILD_TOOLS=OFF
         - -DHDF5_BUILD_UTILS=OFF
+      after_stage_script:
+        - mkdir build
+        - cd build
+        - CXX=/opt/compiler-explorer/gcc-10.2.0/bin/g++ /opt/compiler-explorer/cmake/bin/cmake .. -DCMAKE_INSTALL_PREFIX="." -DBUILD_STATIC_LIBS=OFF -DBUILD_TESTING=OFF -DHDF5_BUILD_EXAMPLES=OFF -DHDF5_BUILD_HL_LIB=OFF -DHDF5_BUILD_TOOLS=OFF -DHDF5_BUILD_UTILS=OFF
+        - /opt/compiler-explorer/cmake/bin/cmake --install .
+        - cp -Rf include ..
+        - cd ..
+        - rm -Rf build
       targets:
         - hdf5-1_12_1
         - hdf5-1_13_1

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -757,6 +757,26 @@ libraries:
       target_prefix: v
       targets:
         - "0.7.3"
+    hdf5:
+      type: github
+      repo: HDFGroup/hdf5
+      method: clone_branch
+      check_file: CMakeLists.txt
+      build_type: cmake
+      lib_type: shared
+      make_targets:
+        - hdf5-shared
+      extra_cmake_arg:
+        - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        - -DBUILD_STATIC_LIBS=OFF
+        - -DBUILD_TESTING=OFF
+        - -DHDF5_BUILD_EXAMPLES=OFF
+        - -DHDF5_BUILD_HL_LIB=OFF
+        - -DHDF5_BUILD_TOOLS=OFF
+        - -DHDF5_BUILD_UTILS=OFF
+      targets:
+        - hdf5-1_12_1
+        - hdf5-1_13_1
     nightly:
       install_always: true
       if: nightly


### PR DESCRIPTION
This adds into the libraries configuration the hdf5 library.
The hdf5 library can be cloned from github. The configuration checks out
stable (1.12.1) and latest experimental (1.13.1) releases and configures
the cmake builds with everything but shared library building off.

Why these versions of HDF5? Most users will be happy with 1.12.1 it's the current stable release, which is what many people use. 1.13.1 is experimental, I thought some users might be interested, so I added it too. One additional version to consider is the legacy release 1.10.8, since there are still many people out there that rely on it, but I wanted to avoid introducing issues/complications dealing with old library versions, so I'm skipping this for now. With new releases it should be relatively easy to simply add a new tag if requested.

To test I did following steps on my development system:

```
make ce
bin/ce_install install 'clang 12.0.1'
bin/ce_install --enable nightly install 'hdf5'
bin/ce_install --enable nightly --buildfor clang1201 --dry build 'hdf5'
```

All commands succeeded. I have verified that the `/opt/compiler-explorer/staging/clang1201_*` directories contain the expected `.so` files. One thing I noticed though, is once multiple hdf5 versions where added, they overwrite the staging directories. It looks like the hash is calculated based on build parameters but not the library version to be built.
