### PR TITLE
move iwyu install to tools.yaml

### DIFF
--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -107,3 +107,22 @@ tools:
     check_exe: bin/pahole
     targets:
       - trunk
+  iwyu:
+    type: tarballs
+    url: https://include-what-you-use.org/downloads/include-what-you-use-0.12.src.tar.gz
+    compression: gz
+    check_exe: bin/include-what-you-use --version
+    dir: iwyu/{{name}}
+    depends:
+    - tools/cmake 3.24.3
+    - compilers/c++/clang 8.0.0
+    untar_dir: include-what-you-use
+    targets:
+    - name: "0.12"
+      after_stage_script:
+      - mv include-what-you-use iwyu-source
+      - mkdir build && cd build
+      - /opt/compiler-explorer/cmake/bin/cmake ../iwyu-source -DCMAKE_PREFIX_PATH=/opt/compiler-explorer/clang-8.0.0 -DCMAKE_INSTALL_PREFIX=../include-what-you-use
+      - /opt/compiler-explorer/cmake/bin/cmake --build . --target install
+      - cd ..
+      - ln -s /opt/compiler-explorer/clang-8.0.0/lib include-what-you-use/lib

--- a/update_compilers/install_binaries.sh
+++ b/update_compilers/install_binaries.sh
@@ -28,22 +28,3 @@ if [[ ! -f ${OPT}/x86-to-6502/lefticus/x86-to-6502 ]]; then
 fi
 
 # x86-to-6502 new version (6502-c++) is built by misc-builder
-
-#########################
-# iwyu - include-what-you-use
-
-if [[ ! -d ${OPT}/iwyu/0.12 ]]; then
-    mkdir -p /tmp/build
-    pushd /tmp/build
-
-    curl https://include-what-you-use.org/downloads/include-what-you-use-0.12.src.tar.gz | tar xzf -
-    cd include-what-you-use/
-    mkdir build
-    cd build
-    "${OPT}/cmake/bin/cmake" .. -DCMAKE_PREFIX_PATH="${OPT}/clang-8.0.0/" -DCMAKE_INSTALL_PREFIX="${OPT}/iwyu/0.12"
-    "${OPT}/cmake/bin/cmake" --build . --target install
-    ln -s "${OPT}/clang-8.0.0/lib" "${OPT}/iwyu/0.12/lib"
-
-    popd
-    rm -rf /tmp/build
-fi


### PR DESCRIPTION
(also tried to add iwyu 0.19, but I couldn't get it to compile properly llvm errors even though it seemed to use the right version (clang-15 for iwyu 0.19))

Tried to use `DEP0` for the dependencies, but I think those are only available for `check_env` and not for the staging script
