### PR TITLE
Add Kalray KVX compilers 4.8.0 and 4.9.0

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -409,6 +409,8 @@ compilers:
             - 4.3.0
             - 4.4.0
             - 4.6.0
+            - 4.8.0
+            - 4.9.0
         s390x:
           arch_prefix: "{subdir}-ibm-linux-gnu"
           check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"


### PR DESCRIPTION
Kalray has (finally ;)) tagged the previous releases 4.8 and 4.9

refs https://github.com/compiler-explorer/compiler-explorer/issues/4066