### PR TITLE
add: gcc bpf cross compiler

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -278,6 +278,17 @@ compilers:
             path_name_prefix: gcc-trunk
             targets:
               - trunk
+        bpf:
+          arch_prefix: "{subdir}-unknown"
+          check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          subdir: bpf
+          nightly:
+            if: nightly
+            type: nightly
+            compiler_name: bpf-gcc-trunk
+            path_name_prefix: gcc-trunk
+            targets:
+              - trunk
         mips:
           - arch_prefix: "{subdir}-unknown-linux-gnu"
             check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"


### PR DESCRIPTION
Add GCC for C and C++, for BPF target.

refs https://github.com/compiler-explorer/compiler-explorer/issues/4408

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>