### PR TITLE
check txz/zip counterparts also with in-use as with deletion

### DIFF
--- a/bin/lib/amazon.py
+++ b/bin/lib/amazon.py
@@ -94,9 +94,9 @@ def get_autoscaling_groups_for(cfg: Config) -> List[dict]:
 
 def s3_file_exists(key: str) -> bool:
     try:
-        s3_client.get_object(Bucket="compiler-explorer", Key=key)
+        s3_client.head_object(Bucket="compiler-explorer", Key=key)
         return True
-    except s3_client.exceptions.NoSuchKey:
+    except:
         return False
 
 

--- a/bin/lib/amazon.py
+++ b/bin/lib/amazon.py
@@ -96,7 +96,7 @@ def s3_file_exists(key: str) -> bool:
     try:
         s3_client.head_object(Bucket="compiler-explorer", Key=key)
         return True
-    except:
+    except s3_client.exceptions.ClientError:
         return False
 
 

--- a/bin/lib/cli/builds.py
+++ b/bin/lib/cli/builds.py
@@ -171,11 +171,12 @@ def builds_rm_old(dry_run: bool, max_age: int):
     for release in get_all_releases():
         max_builds[release.version.source] = max(release.version.number, max_builds[release.version.source])
     for release in get_all_releases():
-        if (release.key in current) or (get_key_counterpart(release.key) in current):
+        counterpart = get_key_counterpart(release.key)
+        if release.key in current or counterpart in current:
             print(f"Skipping {release} as it is a current version")
             if dry_run:
-                if get_key_counterpart(release.key) in current:
-                    print(f"Skipping because of counterpart {get_key_counterpart(release.key)}")
+                if counterpart in current:
+                    print(f"Skipping because of counterpart {counterpart}")
         else:
             age = max_builds[release.version.source] - release.version.number
             if age > max_age:

--- a/bin/lib/cli/builds.py
+++ b/bin/lib/cli/builds.py
@@ -17,6 +17,7 @@ from lib.amazon import (
     find_latest_release,
     find_release,
     get_all_releases,
+    get_key_counterpart,
     log_new_build,
     set_current_key,
     get_ssm_param,
@@ -170,8 +171,11 @@ def builds_rm_old(dry_run: bool, max_age: int):
     for release in get_all_releases():
         max_builds[release.version.source] = max(release.version.number, max_builds[release.version.source])
     for release in get_all_releases():
-        if release.key in current:
+        if (release.key in current) or (get_key_counterpart(release.key) in current):
             print(f"Skipping {release} as it is a current version")
+            if dry_run:
+                if get_key_counterpart(release.key) in current:
+                    print(f"Skipping because of counterpart {get_key_counterpart(release.key)}")
         else:
             age = max_builds[release.version.source] - release.version.number
             if age > max_age:


### PR DESCRIPTION
* checks during `builds_rm_old()` if a version has a windows/linux counterpart in-use (the list of releases lists .zip and .txz separately even if they are the same gh-versionnumber, so it might think something is not in use while it really is)
* if sure to remove, in `remove_release()` also remove the .zip files if they are there

Had to rewrite the delete magic in https://github.com/compiler-explorer/infra/compare/fix-old-build-deletions?expand=1#diff-98b39f6ed2a45cf3cd6cddfb72637ddf89584cf5af3dc21eba56d47c3ade26d4R126 - I think it's correct, but could use another eye on it