### PR TITLE
Add new versions of GCC for rv32 and rv64

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -307,14 +307,22 @@ compilers:
           subdir: riscv64
           targets:
             - 8.2.0
+            - 8.5.0
+            - 9.4.0
             - 10.2.0
+            - 10.3.0
+            - 11.2.0
         riscv32:
           arch_prefix: "riscv32-unknown-elf"
           check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
           subdir: riscv32
           targets:
             - 8.2.0
+            - 8.5.0
+            - 9.4.0
             - 10.2.0
+            - 10.3.0
+            - 11.2.0
         k1:
           arch_prefix: "k1-unknown-elf"
           check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"


### PR DESCRIPTION
Following https://github.com/compiler-explorer/gcc-cross-builder/pull/19,
teach infra about new riscv compilers

GCC versions for riscv32 and riscv64: 8.5.0, 9.4.0, 10.3.0 and 11.2.0.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>