### PR TITLE
Fix filtering

### DIFF
--- a/bin/lib/ce_install.py
+++ b/bin/lib/ce_install.py
@@ -47,12 +47,9 @@ def filter_aggregate(filters: list, installable: Installable, filter_match_all: 
     if not filters:
         return True
 
-    if filter_match_all:
-        # if installable matches all filters, accept it
-        return all((False for filt in filters if not filter_match(filt, installable)))
-    else:
-        # if installable matches any filter, accept it
-        return any((True for filt in filters if filter_match(filt, installable)))
+    # accept installable if it passes all filters (if filter_match_all is set) or any filters (otherwise)
+    filter_generator = (filter_match(filt, installable) for filt in filters)
+    return all(filter_generator) if filter_match_all else any(filter_generator)
 
 
 def main():

--- a/bin/lib/ce_install.py
+++ b/bin/lib/ce_install.py
@@ -42,6 +42,20 @@ def filter_match(filter_query: str, installable: Installable) -> bool:
     return _context_match(split[0], installable) and _target_match(split[1], installable)
 
 
+def filter_aggregate(filters: list, installable: Installable):
+    # if there are no filters, accept it
+    if not filters:
+        return True
+
+    # check installable against all filters
+    # if no filters match installable, reject it
+    for filt in filters:
+        if filter_match(filt, installable):
+            return True
+
+    return False
+
+
 def main():
     parser = ArgumentParser(prog='ce_install',
                             description='Install binaries, libraries and compilers for Compiler Explorer')
@@ -107,11 +121,7 @@ def main():
     for installable in installables:
         installable.link(installables_by_name)
 
-    for filt in args.filter:
-        def make_f(x=filt):  # see https://stupidpythonideas.blogspot.com/2016/01/for-each-loops-should-define-new.html
-            return lambda installable: filter_match(x, installable)
-
-        installables = filter(make_f(), installables)
+    installables = filter(lambda installable: filter_aggregate(args.filter, installable), installables)
     installables = sorted(installables, key=lambda x: x.sort_key)
 
     if args.command == 'list':

--- a/bin/test/ce_install_test.py
+++ b/bin/test/ce_install_test.py
@@ -57,14 +57,14 @@ def test_should_honour_root_matches():
 
 
 def test_should_match_all_filters():
-    assert not filter_aggregate(["a", "b"], fake("a", "target"), 'conjunction')
-    assert not filter_aggregate(["a", "b"], fake("b", "target"), 'conjunction')
-    assert filter_aggregate(["a", "target"], fake("a", "target"), 'conjunction')
+    assert not filter_aggregate(["a", "b"], fake("a", "target"), filter_match_all=True)
+    assert not filter_aggregate(["a", "b"], fake("b", "target"), filter_match_all=True)
+    assert filter_aggregate(["a", "target"], fake("a", "target"), filter_match_all=True)
 
 def test_should_match_any_filter():
-    assert filter_aggregate(["a", "b"], fake("a", "target"), 'disjunction')
-    assert filter_aggregate(["a", "b"], fake("b", "target"), 'disjunction')
-    assert not filter_aggregate(["a", "b"], fake("c", "target"), 'disjunction')
+    assert filter_aggregate(["a", "b"], fake("a", "target"), filter_match_all=False)
+    assert filter_aggregate(["a", "b"], fake("b", "target"), filter_match_all=False)
+    assert not filter_aggregate(["a", "b"], fake("c", "target"), filter_match_all=False)
 
 def test_all_should_match_all_filters():
     test = [
@@ -74,22 +74,22 @@ def test_all_should_match_all_filters():
     ]
 
     filter1 = ["a", "b"]
-    test1 = list(filter(lambda installable: filter_aggregate(filter1, installable, 'conjunction'), test))
+    test1 = list(filter(lambda installable: filter_aggregate(filter1, installable, filter_match_all=True), test))
     test1_answer = []
     assert test1 == test1_answer
 
     filter2 = ["a", "target"]
-    test2 = list(filter(lambda installable: filter_aggregate(filter2, installable, 'conjunction'), test))
+    test2 = list(filter(lambda installable: filter_aggregate(filter2, installable, filter_match_all=True), test))
     test2_answer = [test[0],test[1],test[2]]
     assert test2 == test2_answer
 
     filter3 = ["target", "other"]
-    test3 = list(filter(lambda installable: filter_aggregate(filter3, installable, 'conjunction'), test))
+    test3 = list(filter(lambda installable: filter_aggregate(filter3, installable, filter_match_all=True), test))
     test3_answer = []
     assert test3 == test3_answer
     
     filter4 = ["c",  "z", "other"]
-    test4 = list(filter(lambda installable: filter_aggregate(filter4, installable, 'conjunction'), test))
+    test4 = list(filter(lambda installable: filter_aggregate(filter4, installable, filter_match_all=True), test))
     test4_answer = [test[11]]
     assert test4 == test4_answer
 
@@ -101,21 +101,21 @@ def test_all_should_match_any_filter():
     ]
 
     filter1 = ["a", "b"]
