### PR TITLE
Add llvm-amdgpu compiler for C++

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -562,6 +562,14 @@ compilers:
           - 13.0.1
           - 14.0.0
           - 15.0.0
+    llvm-amdgpu:
+      - type: s3tarballs
+        check_exe: bin/clang++ --version
+        targets:
+          - rocm-4.5.2
+          - rocm-5.0.2
+          - rocm-5.1.3
+          - rocm-5.2.3
     ellccs:
       check_exe: bin/clang++ --version
       dir: ellcc-{name}
@@ -695,6 +703,7 @@ compilers:
           - patmat-trunk
           - p1061-trunk
           - reflection-trunk
+          - amd-stg-open
           - name: llvmflang-trunk
             check_exe: bin/flang
             after_stage_script:

--- a/remove_old_compilers.sh
+++ b/remove_old_compilers.sh
@@ -44,6 +44,7 @@ remove_older clang-embed
 remove_older clang-dang-main
 remove_older clang-widberg-main
 remove_older llvm-spirv
+remove_older llvm-amdgpu
 remove_older go
 remove_older tinycc
 remove_older cc65


### PR DESCRIPTION
This change adds the llvm-amdgpu compiler for building C++. The raison d'etre of llvm-amdgpu is really the HIP language (which has partial support right now under the CUDA category), but I'm pretty new to Compiler Explorer and the combination of adding a compiler and expanding support for a new language at the same time sounded a little intimidating. I figured I'd just start by adding the compiler to C++. While the primary purpose of llvm-amdgpu is for HIP language code, it's still fairly common for it to be used for vanilla C and C++.

I don't think I can test this change until the changes in the other repos are merged, so I'm just opening this one as a draft. Once I figure out how to test it, I'll check that I did this right!

Related:
https://github.com/compiler-explorer/compiler-workflows/pull/9
https://github.com/compiler-explorer/clang-builder/pull/40