### PR TITLE
Add Qt (Core only)

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1537,12 +1537,13 @@ libraries:
       - -DFEATURE_rpath=ON
       - -DFEATURE_relocatable=ON
       lib_type: shared
+      make_targets:
+      - Core
       targets:
       - name: 6.4.2
         url: https://download.qt.io/official_releases/qt/6.4/6.4.2/submodules/qtbase-everywhere-src-6.4.2.tar.xz
       type: tarballs
       untar_dir: qtbase-everywhere-src-{{name}}
-      use_compiler: clang1500
     raberu:
       check_file: README.md
       repo: jfalcou/raberu

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1525,6 +1525,24 @@ libraries:
       targets:
       - 1.11.4
       type: github
+    qt:
+      build_type: cmake
+      check_file: CMakeLists.txt
+      compression: xz
+      dir: libs/qt/{name}
+      extra_cmake_arg:
+      - -DBUILD_EXAMPLES=OFF
+      - -DQT_BUILD_EXAMPLES_BY_DEFAULT=OFF
+      - -DQT_BUILD_TESTS_BY_DEFAULT=OFF
+      - -DFEATURE_rpath=ON
+      - -DFEATURE_relocatable=ON
+      lib_type: shared
+      targets:
+      - name: 6.4.2
+        url: https://download.qt.io/official_releases/qt/6.4/6.4.2/submodules/qtbase-everywhere-src-6.4.2.tar.xz
+      type: tarballs
+      untar_dir: qtbase-everywhere-src-{{name}}
+      use_compiler: clang1500
     raberu:
       check_file: README.md
       repo: jfalcou/raberu


### PR DESCRIPTION
:wave: 

Hey @mattgodbolt,

This PR proposes adding Qt to Compiler Explorer. I've only set up the qt6-base library, as CE can run command line executables, and in particular I'm interested in disassembling Qt container code.

Please note that I've not been able to test if this works, as the `ce_install build` command is hardcoded to fetch the compilers list from GitHub, and thus doesn't accept the system compilers as defined in `c++.default.properties`.

Additionally, I've hardcoded a single, fast compiler to ensure it doesn't become a performance hog in deployment.