### PR TITLE
Add llvm-mos trunk.

### DIFF
--- a/bin/yaml/c.yaml
+++ b/bin/yaml/c.yaml
@@ -28,6 +28,15 @@ compilers:
         - "2.17"
         - "2.18"
         - "2.19"
+    llvmmos:
+      type: tarballs
+      compression: xz
+      dir: llvm-mos-{name}
+      check_exe: bin/clang --version
+      url: https://github.com/llvm-mos/llvm-mos-sdk/releases/latest/download/llvm-mos-linux.tar.xz
+      untar_dir: llvm-mos
+      targets:
+        - trunk
     gcc:
       type: s3tarballs
       check_exe: bin/gcc -v

--- a/bin/yaml/c.yaml
+++ b/bin/yaml/c.yaml
@@ -29,7 +29,8 @@ compilers:
         - "2.18"
         - "2.19"
     llvmmos:
-      type: tarballs
+      if: nightly
+      type: nightlytarballs
       compression: xz
       dir: llvm-mos-{name}
       check_exe: bin/clang --version


### PR DESCRIPTION
This fetches the llvm-mos 6502 toolchain and SDK.

See http://llvm-mos.org and https://github.com/llvm-mos/llvm-mos-sdk for details.