### PR TITLE
Add more OCaml compilers

### DIFF
--- a/bin/yaml/ocaml.yaml
+++ b/bin/yaml/ocaml.yaml
@@ -29,8 +29,5 @@ compilers:
       - 4.13.1-flambda
       - 4.14.0
       - 4.14.0-flambda
-    multicore:
-      if: nightly
-      targets:
-        - "5.0"
-        - 5.0-flambda
+      - "5.0"
+      - 5.0-flambda

--- a/bin/yaml/ocaml.yaml
+++ b/bin/yaml/ocaml.yaml
@@ -29,5 +29,5 @@ compilers:
       - 4.13.1-flambda
       - 4.14.0
       - 4.14.0-flambda
-      - "5.0"
-      - 5.0-flambda
+      - 5.0.0
+      - 5.0.0-flambda

--- a/bin/yaml/ocaml.yaml
+++ b/bin/yaml/ocaml.yaml
@@ -25,3 +25,12 @@ compilers:
       - 4.11.2-flambda
       - 4.12.0
       - 4.12.0-flambda
+      - 4.13.1
+      - 4.13.1-flambda
+      - 4.14.0
+      - 4.14.0-flambda
+    multicore:
+      if: nightly
+      targets:
+        - "5.0"
+        - 5.0-flambda


### PR DESCRIPTION
Added 4.13.1, 4.14.0, and multicore, all with flambda variants

notes:
- 5.0 is still alpha release, the github url points to 5.0 and I believe that branch will continue getting updates till the stable release.
- 4.13.0 was skipped because it's mostly identical to .1, the latter being a bugfix release
- 5.0 should be named 5.0~alpha0 for now, but I'm not sure how doing that will interact with the building infra