### PR TITLE
updated OSACA to version 0.5.0

### DIFF
--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -38,11 +38,11 @@ tools:
   osaca:
     type: pip
     dir: osaca-{name}
-    python: /usr/bin/python3.10
+    python: /usr/bin/python3.8
     package: osaca=={name}
     check_exe: bin/osaca --version
     targets:
-      - 0.4.12
+      - 0.5.0
   rustfmt:
     type: tarballs
     dir: rustfmt-{name}


### PR DESCRIPTION
Updated OSACA to version 0.5.0 with more supported uarchs and functionalities.
I also downgraded the python version back to 3.8 to overcome unsolved issues from https://github.com/compiler-explorer/compiler-explorer/pull/4095