### PR TITLE
Add `ranges-v3` Release `0.11.0`

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1427,6 +1427,7 @@ libraries:
       - 0.9.1
       - 0.10.0
       - 0.11.0
+      - 0.12.0
       type: github
     scnlib:
       build_type: cmake


### PR DESCRIPTION
There is a new [release](https://github.com/ericniebler/range-v3/releases/tag/0.12.0) of `range-v3`. This PR adds the release.