### PR TITLE
gtest versions

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -429,6 +429,10 @@ libraries:
       repo: google/googletest
       targets:
       - release-1.10.0
+      - release-1.11.0
+      - release-1.12.0
+      - release-1.12.1
+      - v1.13.0
       type: github
     gsl:
       check_file: README.md


### PR DESCRIPTION
I noticed there are a few gtest releases that aren't tracked on compiler-explorer. looking at https://github.com/google/googletest/tags and https://github.com/google/googletest/tags it seems like the tag format changed (release-M.mm.p → vM.mm.p) thus i was a bit guessing how to put them in here. :see_no_evil: 