### PR TITLE
Add Swift 5.6

### DIFF
--- a/bin/yaml/swift.yaml
+++ b/bin/yaml/swift.yaml
@@ -30,6 +30,7 @@ compilers:
       targets:
           - '5.4'
           - '5.5'
+          - '5.6'
     nightly:
       if: nightly
       type: restQueryTarballs


### PR DESCRIPTION
Adds Swift 5.6 as a supported compiler. The associated frontend PR is compiler-explorer/compiler-explorer#3516.