### PR TITLE
Add Crystal 1.4.0 and 1.3.2

### DIFF
--- a/bin/yaml/crystal.yaml
+++ b/bin/yaml/crystal.yaml
@@ -15,9 +15,9 @@ compilers:
       - ln -s /opt/compiler-explorer/libs/libpcre/8.45/x86_64/lib/libpcre.a # for 1.1.1 and before
       - ln -s /opt/compiler-explorer/libs/libevent/2.1.12/x86_64/lib/libevent.a
     targets:
-      - 1.3.1
+      - 1.4.0
+      - 1.3.2
       - 1.2.2
-      - 1.2.0
       - 1.1.1
       - 1.0.0
       - 0.36.1


### PR DESCRIPTION
I noticed 1.2.0 is now an alias for 1.2.2 on CE. Is it safe to remove the line for the former here?