### PR TITLE
Add more OCaml compilers

### DIFF
--- a/bin/yaml/ocaml.yaml
+++ b/bin/yaml/ocaml.yaml
@@ -25,3 +25,55 @@ compilers:
       - 4.11.2-flambda
       - 4.12.0
       - 4.12.0-flambda
+    newer:
+      type: tarballs
+      check_exe: bin/ocaml --version
+      url: https://caml.inria.fr/pub/distrib/ocaml-{rel}/ocaml-{rel}.{min}.tar.xz
+      dir: ocaml-{rel}.{min}
+      compression: xz
+      after_stage_script:
+        - mkdir install
+        - cd {dir}
+        - ./configure --prefix={destination}/{dir} {options}
+        - make
+        - make install DESTDIR=$(realpath ../install)
+        - cd ..
+        - rm -r {dir}
+        - mv install/{destination}/{dir} {dir}
+        - rm -r install
+      targets:
+        - name: 4.13.0
+          rel: 4.13
+          min: 0
+          options: ""
+        - name: 4.13.0-flambda
+          rel: 4.13
+          min: 0
+          options: --enable-flambda
+        - name: 4.13.1
+          rel: 4.13
+          min: 1
+          options: ""
+        - name: 4.13.1-flambda
+          rel: 4.13
+          min: 1
+          options: --enable-flambda
+        - name: 4.14.0
+          rel: 4.14
+          min: 0
+          options: ""
+        - name: 4.14.0-flambda
+          rel: 4.14
+          min: 0
+          options: --enable-flambda
+      multicore:
+        if: nightly
+        targets:
+          - name: 5.0.0~alpha0
+            rel: 5.0
+            min: 0~alpha0
+            options: ""
+          - name: 5.0.0~alpha0-flambda
+            rel: 5.0
+            min: 0~alpha0
+            options: --enable-flambda


### PR DESCRIPTION
Added versions: 4.13.{0,1}, 4.14.0, and the first multicore alpha, all with flambda variants, 8 new compilers in total
Tested: 4.13.0, and the flambda variant