### PR TITLE
Add GCC 13.1.0 for BPF

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -294,6 +294,8 @@ compilers:
           arch_prefix: "bpf-unknown-none"
           check_exe: "{arch_prefix}/bin/bpf-unknown-g++ --version"
           subdir: bpf
+          targets:
+            - 13.1.0
           nightly:
             if: nightly
             type: nightly


### PR DESCRIPTION
refs https://github.com/compiler-explorer/compiler-explorer/issues/4987

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>