### PR TITLE
Add ce_install command to reformat libraries.yaml

### DIFF
--- a/bin/lib/ce_install.py
+++ b/bin/lib/ce_install.py
@@ -284,7 +284,7 @@ def main():
         sys.exit(0)
     elif args.command == 'reformat':
         libyaml = LibraryYaml(args.yaml_dir)
-        libyaml.Reformat()
+        libyaml.reformat()
 
     else:
         raise RuntimeError("Er, whoops")

--- a/bin/lib/ce_install.py
+++ b/bin/lib/ce_install.py
@@ -9,6 +9,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 import yaml
+from lib.library_yaml import LibraryYaml
 
 from lib.amazon_properties import get_properties_compilers_and_libraries
 from lib.config_safe_loader import ConfigSafeLoader
@@ -100,7 +101,7 @@ def main():
                         help='installables must pass any filter (default "False")')
 
     parser.add_argument('command',
-                        choices=['list', 'install', 'check_installed', 'verify', 'amazoncheck', 'build', 'squash', 'squashcheck'],
+                        choices=['list', 'install', 'check_installed', 'verify', 'amazoncheck', 'build', 'squash', 'squashcheck', 'reformat'],
                         default='list',
                         nargs='?')
     parser.add_argument('filter', nargs='*', help='filters to apply', default=[])
@@ -281,6 +282,10 @@ def main():
         if num_failed:
             sys.exit(1)
         sys.exit(0)
+    elif args.command == 'reformat':
+        libyaml = LibraryYaml(args.yaml_dir)
+        libyaml.Reformat()
+
     else:
         raise RuntimeError("Er, whoops")
 

--- a/bin/lib/installation.py
+++ b/bin/lib/installation.py
@@ -1128,7 +1128,7 @@ def _targets_from(node, enabled, context, name, base_config):
             if isinstance(target, float):
                 raise RuntimeError(f"Target {target} was parsed as a float. Enclose in quotes")
             if isinstance(target, str):
-                target = {'name': target}
+                target = {'name': target, 'underscore_name': target.replace('.', '_')}
             yield expand_target(ChainMap(target, base_config), context)
 
 

--- a/bin/lib/library_yaml.py
+++ b/bin/lib/library_yaml.py
@@ -11,12 +11,12 @@ class LibraryYaml:
         self.Load()
 
     def Load(self):
-        with self.yaml_path.open() as yaml_file:
+        with self.yaml_path.open(encoding='utf-8', mode="r") as yaml_file:
             self.yaml_doc = yaml.load(yaml_file, Loader=ConfigSafeLoader)
 
     def Save(self):
-       with open(self.yaml_path, "w") as yaml_file:
-           yaml.dump(self.yaml_doc, yaml_file)
+        with self.yaml_path.open(encoding='utf-8', mode="w") as yaml_file:
+            yaml.dump(self.yaml_doc, yaml_file)
 
     def Reformat(self):
         self.Load()

--- a/bin/lib/library_yaml.py
+++ b/bin/lib/library_yaml.py
@@ -1,0 +1,23 @@
+import os
+import yaml
+from pathlib import Path
+
+from lib.config_safe_loader import ConfigSafeLoader
+
+class LibraryYaml:
+    def __init__(self, yaml_dir):
+        self.yaml_dir = yaml_dir
+        self.yaml_path = Path(os.path.join(self.yaml_dir, 'libraries.yaml'))
+        self.Load()
+
+    def Load(self):
+        with self.yaml_path.open() as yaml_file:
+            self.yaml_doc = yaml.load(yaml_file, Loader=ConfigSafeLoader)
+
+    def Save(self):
+       with open(self.yaml_path, "w") as yaml_file:
+           yaml.dump(self.yaml_doc, yaml_file)
+
+    def Reformat(self):
+        self.Load()
+        self.Save()

--- a/bin/lib/library_yaml.py
+++ b/bin/lib/library_yaml.py
@@ -8,16 +8,15 @@ class LibraryYaml:
     def __init__(self, yaml_dir):
         self.yaml_dir = yaml_dir
         self.yaml_path = Path(os.path.join(self.yaml_dir, 'libraries.yaml'))
-        self.Load()
+        self.load()
 
-    def Load(self):
+    def load(self):
         with self.yaml_path.open(encoding='utf-8', mode="r") as yaml_file:
             self.yaml_doc = yaml.load(yaml_file, Loader=ConfigSafeLoader)
 
-    def Save(self):
+    def save(self):
         with self.yaml_path.open(encoding='utf-8', mode="w") as yaml_file:
             yaml.dump(self.yaml_doc, yaml_file)
 
-    def Reformat(self):
-        self.Load()
-        self.Save()
+    def reformat(self):
+        self.save()

--- a/bin/test/installation_test.py
+++ b/bin/test/installation_test.py
@@ -22,7 +22,7 @@ weasel:
     targets:
     - moo
     """) == [
-        {'type': 'foo', 'name': 'moo', 'context': ['weasel']}
+        {'type': 'foo', 'name': 'moo', 'underscore_name': 'moo', 'context': ['weasel']}
     ]
 
 
@@ -38,7 +38,7 @@ weasel:
         - ook
     """) == [
         {'type': 'foo', 'base_config': 'baboon', 'weasel_config': 'weasel',
-         'context': ['weasel', 'baboon'], 'name': 'ook'}
+         'context': ['weasel', 'baboon'], 'name': 'ook', 'underscore_name': 'ook'}
     ]
 
 

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -13,7 +13,6 @@ libraries:
     boost:
       type: tarballs
       compression: bz2
-      underscore_name: "{{ name | replace('.', '_') }}"
       check_file: boost/version.hpp
       extract_only: boost_{{underscore_name}}/boost
       untar_dir: boost_{{underscore_name}}


### PR DESCRIPTION
This PR is so that we can reformat `libraries.yaml` and easily automate adding new libraries to it.

* Adds `underscore_name` by default to everything, the yaml save option mangles the original contents of `underscore_name`
* Adds a `reformat` command to load `libraries.yaml` and save it in the natural order the python dict uses
