### PR TITLE
Install OpenJDK 18

### DIFF
--- a/bin/yaml/java.yaml
+++ b/bin/yaml/java.yaml
@@ -20,3 +20,6 @@ compilers:
       - name: 17.0.0
         url: https://download.java.net/java/GA/jdk17/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-17_linux-x64_bin.tar.gz
         untar_dir: jdk-17
+      - name: 18.0.0
+        url: https://download.java.net/java/GA/jdk18/43f95e8614114aeaa8e8a5fcf20a682d/36/GPL/openjdk-18_linux-x64_bin.tar.gz
+        untar_dir: jdk-18


### PR DESCRIPTION
Java 18 was released and reached GA last month: https://jdk.java.net/18/

CE: https://github.com/compiler-explorer/compiler-explorer/pull/3523