### PR TITLE
Install `kokkos` library headers correctly

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -532,10 +532,9 @@ libraries:
       type: github
     kokkos:
       build_type: cmake
-      extra_cmake_arg:
-      - -DCMAKE_INSTALL_PREFIX="."
       make_targets:
-      - install
+      - all
+      package_install: True
       repo: kokkos/kokkos
       targets:
       - 4.0.01

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -536,6 +536,10 @@ libraries:
       - all
       package_install: True
       repo: kokkos/kokkos
+      staticliblink:
+      - kokkoscore
+      - kokkoscontainers
+      - kokkossimd
       targets:
       - 4.0.01
       type: github

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -532,8 +532,10 @@ libraries:
       type: github
     kokkos:
       build_type: cmake
+      extra_cmake_arg:
+      - -DCMAKE_INSTALL_PREFIX="."
       make_targets:
-      - all
+      - install
       repo: kokkos/kokkos
       targets:
       - 4.0.01


### PR DESCRIPTION
Follow-up to https://github.com/compiler-explorer/compiler-explorer/pull/5094.

First of all thanks for getting the previous PRs merged! :slightly_smiling_face: 
Turns out that there is still one key piece missing. Currently I'm getting following error at godbolt.org:
```
<source>:1:10: fatal error: Kokkos_Core.hpp: No such file or directory
```
This is because `kokkos` headers are only gathered together during installation.

This PR fixes the error above. Changes have been tested with:
```
bin/ce_install --dry-run --keep-staging --enable nightly build --buildfor g123 'kokkos'
```
and the `include` directory shows up inside `staging` alongside `*.a` libraries.