### PR TITLE
Update FRC 2023 compiler

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -197,7 +197,7 @@ compilers:
               url: https://github.com/wpilibsuite/opensdk/releases/download/v{year}-{build}/cortexa9_vfpv3-roborio-academic-{year}-x86_64-linux-gnu-Toolchain-{name}.tgz
               targets:
                 - year: 2023
-                  build: 4
+                  build: 9
                   name: 12.1.0
               older:
                 check_exe: roborio/bin/arm-frc{year}-linux-gnueabi-g++ --version


### PR DESCRIPTION
This version is built on Ubuntu 20.04 so uses an older glibc.

This works around the glibc issue identified in compiler-explorer/compiler-explorer#4568.