### PR TITLE
Add the jakt programming language

### DIFF
--- a/bin/yaml/jakt.yaml
+++ b/bin/yaml/jakt.yaml
@@ -1,0 +1,8 @@
+compilers:
+  jakt:
+    if: nightly
+    type: nightly
+    s3_path_prefix: jakt-{name}
+    check_exe: jakt-selfhost --version
+    targets:
+      - trunk


### PR DESCRIPTION
Jakt does not currently (and for the forseeable future) provide any
precompiled binaries. So the compiler needs to be build from source.

The way I did it is a bit of a hack, since I didn't see how I could install a
compiler from GitHub, so I reused the GitHub installation for libraries
and manually installed them to a different path than libs/

There are two compilers, a rust-based one that's build using cargo, and
then a selfhosted compiler that's build using the rust-based compiler
(for now).

This installs two compilers as one, since we need our rust-based
compiler to compile the selfhosted compiler.