### PR TITLE
Add c6x config

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -434,6 +434,12 @@ compilers:
             - 4.9.4
             - 9.5.0
             - 12.2.0
+        c6x:
+          arch_prefix: "tic6x-elf"
+          check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          subdir: c6x
+          targets:
+            - 12.2.0
         loongarch64:
           arch_prefix: "{subdir}-unknown-linux-gnu"
           check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"


### PR DESCRIPTION
Add new TI C6x config for C and C++ (c6x-elf).

refs https://github.com/compiler-explorer/compiler-explorer/issues/1806

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>