### PR TITLE
fix gcc-arm-none-eabi 2022.02 dir

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -161,7 +161,7 @@ compilers:
           - type: tarballs
             check_exe: bin/arm-none-eabi-g++ --version
             subdir: arm
-            dir: arm/gcc-arm-11.2-2022.02-x86_64-arm-none-eabi
+            dir: arm/gcc-arm-none-eabi-11.2-2022.02
             untar_dir: gcc-arm-11.2-2022.02-x86_64-arm-none-eabi
             url: https://developer.arm.com/-/media/Files/downloads/gnu/11.2-2022.02/binrel/gcc-arm-11.2-2022.02-x86_64-arm-none-eabi.tar.xz
             compression: xz


### PR DESCRIPTION
apparently I got the wrong path name with how arm1121 was written

https://github.com/compiler-explorer/compiler-explorer/blob/c9b45c64d34d4ae566d8c075c399fde17ccb5e74/etc/config/c%2B%2B.amazon.properties#L851