### PR TITLE
Simdjson

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1600,20 +1600,19 @@ libraries:
       - 3.2.0
       type: github
     simdjson:
-      build_type: none
+      build_type: cmake
+      make_targets:
+      - simdjson
+      lib_type: static
+      staticliblink:
+      - simdjson
       repo: simdjson/simdjson
-      type: script
-      dir: libs/simdjson/{name}
-      check_file: simdjson.h
+      type: github
+      check_file: include/simdjson.h
+      target_prefix: v
       targets:
       - 3.0.1
       - 3.1.5
-      fetch:
-      - https://github.com/simdjson/simdjson/releases/download/v{name}/simdjson.cpp simdjson.cpp
-      - https://github.com/simdjson/simdjson/releases/download/v{name}/simdjson.h simdjson.h
-      script: |
-        mkdir -p {dir}
-        mv simdjson.* "{dir}"
     sol2:
       build_type: none
       check_file: include/sol/sol.hpp

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1599,6 +1599,21 @@ libraries:
       targets:
       - 3.2.0
       type: github
+    simdjson:
+      build_type: none
+      repo: simdjson/simdjson
+      type: script
+      dir: libs/simdjson/{name}
+      check_file: simdjson.h
+      targets:
+      - 3.0.1
+      - 3.1.5
+      fetch:
+      - https://github.com/simdjson/simdjson/releases/download/v{name}/simdjson.cpp simdjson.cpp
+      - https://github.com/simdjson/simdjson/releases/download/v{name}/simdjson.h simdjson.h
+      script: |
+        mkdir -p {dir}
+        mv simdjson.* "{dir}"
     sol2:
       build_type: none
       check_file: include/sol/sol.hpp


### PR DESCRIPTION
Builds a static library instead of what was suggested in https://github.com/compiler-explorer/compiler-explorer/issues/4508

The "amalgamation" consists of both a .cpp and a .h file, now you could just support it by doing
```
#include "simdjson.h"
#include "simdjson.cpp"
```

But since that is undocumented, I wouldn't really like that. Nor the idea of the user having to enter "simdjson.cpp" as a compiler argument.

But it's still possible already using URL inclusion if a user still wants that and/or IDE mode.
