### PR TITLE
Add 2 more versions of GCC for rv32 and rv64

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -312,6 +312,8 @@ compilers:
             - 10.2.0
             - 10.3.0
             - 11.2.0
+            - 11.3.0
+            - 12.1.0
         riscv32:
           arch_prefix: "riscv32-unknown-elf"
           check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
@@ -323,6 +325,8 @@ compilers:
             - 10.2.0
             - 10.3.0
             - 11.2.0
+            - 11.3.0
+            - 12.1.0
         k1:
           arch_prefix: "k1-unknown-elf"
           check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"


### PR DESCRIPTION
Thanks to these PR:
https://github.com/compiler-explorer/gcc-cross-builder/pull/27
https://github.com/compiler-explorer/gcc-cross-builder/pull/26

we can add 11.3.0 and (fresh) 12.1.0.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>