### PR TITLE
Add native GCC 12.2.0

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -55,6 +55,7 @@ compilers:
           - 11.2.0
           - 11.3.0
           - 12.1.0
+          - 12.2.0
     cross:
       type: s3tarballs
       arch_prefix:


### PR DESCRIPTION
Add native GCC 12.2.0

refs https://github.com/compiler-explorer/compiler-explorer/issues/3973

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>