### PR TITLE
Add the gitlab bmulti library to the live site

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -97,6 +97,14 @@ libraries:
       build_type: cmake
       extra_cmake_arg:
         - -DBENCHMARK_ENABLE_TESTING=off
+    bmulti:
+      type: gitlab
+      method: nightlyclone
+      repo: correaa/boost-multi
+      check_file: include/multi/array.hpp
+      build_type: none
+      targets:
+        - trunk
     googletest:
       type: github
       repo: google/googletest


### PR DESCRIPTION
Proposing to add the B-Multi library to the live site. https://gitlab.com/correaa/boost-multi

Followed the steps as best as I could in https://github.com/compiler-explorer/compiler-explorer/blob/main/docs/AddingALibrary.md#adding-a-new-library-to-the-live-site

Feedback on improving the hooks and the organizations of files in the repository is welcome.
The goal is to include the library by doing `#include<multi/array.hpp>`.