### PR TITLE
Add widberg compiler

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -610,6 +610,7 @@ compilers:
           - concepts-trunk
           - embed-trunk
           - dang-main
+          - widberg-main
           - relocatable-trunk
           - autonsdmi-trunk
           - lifetime-trunk

--- a/remove_old_compilers.sh
+++ b/remove_old_compilers.sh
@@ -42,6 +42,7 @@ remove_older clang-parmexpr
 remove_older clang-patmat
 remove_older clang-embed
 remove_older clang-dang-main
+remove_older clang-widberg-main
 remove_older llvm-spirv
 remove_older go
 remove_older tinycc


### PR DESCRIPTION
This PR adds the [widberg clang compiler](https://github.com/widberg/llvm-project-widberg-extensions). This compiler is an experimental reverse engineering compiler being developed at the University of Massachusetts Lowell Computer Science Department. We believe that there will be great utility in being able to provide live links to code samples using the compiler in publications. The multi-repo organization of CE is somewhat unwieldy to an outsider like me, so I have undoubtably made a mistake in at least one of these PRs; thank you for any fixes you are able to provide.

Related PRs:
https://github.com/compiler-explorer/clang-builder/pull/35
https://github.com/compiler-explorer/compiler-workflows/pull/8
https://github.com/compiler-explorer/compiler-explorer/pull/3658