### PR TITLE
Add missing gcc 12.1.0 msp430

### DIFF
--- a/bin/yaml/c.yaml
+++ b/bin/yaml/c.yaml
@@ -132,4 +132,5 @@ compilers:
           subdir: msp430
           check_exe: "{arch_prefix}/bin/{arch_prefix}-gcc --version"
           targets:
+            - 12.1.0
             - 12.2.0


### PR DESCRIPTION
Was listed in config, but not installed.

refs https://github.com/compiler-explorer/compiler-explorer/issues/5004

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>