### PR TITLE
add cereal to libraries list

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -138,6 +138,18 @@ libraries:
       targets:
       - '2.3'
       type: github
+    cereal:
+      check_file: README.md
+      repo: USCiLab/cereal
+      target_prefix: v
+      targets:
+      - 1.3.2
+      - 1.3.1
+      - 1.3.0
+      - 1.2.2
+      - 1.2.1
+      - 1.2.0
+      type: github
     cli11:
       build_type: none
       check_file: include/CLI/CLI.hpp


### PR DESCRIPTION
This PR is related to [PR](https://github.com/compiler-explorer/compiler-explorer/pull/4782) made on compiler-explorer repo,  adds cereal library to the list of libraries.