### PR TITLE
Add stdexec C++ library

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1285,6 +1285,13 @@ libraries:
         targets:
         - trunk
         type: github
+      stdexec:
+        check_file: include/stdexec/execution.hpp
+        method: nightlyclone
+        repo: NVIDIA/stdexec
+        targets:
+        - trunk
+        type: github
       taojson:
         build_type: none
         check_file: include/tao/json.hpp


### PR DESCRIPTION
Adds [`std::exec`](https://github.com/NVIDIA/stdexec/) as a C++ library.

Related PR: https://github.com/compiler-explorer/compiler-explorer/pull/4201