### PR TITLE
Add --from and --until date ranges to ads

### DIFF
--- a/bin/lib/cli/ads.py
+++ b/bin/lib/cli/ads.py
@@ -18,6 +18,28 @@ def format_ad(ad):
     return ADS_FORMAT.format(ad['id'], str(ad['filter']), f"{valid_from} - {valid_until}", ad['html'])
 
 
+def parse_valid_ranges(valid_from: Optional[str], valid_until: Optional[str]) -> (Optional[str], Optional[str]):
+    from_date = None
+    until_date = None
+    if valid_from is not None:
+        parsed_from = ''
+        try:
+            parsed_from = dateutil.parser.parse(valid_from).isoformat()
+        except (dateutil.parser.ParserError, OverflowError) as e:
+            print(f'Could not parse valid_from {valid_from} date:\n{e}')
+        finally:
+            from_date = parsed_from
+    if valid_until is not None:
+        parsed_until = ''
+        try:
+            parsed_until = dateutil.parser.parse(valid_until).isoformat()
+        except (dateutil.parser.ParserError, OverflowError) as e:
+            print(f'Could not parse valid_until {valid_until} date:\n{e}')
+        finally:
+            until_date = parsed_until
+    return from_date, until_date
+
+
 @cli.group()
 def ads():
     """Community advert manipulation features."""
@@ -47,24 +69,11 @@ def ads_add(cfg: Config, lang_filter: Sequence[str], valid_from: Optional[str], 
         'filter': lang_filter,
         'id': max([x['id'] for x in events['ads']]) + 1 if len(events['ads']) > 0 else 0
     }
-    if valid_from is not None:
-        parsed_from = ''
-        try:
-            parsed_from = dateutil.parser.parse(valid_from).isoformat()
-        except:
-            print(f'Could not parse valid_from {valid_from} date, aborting')
-            return
-        finally:
-            new_ad['valid_from'] = parsed_from
-    if valid_until is not None:
-        parsed_until = ''
-        try:
-            parsed_until = dateutil.parser.parse(valid_until).isoformat()
-        except:
-            print(f'Could not parse valid_until {valid_until} date, aborting')
-            return
-        finally:
-            new_ad['valid_until'] = parsed_until
+    (from_date, until_date) = parse_valid_ranges(valid_from, valid_until)
+    if from_date is not None:
+        new_ad['valid_from'] = from_date
+    if until_date is not None:
+        new_ad['valid_until'] = until_date
     if are_you_sure('add ad: {}'.format(format_ad(new_ad)), cfg):
         events['ads'].append(new_ad)
         save_event_file(cfg, json.dumps(events))
@@ -112,24 +121,11 @@ def ads_edit(cfg: Config, ad_id: int, html: str, lang_filter: Sequence[str], val
                 'filter': lang_filter or ad['filter'],
                 'html': html or ad['html']
             }
-            if valid_from is not None:
-                parsed_from = ''
-                try:
-                    parsed_from = dateutil.parser.parse(valid_from).isoformat()
-                except:
-                    print(f'Could not parse valid_from {valid_from} date, aborting')
-                    break
-                finally:
-                    new_ad['valid_from'] = parsed_from
-            if valid_until is not None:
-                parsed_until = ''
-                try:
-                    parsed_until = dateutil.parser.parse(valid_until).isoformat()
-                except:
-                    print(f'Could not parse valid_until {valid_until} date, aborting')
-                    break
-                finally:
-                    new_ad['valid_until'] = parsed_until
+            (from_date, until_date) = parse_valid_ranges(valid_from, valid_until)
+            if from_date is not None:
+                new_ad['valid_from'] = from_date
+            if until_date is not None:
+                new_ad['valid_until'] = until_date
             print('\t{}\n<FROM\t{}\n>TO\t{}'.format(ADS_FORMAT.format('Event', 'Filter(s)', 'Valid date', 'HTML'),
                                                     format_ad(ad),
                                                     format_ad(new_ad)))

--- a/bin/lib/cli/ads.py
+++ b/bin/lib/cli/ads.py
@@ -1,5 +1,5 @@
 import json
-from typing import Sequence, Optional
+from typing import Sequence, Optional, Tuple
 
 import click
 import dateutil.parser
@@ -18,7 +18,7 @@ def format_ad(ad):
     return ADS_FORMAT.format(ad['id'], str(ad['filter']), f"{valid_from} - {valid_until}", ad['html'])
 
 
-def parse_valid_ranges(valid_from: Optional[str], valid_until: Optional[str]) -> (Optional[str], Optional[str]):
+def parse_valid_ranges(valid_from: Optional[str], valid_until: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
     from_date = None
     until_date = None
     if valid_from is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ jinja2
 mypy
 pylint
 pytest
+python-dateutil
 pyyaml
 requests
 types-python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pylint
 pytest
 pyyaml
 requests
+types-python-dateutil
 types-PyYAML
 types-pkg_resources
 types-requests


### PR DESCRIPTION
Lets you optionally specify both/either `--from` and `--until` dates for ads to be visible. This does not remove them automatically, but filters the ads clientside