### PR TITLE
Updated OSACA version to 0.4.11

### DIFF
--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -16,7 +16,7 @@ tools:
   osaca:
     type: pip
     dir: osaca-{name}
-    python: /usr/bin/python3.8
+    python: /usr/bin/python3.10
     package: osaca=={name}
     check_exe: bin/osaca --version
     targets:

--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -20,7 +20,7 @@ tools:
     package: osaca=={name}
     check_exe: bin/osaca --version
     targets:
-      - 0.4.8
+      - 0.4.11
   rustfmt:
     type: tarballs
     dir: rustfmt-{name}


### PR DESCRIPTION
This version fixed several bugs compared to the last active one on CE (0.4.8) and introduced support for Intel Ice Lake Server (--arch icx) and AMD Zen 3 (--arch zen3).
Furthermore, I changed the used python version from 3.8 to 3.10.

See also the corresponding [PR #4095 in compiler-explorer/compiler-explorer](https://github.com/compiler-explorer/compiler-explorer/pull/4095).