-    test1 = list(filter(lambda installable: filter_aggregate(filter1, installable, 'disjunction'), test))
+    test1 = list(filter(lambda installable: filter_aggregate(filter1, installable, filter_match_all=False), test))
     test1_answer = [test[0],test[1],test[2],test[3],test[4],test[5],test[6],test[7]]
     assert test1 == test1_answer
 
     filter2 = ["a", "b", "c/z"]
-    test2 = list(filter(lambda installable: filter_aggregate(filter2, installable, 'disjunction'), test))
+    test2 = list(filter(lambda installable: filter_aggregate(filter2, installable, filter_match_all=False), test))
     test2_answer = [test[0],test[1],test[2],test[3],test[4],test[5],test[6],test[7],test[10],test[11]]
     assert test2 == test2_answer
 
     filter3 = ["a/x target", "b/z other", "c/z other"]
-    test3 = list(filter(lambda installable: filter_aggregate(filter3, installable, 'disjunction'), test))
+    test3 = list(filter(lambda installable: filter_aggregate(filter3, installable, filter_match_all=False), test))
     test3_answer = [test[0],test[7],test[11]]
     assert test3 == test3_answer
     
     filter4 = ["y",  "z"]
-    test4 = list(filter(lambda installable: filter_aggregate(filter4, installable, 'disjunction'), test))
+    test4 = list(filter(lambda installable: filter_aggregate(filter4, installable, filter_match_all=False), test))
     test4_answer = [test[1],test[2],test[3],test[5],test[6],test[7],test[9],test[10],test[11]]
     assert test4 == test4_answer

--- a/bin/test/ce_install_test.py
+++ b/bin/test/ce_install_test.py
@@ -55,10 +55,43 @@ def test_should_honour_root_matches():
     assert filter_match("/a/b/c", fake("a/b/c", "target"))
     assert not filter_match("/b/c", fake("a/b/c", "target"))
 
+
+def test_should_match_all_filters():
+    assert not filter_aggregate(["a", "b"], fake("a", "target"), 'conjunction')
+    assert not filter_aggregate(["a", "b"], fake("b", "target"), 'conjunction')
+    assert filter_aggregate(["a", "target"], fake("a", "target"), 'conjunction')
+
 def test_should_match_any_filter():
-    assert filter_aggregate(["a", "b"], fake("a", "target"))
-    assert filter_aggregate(["a", "b"], fake("b", "target"))
-    assert not filter_aggregate(["a", "b"], fake("c", "target"))
+    assert filter_aggregate(["a", "b"], fake("a", "target"), 'disjunction')
+    assert filter_aggregate(["a", "b"], fake("b", "target"), 'disjunction')
+    assert not filter_aggregate(["a", "b"], fake("c", "target"), 'disjunction')
+
+def test_all_should_match_all_filters():
+    test = [
+        fake("a/x", "target"), fake("a/y", "target"), fake("a/z", "target"), fake("a/z", "other"),
+        fake("b/x", "target"), fake("b/y", "target"), fake("b/z", "target"), fake("b/z", "other"),
+        fake("c/x", "target"), fake("c/y", "target"), fake("c/z", "target"), fake("c/z", "other"),
+    ]
+
+    filter1 = ["a", "b"]
+    test1 = list(filter(lambda installable: filter_aggregate(filter1, installable, 'conjunction'), test))
+    test1_answer = []
+    assert test1 == test1_answer
+
+    filter2 = ["a", "target"]
+    test2 = list(filter(lambda installable: filter_aggregate(filter2, installable, 'conjunction'), test))
+    test2_answer = [test[0],test[1],test[2]]
+    assert test2 == test2_answer
+
+    filter3 = ["target", "other"]
+    test3 = list(filter(lambda installable: filter_aggregate(filter3, installable, 'conjunction'), test))
+    test3_answer = []
+    assert test3 == test3_answer
+    
+    filter4 = ["c",  "z", "other"]
+    test4 = list(filter(lambda installable: filter_aggregate(filter4, installable, 'conjunction'), test))
+    test4_answer = [test[11]]
+    assert test4 == test4_answer
 
 def test_all_should_match_any_filter():
     test = [
@@ -68,21 +101,21 @@ def test_all_should_match_any_filter():
     ]
 
     filter1 = ["a", "b"]
