### PR TITLE
Adds a new release for xtensa compiler

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -525,12 +525,14 @@ compilers:
             - name: 10.4.0
         xtensa:
           subdir: xtensa
-          url: https://github.com/espressif/crosstool-NG/releases/download/esp-{name}/{arch_prefix}-gcc{base}-esp-{name}-linux-amd64.tar.{compression}
+          url: https://github.com/espressif/crosstool-NG/releases/download/esp-{name}/{arch_prefix}-{release_name}-{host_type}.tar.{compression}
           untar_dir: "{arch_prefix}"
-          dir: "xtensa/{arch_prefix}-gcc{base}-esp-{name}"
+          dir: "xtensa/{arch_prefix}-{release_name}"
           check_exe: "bin/{arch_prefix}-g++ --version"
           type: tarballs
           compression: gz
+          host_type: linux-amd64
+          release_name: "gcc{base}-esp-{name}"
           esp32:
             arch_prefix: xtensa-esp32-elf
             targets:
@@ -548,6 +550,11 @@ compilers:
                 base: "8_4_0"
               - name: 2022r1
                 base: "11_2_0"
+                compression: xz
+              - name: 12.2.0_20230208
+                base: "12.2.0_20230208"
+                host_type: x86_64-linux-gnu
+                release_name: "{base}"
                 compression: xz
           esp32s2:
             arch_prefix: xtensa-esp32s2-elf
@@ -567,6 +574,11 @@ compilers:
               - name: 2022r1
                 base: "11_2_0"
                 compression: xz
+              - name: 12.2.0_20230208
+                base: "12.2.0_20230208"
+                host_type: x86_64-linux-gnu
+                release_name: "{base}"
+                compression: xz
           esp32s3:
             arch_prefix: xtensa-esp32s3-elf
             targets:
@@ -578,6 +590,11 @@ compilers:
                 base: "8_4_0"
               - name: 2022r1
                 base: "11_2_0"
+                compression: xz
+              - name: 12.2.0_20230208
+                base: "12.2.0_20230208"
+                host_type: x86_64-linux-gnu
+                release_name: "{base}"
                 compression: xz
     clang:
       - type: tarballs


### PR DESCRIPTION
Update the yaml with the latest release. 

Had to do some tweaks in the configuration due to a URL format change. 