### PR TITLE
Change SH compilers

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -419,12 +419,11 @@ compilers:
             - 12.1.0
             - 12.2.0
         sh:
-          arch_prefix: "sh-multilib-linux-gnu"
+          arch_prefix: "sh-unknown-elf"
           check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
           subdir: sh
           targets:
-            - name: 4.9.4
-              arch_prefix: "sh-unknown-elf"
+            - 4.9.4
             - 9.5.0
             - 12.2.0
         powerpc:


### PR DESCRIPTION
SH GCC 9.5 and 12.2 were linux-* and not supporting sh2. We decided to change these compilers to elf-* with sh2 support.

This also causes the removal of fortran as it's not available for elf targets. 

refs https://github.com/compiler-explorer/compiler-explorer/issues/94

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>