### PR TITLE
Add riscv32 and riscv64 nightly compilers

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -396,6 +396,13 @@ compilers:
             - 11.3.0
             - 12.1.0
             - 12.2.0
+          nightly:
+            if: nightly
+            type: nightly
+            compiler_name: riscv64-gcc-trunk
+            path_name_prefix: gcc-trunk
+            targets:
+              - trunk
         riscv32:
           arch_prefix: "riscv32-unknown-elf"
           check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
@@ -411,6 +418,14 @@ compilers:
             - 12.1.0
             - name: 12.2.0
               arch_prefix: "riscv32-unknown-linux-gnu"
+          nightly:
+            if: nightly
+            type: nightly
+            compiler_name: riscv32-gcc-trunk
+            arch_prefix: "riscv32-unknown-linux-gnu"
+            path_name_prefix: gcc-trunk
+            targets:
+              - trunk
         k1:
           arch_prefix: "k1-unknown-elf"
           check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"


### PR DESCRIPTION
refs https://github.com/compiler-explorer/compiler-explorer/issues/4900

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>