### PR TITLE
Add dart 2.18 and dart dev version

### DIFF
--- a/bin/yaml/dart.yaml
+++ b/bin/yaml/dart.yaml
@@ -9,6 +9,7 @@ compilers:
       - find -executable -print0 | xargs -0 chmod og+x
     url: https://storage.googleapis.com/dart-archive/channels/stable/release/{name}/sdk/dartsdk-linux-x64-release.zip
     targets:
+      - 2.18.5
       - 2.17.1
       - 2.16.1
       - 2.15.1

--- a/bin/yaml/dart.yaml
+++ b/bin/yaml/dart.yaml
@@ -20,3 +20,8 @@ compilers:
       - 2.10.5
       - 2.9.3
       - 2.8.4
+    nightly:
+      if: nightly
+      url: https://storage.googleapis.com/dart-archive/channels/{name}/release/latest/sdk/dartsdk-linux-x64-release.zip
+      targets:
+        - dev

--- a/bin/yaml/dart.yaml
+++ b/bin/yaml/dart.yaml
@@ -22,6 +22,7 @@ compilers:
       - 2.8.4
     nightly:
       if: nightly
+      install_always: true
       url: https://storage.googleapis.com/dart-archive/channels/{name}/release/latest/sdk/dartsdk-linux-x64-release.zip
       targets:
         - dev


### PR DESCRIPTION
Adds dart version 2.18.5 (I think it makes sense not to include all patch versions) and the latest dev channel build (currently version 3.0). I think if I declare it this way it should always automatically use the latest version, right?