### PR TITLE
Add GCC 12.1.0 for cross targets

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -231,6 +231,9 @@ compilers:
             - 9.3.0
             - 10.3.0
             - 11.1.0
+            - name: 12.1.0
+              untar_dir: "gcc-{name}"
+              check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
         arm64:
           arch_prefix: aarch64-unknown-linux-gnu
           check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
@@ -268,19 +271,26 @@ compilers:
               targets:
                 - 5.4.0
                 - 11.2.0
+                - 12.1.0
             mipsel:
               subdir: mipsel
               targets:
                 - 5.4.0
+                - name: 12.1.0
+                  arch_prefix: "{subdir}-multilib-linux-gnu"
             mips64:
               subdir: mips64
               targets:
                 - 5.4.0
                 - 11.2.0
+                - 12.1.0
             mips64el:
               subdir: mips64el
               targets:
                 - 5.4.0
+                - name: 12.1.0
+                  arch_prefix: "{subdir}-multilib-linux-uclibc"
+
           - type: tarballs
             subdir: mips
             check_exe: "bin/mips-mti-elf-g++ --version"
@@ -389,6 +399,7 @@ compilers:
           subdir: s390x
           targets:
             - 11.2.0
+            - 12.1.0
         powerpc:
           arch_prefix: "{subdir}-unknown-linux-gnu"
           check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
@@ -398,12 +409,14 @@ compilers:
               - name: 4.8.5
                 check_exe: "{arch_prefix}/bin/g++ --version"
               - name: 11.2.0
+              - name: 12.1.0
           powerpc64:
             subdir: powerpc64
             targets:
               - at12
               - at13
               - 11.2.0
+              - 12.1.0
           powerpc64le:
             subdir: powerpc64le
             targets:
@@ -411,6 +424,7 @@ compilers:
               - at12
               - at13
               - 11.2.0
+              - 12.1.0
         xtensa:
           esp32:
             arch_prefix: xtensa-esp32-elf


### PR DESCRIPTION
Update with GCC 12.1.0 for:

 - mips + mips64 + mipsel + mips64el
 - powerpc + powerpc64 + powerpc64le
 - s390x
 - avr
 - msp430

refs compiler-explorer/compiler-explorer#3729
refs compiler-explorer/compiler-explorer#3761

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>