### PR TITLE
Add ROCm HIP library

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -442,7 +442,7 @@ libraries:
       targets:
       - 0.12.2
       type: github
-    hip-runtime-amd:
+    hip-amd:
       check_file: include/hip/hip_runtime.h
       path_name: libs/rocm/{name}
       s3_path_prefix: hip-amd-rocm-{name}
@@ -1670,7 +1670,7 @@ libraries:
       targets:
       - 1.8.0
       type: github
-    hip-runtime-amd:
+    hip-amd:
       check_file: include/hip/hip_runtime.h
       path_name: libs/rocm/{name}
       s3_path_prefix: hip-amd-rocm-{name}

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -447,7 +447,7 @@ libraries:
       path_name: libs/rocm/{name}
       s3_path_prefix: hip-amd-rocm-{name}
       subdir: libs/rocm/{name}
-      untar_dir: opt/compiler-explorer/libs/rocm/{{name}}
+      untar_dir: hip-amd-rocm-{{name}}
       targets:
       - 4.5.2
       - 5.0.2
@@ -1675,7 +1675,7 @@ libraries:
       path_name: libs/rocm/{name}
       s3_path_prefix: hip-amd-rocm-{name}
       subdir: libs/rocm/{name}
-      untar_dir: opt/compiler-explorer/libs/rocm/{{name}}
+      untar_dir: hip-amd-rocm-{{name}}
       targets:
       - 4.5.2
       - 5.0.2

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1670,18 +1670,6 @@ libraries:
       targets:
       - 1.8.0
       type: github
-    hip-amd:
-      check_file: include/hip/hip_runtime.h
-      path_name: libs/rocm/{name}
-      s3_path_prefix: hip-amd-rocm-{name}
-      subdir: libs/rocm/{name}
-      untar_dir: hip-amd-rocm-{{name}}
-      targets:
-      - 4.5.2
-      - 5.0.2
-      - 5.1.3
-      - 5.2.3
-      type: s3tarballs
     nightly:
       cucollections:
         check_file: include/cuco/static_map.cuh

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1681,7 +1681,6 @@ libraries:
       - 5.0.2
       - 5.1.3
       - 5.2.3
-      install_always: true
       type: s3tarballs
     nightly:
       cucollections:

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -442,6 +442,18 @@ libraries:
       targets:
       - 0.12.2
       type: github
+    hip-runtime-amd:
+      check_file: include/hip/hip_runtime.h
+      path_name: libs/rocm/{name}
+      s3_path_prefix: hip-amd-rocm-{name}
+      subdir: libs/rocm/{name}
+      untar_dir: opt/compiler-explorer/libs/rocm/{{name}}
+      targets:
+      - 4.5.2
+      - 5.0.2
+      - 5.1.3
+      - 5.2.3
+      type: s3tarballs
     jsoncons:
       check_file: README.md
       repo: danielaparker/jsoncons
@@ -1658,6 +1670,19 @@ libraries:
       targets:
       - 1.8.0
       type: github
+    hip-runtime-amd:
+      check_file: include/hip/hip_runtime.h
+      path_name: libs/rocm/{name}
+      s3_path_prefix: hip-amd-rocm-{name}
+      subdir: libs/rocm/{name}
+      untar_dir: opt/compiler-explorer/libs/rocm/{{name}}
+      targets:
+      - 4.5.2
+      - 5.0.2
+      - 5.1.3
+      - 5.2.3
+      install_always: true
+      type: s3tarballs
     nightly:
       cucollections:
         check_file: include/cuco/static_map.cuh


### PR DESCRIPTION
This change adds the HIP runtime for the AMD GPU platform (ROCm) to the library install list.

I had to specify the untar directory to make this work, but it doesn't seem like other libraries needed to do that so I wonder if perhaps I screwed up the tar command in https://github.com/compiler-explorer/misc-builder/pull/47.

~I marked `install_always: true` for the hip-runtime-amd in the CUDA section, as this library is necessary to properly build anything with HIP for AMDGPUs. I figured that if the HIP compilers are used in the CUDA section, then to ensure they work when the language is set to CUDA, the runtime library should always be installed when the language is CUDA. However,~ my understanding of the overall Compiler Explorer system is very shallow and it's possible that I'm approaching this in a suboptimal way.