### PR TITLE
add trunk in dotnet

### DIFF
--- a/bin/yaml/dotnet.yaml
+++ b/bin/yaml/dotnet.yaml
@@ -5,7 +5,9 @@ compilers:
     untar_dir: Core_Root
     check_exe: .dotnet/dotnet --version
     targets:
-      - trunk
+      - name: trunk
+        if: nightly
+        always_install: true
       - v7.0.0
       - name: v6.0.11
         check_env:

--- a/bin/yaml/dotnet.yaml
+++ b/bin/yaml/dotnet.yaml
@@ -5,7 +5,8 @@ compilers:
     untar_dir: Core_Root
     check_exe: .dotnet/dotnet --version
     targets:
+      - trunk
+      - v7.0.0
       - name: v6.0.11
         check_env:
           - DOTNET_CLI_HOME=/tmp
-      - v7.0.0


### PR DESCRIPTION
it's already handled here: https://github.com/compiler-explorer/misc-builder/blob/3721571a5fcb45f3d6caf167f25832203b8ab5f9/build/build-dotnet.sh#L6

just need to enable it in properties after this is merged

also it's `trunk`, `v7` then `v6` in that order (same as gcc/clang)