-    test1 = list(filter(lambda installable: filter_aggregate(filter1, installable), test))
+    test1 = list(filter(lambda installable: filter_aggregate(filter1, installable, 'disjunction'), test))
     test1_answer = [test[0],test[1],test[2],test[3],test[4],test[5],test[6],test[7]]
     assert test1 == test1_answer
 
     filter2 = ["a", "b", "c/z"]
-    test2 = list(filter(lambda installable: filter_aggregate(filter2, installable), test))
+    test2 = list(filter(lambda installable: filter_aggregate(filter2, installable, 'disjunction'), test))
     test2_answer = [test[0],test[1],test[2],test[3],test[4],test[5],test[6],test[7],test[10],test[11]]
     assert test2 == test2_answer
 
     filter3 = ["a/x target", "b/z other", "c/z other"]
-    test3 = list(filter(lambda installable: filter_aggregate(filter3, installable), test))
-    test4_answer = [test[0],test[7],test[11]]
-    assert test3 == test4_answer
+    test3 = list(filter(lambda installable: filter_aggregate(filter3, installable, 'disjunction'), test))
+    test3_answer = [test[0],test[7],test[11]]
+    assert test3 == test3_answer
     
     filter4 = ["y",  "z"]
-    test4 = list(filter(lambda installable: filter_aggregate(filter4, installable), test))
+    test4 = list(filter(lambda installable: filter_aggregate(filter4, installable, 'disjunction'), test))
     test4_answer = [test[1],test[2],test[3],test[5],test[6],test[7],test[9],test[10],test[11]]
     assert test4 == test4_answer

--- a/bin/test/ce_install_test.py
+++ b/bin/test/ce_install_test.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock
 
-from lib.ce_install import filter_match
+from lib.ce_install import filter_match, filter_aggregate
 
 
 def fake(context, target_name):
@@ -54,3 +54,35 @@ def test_should_match_end_of_context():
 def test_should_honour_root_matches():
     assert filter_match("/a/b/c", fake("a/b/c", "target"))
     assert not filter_match("/b/c", fake("a/b/c", "target"))
+
+def test_should_match_any_filter():
+    assert filter_aggregate(["a", "b"], fake("a", "target"))
+    assert filter_aggregate(["a", "b"], fake("b", "target"))
+    assert not filter_aggregate(["a", "b"], fake("c", "target"))
+
+def test_all_should_match_any_filter():
+    test = [
+        fake("a/x", "target"), fake("a/y", "target"), fake("a/z", "target"), fake("a/z", "other"),
+        fake("b/x", "target"), fake("b/y", "target"), fake("b/z", "target"), fake("b/z", "other"),
+        fake("c/x", "target"), fake("c/y", "target"), fake("c/z", "target"), fake("c/z", "other"),
+    ]
+
+    filter1 = ["a", "b"]
+    test1 = list(filter(lambda installable: filter_aggregate(filter1, installable), test))
+    test1_answer = [test[0],test[1],test[2],test[3],test[4],test[5],test[6],test[7]]
+    assert test1 == test1_answer
+
+    filter2 = ["a", "b", "c/z"]
+    test2 = list(filter(lambda installable: filter_aggregate(filter2, installable), test))
+    test2_answer = [test[0],test[1],test[2],test[3],test[4],test[5],test[6],test[7],test[10],test[11]]
+    assert test2 == test2_answer
+
+    filter3 = ["a/x target", "b/z other", "c/z other"]
+    test3 = list(filter(lambda installable: filter_aggregate(filter3, installable), test))
+    test4_answer = [test[0],test[7],test[11]]
+    assert test3 == test4_answer
+    
+    filter4 = ["y",  "z"]
+    test4 = list(filter(lambda installable: filter_aggregate(filter4, installable), test))
+    test4_answer = [test[1],test[2],test[3],test[5],test[6],test[7],test[9],test[10],test[11]]
+    assert test4 == test4_answer


### PR DESCRIPTION
Changing filtering from `and`-ing to `or`-ing. Unless there are no filters, each installable must pass at least one filter to be installed.
Resolves #719 .