### PR TITLE
adding mfem library

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -293,13 +293,6 @@ libraries:
       lib_type: static
       extra_cmake_arg:
         - -DBUILD_STATIC_LIBS=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_OBJECT_LIBS=OFF -DBUILD_TESTING=OFF -DJSONCPP_WITH_TESTS=OFF -DJSONCPP_WITH_POST_BUILD_UNITTEST=OFF -DJSONCPP_WITH_CMAKE_PACKAGE=OFF -DJSONCPP_WITH_STRICT_ISO=OFF -DJSONCPP_WITH_PKGCONFIG_SUPPORT=OFF
-    mfem:
-       type: github
-       repo: mfem/mfem
-       build_type: cmake
-       lib_type: static
-       targets:
-         - master
     nsimd:
       type: s3tarballs
       s3_path_prefix: nsimd-{name}
@@ -1090,6 +1083,16 @@ libraries:
         build_type: none
         targets:
           - trunk
+      mfem:
+        type: github
+        method: nightlyclone
+        repo: mfem/mfem
+        build_type: cmake
+        lib_type: static
+        targets:
+          - trunk
+        staticliblink:
+          - mfem
       ofw:
         type: github
         method: nightlyclone

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -293,6 +293,13 @@ libraries:
       lib_type: static
       extra_cmake_arg:
         - -DBUILD_STATIC_LIBS=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_OBJECT_LIBS=OFF -DBUILD_TESTING=OFF -DJSONCPP_WITH_TESTS=OFF -DJSONCPP_WITH_POST_BUILD_UNITTEST=OFF -DJSONCPP_WITH_CMAKE_PACKAGE=OFF -DJSONCPP_WITH_STRICT_ISO=OFF -DJSONCPP_WITH_PKGCONFIG_SUPPORT=OFF
+    mfem:
+       type: github
+       repo: mfem/mfem
+       build_type: cmake
+       lib_type: static
+       targets:
+         - master
     nsimd:
       type: s3tarballs
       s3_path_prefix: nsimd-{name}


### PR DESCRIPTION
Hi, I'm interested in adding support for the C++ library, mfem: https://mfem.org

I'm trying to follow the instructions here: 
https://github.com/compiler-explorer/compiler-explorer/blob/main/docs/AddingALibrary.md 
but I don't fully understand all of the details. In particular, I'm not sure how to test if these changes to libraries.yaml are doing the right thing or not.

For reference, the mfem static library can be built with the idiomatic cmake commands:
```sh
git clone https://github.com/mfem/mfem
cd mfem
cmake . -B build && cd build
make -j
```

the companion PR for compiler-explorer/compiler-explorer is https://github.com/compiler-explorer/compiler-explorer/pull/3745
