### PR TITLE
Add Swift 5.7 RELEASE

### DIFF
--- a/bin/yaml/swift.yaml
+++ b/bin/yaml/swift.yaml
@@ -31,18 +31,19 @@ compilers:
           - '5.4'
           - '5.5'
           - '5.6'
+          - '5.7'
     # when the pre-release becomes a release, comment out the `5.x-nightly` section to allow reuse at a later time
-    5.7-nightly:
-      if: nightly
-      type: restQueryTarballs
-      install_always: true
-      url: https://swift.org/builds/swift-{name}-branch/ubuntu2004/latest-build.yml
-      query: |
-        'https://swift.org/builds/swift-{name}-branch/ubuntu2004/' \
-        + document['download'].replace('-ubuntu20.04.tar.gz', '') \
-        + '/' + document['download']
-      targets:
-        - '5.7'
+    #5.7-nightly:
+    #  if: nightly
+    #  type: restQueryTarballs
+    #  install_always: true
+    #  url: https://swift.org/builds/swift-{name}-branch/ubuntu2004/latest-build.yml
+    #  query: |
+    #    'https://swift.org/builds/swift-{name}-branch/ubuntu2004/' \
+    #    + document['download'].replace('-ubuntu20.04.tar.gz', '') \
+    #    + '/' + document['download']
+    #  targets:
+    #    - '5.7'
     nightly:
       if: nightly
       type: restQueryTarballs


### PR DESCRIPTION
Adds the final version of Swift 5.7 as a supported compiler and removes the 5.7 nightlies. Leaves the 5.7 nightly builder commented out for future use for new Swift versions.

The associated frontend PR is compiler-explorer/compiler-explorer#4063.