### PR TITLE
C++ 6502 things

### DIFF
--- a/bin/lib/installation.py
+++ b/bin/lib/installation.py
@@ -678,7 +678,8 @@ class NightlyInstallable(Installable):
         most_recent = max(current[compiler_name])
         self.info(f'Most recent {compiler_name} is {most_recent}')
         path_name_prefix = self.config_get('path_name_prefix', compiler_name)
-        self.s3_path = f'{compiler_name}-{most_recent}'
+        s3_name = self.config_get('s3_name', compiler_name)
+        self.s3_path = f'{s3_name}-{most_recent}'
         self.local_path = f'{path_name_prefix}-{most_recent}'
         self.install_path = os.path.join(self.subdir, f'{path_name_prefix}-{most_recent}')
         self.compiler_pattern = os.path.join(self.subdir, f'{path_name_prefix}-*')

--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -678,6 +678,12 @@ compilers:
         check_exe: bin/tcc -v
         targets:
           - trunk
+      6502-c++:
+        type: nightly
+        s3_name: 6502-c%2B%2B-{{name}}
+        check_exe: bin/6502-c++
+        targets:
+          - trunk
     djgpp:
       type: tarballs
       check_exe: bin/i586-pc-msdosdjgpp-g++ --version

--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -681,7 +681,7 @@ compilers:
       6502-c++:
         type: nightly
         s3_name: 6502-c%2B%2B-{{name}}
-        check_exe: bin/6502-c++
+        check_exe: bin/6502-c++ --help
         targets:
           - trunk
     djgpp:

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1595,6 +1595,14 @@ libraries:
     nightly:
       install_always: true
       if: nightly
+      avr-libstdcpp:
+        type: github
+        method: nightlyclone
+        repo: modm-io/avr-libstdcpp
+        build_type: manual
+        check_file: include/array
+        targets:
+          - trunk
       mir_core:
         type: github
         method: nightlyclone

--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -49,3 +49,23 @@ tools:
     check_exe: asm-parser --version
     targets:
       - trunk
+  xa:
+    type: tarballs
+    dir: x86-to-6502/xa-{{name}}
+    untar_dir: xa-{{name}}
+    check_exe: bin/xa --version
+    url: https://www.floodgap.com/retrotech/xa/dists/xa-{{name}}.tar.gz
+    compression: gz
+    targets:
+      - 2.3.13
+    after_stage_script:
+      - mv xa-{{name}} xa-build
+      - mkdir -p xa-{{name}}/bin
+      - cd xa-build
+      - make xa uncpk
+      - mv xa ../xa-{{name}}/bin/xa
+      - mv reloc65 ../xa-{{name}}/bin/reloc65
+      - mv ldo65 ../xa-{{name}}/bin/ldo65
+      - mv file65 ../xa-{{name}}/bin/file65
+      - mv printcbm ../xa-{{name}}/bin/printcbm
+      - mv uncpk ../xa-{{name}}/bin/uncpk

--- a/update_compilers/install_binaries.sh
+++ b/update_compilers/install_binaries.sh
@@ -70,9 +70,9 @@ if [[ "$TARGET_PAHOLE_VERSION" != "$CURRENT_PAHOLE_VERSION" ]]; then
 fi
 
 #########################
-# x86-to-6502
+# x86-to-6502 old version
 
-if [[ ! -d ${OPT}/x86-to-6502/lefticus ]]; then
+if [[ ! -f ${OPT}/x86-to-6502/lefticus/x86-to-6502 ]]; then
     mkdir -p ${OPT}/x86-to-6502/lefticus
 
     mkdir -p /tmp/build
@@ -80,10 +80,59 @@ if [[ ! -d ${OPT}/x86-to-6502/lefticus ]]; then
 
     git clone https://github.com/lefticus/x86-to-6502.git lefticus
     pushd lefticus
+    git checkout 2a2ce54d32097558b81d014039309b68bce7aed8
     ${OPT}/cmake/bin/cmake .
     make
     mv x86-to-6502 ${OPT}/x86-to-6502/lefticus
     popd
