### PR TITLE
Add 3 new versions of GCC for ARM GNU Toolchain

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -141,6 +141,33 @@ compilers:
             targets:
               - gcc-arm-none-eabi-10-2020-q4 # name unused in this case
           - type: tarballs
+            check_exe: bin/arm-none-eabi-g++ --version
+            subdir: arm
+            dir: arm/gcc-arm-none-eabi-10.3-2021.07
+            untar_dir: gcc-arm-none-eabi-10.3-2021.07
+            url: https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.07/gcc-arm-none-eabi-10.3-2021.07-x86_64-linux.tar.bz2
+            compression: bz2
+            targets:
+              - gcc-arm-none-eabi-10.3-2021.07 # name unused in this case
+          - type: tarballs
+            check_exe: bin/arm-none-eabi-g++ --version
+            subdir: arm
+            dir: arm/gcc-arm-none-eabi-10.3-2021.10
+            untar_dir: gcc-arm-none-eabi-10.3-2021.10
+            url: https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2
+            compression: bz2
+            targets:
+              - gcc-arm-none-eabi-10.3-2021.10 # name unused in this case
+          - type: tarballs
+            check_exe: bin/arm-none-eabi-g++ --version
+            subdir: arm
+            dir: arm/gcc-arm-none-eabi-11.2-2022.02
+            untar_dir: gcc-arm-none-eabi-11.2-2022.02
+            url: https://developer.arm.com/-/media/Files/downloads/gnu/11.2-2022.02/binrel/gcc-arm-11.2-2022.02-x86_64-arm-none-eabi.tar.xz
+            compression: xz
+            targets:
+              - gcc-arm-none-eabi-11.2-2022.02 # name unused in this case
+          - type: tarballs
             # Not in a subdir
             check_exe: bin/arm-none-eabi-g++ --version
             dir: gcc-arm-none-eabi-5_4-2016q3


### PR DESCRIPTION
ARM GNU Toolchain: 11.2-2022.02 for AArch32 bare-metal target (arm-none-eabi)
ARM GNU Toolchain: 10.3-2021.10 for AArch32 bare-metal target (arm-none-eabi)
ARM GNU Toolchain: 10.3-2021.07 for AArch32 bare-metal target (arm-none-eabi)

Signed-off-by: Ryan McClelland <rymcclel@gmail.com>