### PR TITLE
Add new version of Kalray's KVX compiler

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -418,6 +418,7 @@ compilers:
             - 4.6.0
             - 4.8.0
             - 4.9.0
+            - 4.10.0
         s390x:
           arch_prefix: "{subdir}-ibm-linux-gnu"
           check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"


### PR DESCRIPTION
Add latest 4.10.0 compiler.

refs https://github.com/compiler-explorer/compiler-explorer/issues/4280

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>