### PR TITLE
Fix sparc-leon 12.2.0

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -494,7 +494,7 @@ compilers:
           check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
           subdir: sparc-leon
           targets:
-            - 12.2.0
+            - 12.2.0-1
         loongarch64:
           arch_prefix: "{subdir}-unknown-linux-gnu"
           check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"


### PR DESCRIPTION
The compiler was incorrectly built using gcc's master branch instead of 12.2.0 release tarball. Rebuilding it on correct version and using name 12.2.0-1 to avoid overwriting previous one.

refs https://github.com/compiler-explorer/compiler-explorer/issues/4994