### PR TITLE
Add Python 3.11 to the testing

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -10,6 +10,7 @@ jobs:
         python-version:
           - 3.9
           - '3.10'
+          - 3.11
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Python 3.11 is between 10-60% faster than Python 3.10. On average, we measured a 1.25x speedup on the standard benchmark suite.

https://docs.python.org/3/whatsnew/3.11.html