### PR TITLE
Install the Texas Instruments toolchain for MSP430

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -681,6 +681,18 @@ compilers:
       check_exe: bin/tcc -v
       targets:
         - 0.9.27
+    cl430:
+      type: script
+      dir: "ti-cgt-msp430_{name}"
+      check_exe: bin/cl430 -version
+      targets:
+        - name: 21.6.1.LTS
+          fetch:
+            - https://dr-download.ti.com/software-development/ide-configuration-compiler-or-debugger/MD-p4jWEYpR8n/21.6.1.LTS/ti_cgt_msp430_21.6.1.LTS_linux-x64_installer.bin installer.bin
+          script: |
+            chmod +x installer.bin
+            ./installer.bin --unattendedmodeui none --mode unattended --installdir .
+            rm installer.bin
     intel-cpp:
       type: script
       dir: "intel-cpp-{name}"


### PR DESCRIPTION
See https://github.com/compiler-explorer/compiler-explorer/issues/4480

This downloads and runs the installer provided by Texas Instruments on their website: https://www.ti.com/tool/MSP-CGT

Tested by running `bin/ce_install install cl430`. Output:

```
2022-12-22 16:04:10,528 lib.installation_context INFO     Making uncached requests
2022-12-22 16:04:10,529 lib.ce_install  INFO     Creating multiprocessing pool with 8 workers
2022-12-22 16:04:12,244 compilers/dotnet trunk INFO     Most recent dotnet-trunk is 20221222
Installing compilers/c++/cl430 21.6.1.LTS
2022-12-22 16:04:14,182 lib.installation_context INFO     Fetching https://dr-download.ti.com/software-development/ide-configuration-compiler-or-debugger/MD-p4jWEYpR8n/21.6.1.LTS/ti_cgt_msp430_21.6.1.LTS_linux-x64_installer.bin (26384268 bytes)
2022-12-22 16:04:16,408 lib.installation_context INFO     100% of https://dr-download.ti.com/software-development/ide-configuration-compiler-or-debugger/MD-p4jWEYpR8n/21.6.1.LTS/ti_cgt_msp430_21.6.1.LTS_linux-x64_installer.bin
2022-12-22 16:04:16,410 compilers/c++/cl430 21.6.1.LTS INFO     https://dr-download.ti.com/software-development/ide-configuration-compiler-or-debugger/MD-p4jWEYpR8n/21.6.1.LTS/ti_cgt_msp430_21.6.1.LTS_linux-x64_installer.bin -> installer.bin
2022-12-22 16:04:16,410 lib.installation_context INFO     Staging with bash -c 'chmod +x installer.bin
./installer.bin --unattendedmodeui none --mode unattended --installdir .
rm installer.bin'
2022-12-22 16:04:19,847 lib.installation_context INFO     Moving from staging (/opt/compiler-explorer/staging/0889dc08-2ff9-4a7b-a691-489861a29401/ti-cgt-msp430_21.6.1.LTS) to final destination (/opt/compiler-explorer/ti-cgt-msp430_21.6.1.LTS)
2022-12-22 16:04:19,866 lib.ce_install  INFO     compilers/c++/cl430 21.6.1.LTS installed OK
1 packages installed OK, 0 skipped, and 0 failed installation
```

As far as I can tell, all the installer does is to unpack some compressed files embedded into the .bin file. The downloaded file is 26 MB compressed and expands to 188 MB.