### PR TITLE
Add sparc, sparc64 and sparc-leon compilers

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -440,6 +440,24 @@ compilers:
           subdir: c6x
           targets:
             - 12.2.0
+        sparc:
+          arch_prefix: "sparc-unknown-linux-gnu"
+          check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          subdir: sparc
+          targets:
+            - 12.2.0
+        sparc64:
+          arch_prefix: "sparc64-multilib-linux-gnu"
+          check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          subdir: sparc64
+          targets:
+            - 12.2.0
+        sparc-leon:
+          arch_prefix: "sparc-leon-linux-uclibc"
+          check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          subdir: sparc-leon
+          targets:
+            - 12.2.0
         loongarch64:
           arch_prefix: "{subdir}-unknown-linux-gnu"
           check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"


### PR DESCRIPTION
3 new gcc cross compilers for sparc, sparc64 and sparc-leon.

refs https://github.com/compiler-explorer/compiler-explorer/issues/266

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>