### PR TITLE
LLVM 16

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -645,6 +645,7 @@ compilers:
           - 13.0.1
           - 14.0.0
           - 15.0.0
+          - 16.0.0
     clang-rocm:
       - type: s3tarballs
         dir:

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -669,6 +669,7 @@ libraries:
       - 13.0.1
       - 14.0.0
       - 15.0.0
+      - 16.0.0
       type: s3tarballs
     magic_enum:
       check_file: include/magic_enum.hpp


### PR DESCRIPTION
CE: https://github.com/compiler-explorer/compiler-explorer/pull/4887.

The [`llvmorg-16.0.0`](https://github.com/llvm/llvm-project/releases/tag/llvmorg-16.0.0) tag has just been published, but it hasn't been announced yet. Edit: [announced](https://discourse.llvm.org/t/llvm-16-0-0-release/69326).