### PR TITLE
Makefile: Add Python 3.11

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -1,6 +1,10 @@
 name: Python tests
 
-on: [ push ]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   build:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ export POETRY_HOME=$(CURDIR)/.poetry
 POETRY:=$(POETRY_HOME)/bin/poetry
 POETRY_VENVS=$(POETRY_HOME)/virtualenvs
 POETRY_DEPS:=$(POETRY_VENVS)/.deps
-SYS_PYTHON:=$(shell env PATH='/bin:/usr/bin:/usr/local/bin:$(PATH)' bash -c "command -v python3.10 || command -v python3.9 || echo .python-not-found")
+SYS_PYTHON:=$(shell env PATH='/bin:/usr/bin:/usr/local/bin:$(PATH)' bash -c "command -v python3.11 || command -v python3.10 || command -v python3.9 || echo .python-not-found")
 export PYTHONPATH=$(CURDIR)/bin
 
 .PHONY: help

--- a/bin/lib/releases.py
+++ b/bin/lib/releases.py
@@ -13,7 +13,7 @@ class Hash:
 
 
 class VersionSource(Enum):
-    value: Tuple[int, str]
+    value: Tuple[int, str]  # type: ignore[assignment]
     TRAVIS = (0, "tr")
     GITHUB = (1, "gh")
 


### PR DESCRIPTION
https://docs.python.org/3.11/whatsnew/3.11.html
> Python 3.11 is between 10-60% faster than Python 3.10. On average, we measured a 1.25x speedup on the standard benchmark suite.