### PR TITLE
fix: use Kalray's ACB 4.11.1

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -430,7 +430,8 @@ compilers:
             - 4.8.0
             - 4.9.0
             - 4.10.0
-            - 4.11.0
+            - name: 4.11.1
+              url: https://github.com/kalray/build-scripts/releases/download/v{name}/gcc-kalray-kvx-ubuntu-20.04-v{name}.tar.gz
         s390x:
           arch_prefix: "{subdir}-ibm-linux-gnu"
           check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"


### PR DESCRIPTION
4.11.0 as published on github is not compatible with ubuntu 18.04. Use their new release build for 20.04 instead of one for 22.04.

refs https://github.com/compiler-explorer/compiler-explorer/issues/4523

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>