### PR TITLE
Add ROCm 5.3.2

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -599,7 +599,7 @@ compilers:
           - 5.0.2
           - 5.1.3
           - 5.2.3
-          - 5.3.1
+          - 5.3.2
     ellccs:
       check_exe: bin/clang++ --version
       dir: ellcc-{name}

--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -599,6 +599,7 @@ compilers:
           - 5.0.2
           - 5.1.3
           - 5.2.3
+          - 5.3.1
     ellccs:
       check_exe: bin/clang++ --version
       dir: ellcc-{name}

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -467,6 +467,7 @@ libraries:
       - 5.0.2
       - 5.1.3
       - 5.2.3
+      - 5.3.1
       type: s3tarballs
       untar_dir: hip-amd-rocm-{{name}}
     jsoncons:

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -467,7 +467,7 @@ libraries:
       - 5.0.2
       - 5.1.3
       - 5.2.3
-      - 5.3.1
+      - 5.3.2
       type: s3tarballs
       untar_dir: hip-amd-rocm-{{name}}
     jsoncons:


### PR DESCRIPTION
This change adds ROCm 5.3.2 for C++ and HIP. It depends on:
- https://github.com/compiler-explorer/misc-builder/pull/49