### PR TITLE
Kotlin 1.9.0

### DIFF
--- a/bin/yaml/kotlin-native.yaml
+++ b/bin/yaml/kotlin-native.yaml
@@ -44,3 +44,5 @@ compilers:
         filename: kotlin-native-linux-x86_64-1.8.10
       - name: 1.8.20
         filename: kotlin-native-linux-x86_64-1.8.20
+      - name: 1.9.0
+        filename: kotlin-native-linux-x86_64-1.9.0

--- a/bin/yaml/kotlin.yaml
+++ b/bin/yaml/kotlin.yaml
@@ -49,3 +49,5 @@ compilers:
         url: https://github.com/JetBrains/kotlin/releases/download/v1.8.10/kotlin-compiler-1.8.10.zip
       - name: 1.8.20
         url: https://github.com/JetBrains/kotlin/releases/download/v1.8.20/kotlin-compiler-1.8.20.zip
+      - name: 1.9.0
+        url: https://github.com/JetBrains/kotlin/releases/download/v1.9.0/kotlin-compiler-1.9.0.zip


### PR DESCRIPTION
- Follow up #983.
- For https://github.com/compiler-explorer/compiler-explorer/pull/5280.

https://github.com/JetBrains/kotlin/releases/tag/v1.9.0