### PR TITLE
"--install" is enough but fails, ignore failure

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -780,7 +780,7 @@ libraries:
         - mkdir build
         - cd build
         - CXX=/opt/compiler-explorer/gcc-10.2.0/bin/g++ /opt/compiler-explorer/cmake/bin/cmake .. -DCMAKE_INSTALL_PREFIX="." -DBUILD_STATIC_LIBS=OFF -DBUILD_TESTING=OFF -DHDF5_BUILD_EXAMPLES=OFF -DHDF5_BUILD_HL_LIB=OFF -DHDF5_BUILD_TOOLS=OFF -DHDF5_BUILD_UTILS=OFF
-        - /opt/compiler-explorer/cmake/bin/cmake --install .
+        - /opt/compiler-explorer/cmake/bin/cmake --install . || true
         - cp -Rf include ..
         - cd ..
         - rm -Rf build


### PR DESCRIPTION
Just a very minor fix (workaround) as discussed with @mattgodbolt.

Probably later we should check `bin/lib/installation.py` and see if installing headers can be better supported.