### PR TITLE
Add think-cell-library

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1379,6 +1379,14 @@ libraries:
         targets:
         - trunk
         type: github
+      thinkcell:
+        build_type: none
+        check_file: README.md
+        method: nightlyclone
+        repo: think-cell/think-cell-library
+        targets:
+        - trunk
+        type: github
       toml11:
         build_type: none
         check_file: toml.hpp


### PR DESCRIPTION
It's a header-only library that serves as an extension/complement to the C++ standard library. I'm giving a talk about it at C++Now in two weeks, so it would be great to have it on compiler explorer.