+
+    popd
+    rm -rf /tmp/build
+fi
+
+#########################
+# x86-to-6502 new version
+
+if [[ ! -f ${OPT}/x86-to-6502/lefticus/6502-c++ ]]; then
+    mkdir -p ${OPT}/x86-to-6502/lefticus
+
+    mkdir -p /tmp/build
+    pushd /tmp/build
+
+    git clone https://github.com/lefticus/6502-cpp.git lefticus
+    pushd lefticus
+    mkdir -p build
+    cd build
+    CXX=/opt/compiler-explorer/gcc-10.2.0/bin/g++ ${OPT}/cmake/bin/cmake ..
+    make 6502-c++
+    mv bin/6502-c++ ${OPT}/x86-to-6502/lefticus
+    popd
+
+    popd
+    rm -rf /tmp/build
+fi
+
+#########################
+# xa 6502 cross compiler
+
+if [[ ! -f ${OPT}/x86-to-6502/xa/bin/xa ]]; then
+    mkdir -p ${OPT}/x86-to-6502/xa/bin
+
+    mkdir -p /tmp/build
+    pushd /tmp/build
+
+    curl https://www.floodgap.com/retrotech/xa/dists/xa-2.3.13.tar.gz | tar xzf -
+    cd xa-2.3.13
+
+    make xa uncpk
+    mv xa ${OPT}/x86-to-6502/xa/bin/xa
+    mv reloc65 ${OPT}/x86-to-6502/xa/bin/reloc65
+    mv ldo65 ${OPT}/x86-to-6502/xa/bin/ldo65
+    mv file65 ${OPT}/x86-to-6502/xa/bin/file65
+    mv printcbm ${OPT}/x86-to-6502/xa/bin/printcbm
+    mv uncpk ${OPT}/x86-to-6502/xa/bin/uncpk
+
+    cd ..
 
     popd
     rm -rf /tmp/build

--- a/update_compilers/install_binaries.sh
+++ b/update_compilers/install_binaries.sh
@@ -99,27 +99,7 @@ if [[ ! -f ${OPT}/x86-to-6502/lefticus/x86-to-6502 ]]; then
     rm -rf /tmp/build
 fi
 
-#########################
-# x86-to-6502 new version
-
-if [[ ! -f ${OPT}/x86-to-6502/lefticus/6502-c++ ]]; then
-    mkdir -p ${OPT}/x86-to-6502/lefticus
-
-    mkdir -p /tmp/build
-    pushd /tmp/build
-
-    git clone https://github.com/lefticus/6502-cpp.git lefticus
-    pushd lefticus
-    mkdir -p build
-    cd build
-    CXX=/opt/compiler-explorer/gcc-10.2.0/bin/g++ ${OPT}/cmake/bin/cmake ..
-    make 6502-c++
-    mv bin/6502-c++ ${OPT}/x86-to-6502/lefticus
-    popd
-
-    popd
-    rm -rf /tmp/build
-fi
+# x86-to-6502 new version (6502-c++) is built by misc-builder
 
 #########################
 # iwyu - include-what-you-use

--- a/update_compilers/install_binaries.sh
+++ b/update_compilers/install_binaries.sh
@@ -122,32 +122,6 @@ if [[ ! -f ${OPT}/x86-to-6502/lefticus/6502-c++ ]]; then
 fi
 
 #########################
-# xa 6502 cross compiler
-
-if [[ ! -f ${OPT}/x86-to-6502/xa/bin/xa ]]; then
-    mkdir -p ${OPT}/x86-to-6502/xa/bin
-
-    mkdir -p /tmp/build
-    pushd /tmp/build
-
-    curl https://www.floodgap.com/retrotech/xa/dists/xa-2.3.13.tar.gz | tar xzf -
-    cd xa-2.3.13
-
-    make xa uncpk
-    mv xa ${OPT}/x86-to-6502/xa/bin/xa
-    mv reloc65 ${OPT}/x86-to-6502/xa/bin/reloc65
-    mv ldo65 ${OPT}/x86-to-6502/xa/bin/ldo65
-    mv file65 ${OPT}/x86-to-6502/xa/bin/file65
-    mv printcbm ${OPT}/x86-to-6502/xa/bin/printcbm
-    mv uncpk ${OPT}/x86-to-6502/xa/bin/uncpk
-
-    cd ..
-
-    popd
-    rm -rf /tmp/build
-fi
-
-#########################
 # iwyu - include-what-you-use
 
 if [[ ! -d ${OPT}/iwyu/0.12 ]]; then


### PR DESCRIPTION
* Fixes the commit hash for the old version of x86-to-6502 that we use on the main site
* Adds the new avr-based x86-to-6502
* Adds avr-libstdcpp library (required by new x86-to-6502)
* Adds xa 6502 cross compiler (required by new x86-to-6502)

Bit sad about adding more to the .sh file while we should probably be phasing that out...
