### PR TITLE
Add Loongarch64 config

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -426,6 +426,12 @@ compilers:
             - 4.9.4
             - 9.5.0
             - 12.2.0
+        loongarch64:
+          arch_prefix: "{subdir}-unknown-linux-gnu"
+          check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          subdir: loongarch64
+          targets:
+            - 12.2.0
         powerpc:
           arch_prefix: "{subdir}-unknown-linux-gnu"
           check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"


### PR DESCRIPTION
Add 1 compiler for the Loongarch64 that has been introduced in GCC 12:
 https://gcc.gnu.org/gcc-12/changes.html

refs https://github.com/compiler-explorer/compiler-explorer/issues/4162

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>