### PR TITLE
Changes made in cpp.yaml to install hexagon-clang++

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -820,6 +820,16 @@ compilers:
           - assertions-15.0.0
           - 16.0.0
           - assertions-16.0.0
+    clang-hexagon:
+      - type: tarballs
+        check_exe: x86_64-linux-gnu/bin/clang++ --version
+        dir: clang+llvm-16.0.5-cross-hexagon-unknown-linux-musl
+        url: https://codelinaro.jfrog.io/artifactory/codelinaro-toolchain-for-hexagon/v16.0.5/clang+llvm-16.0.5-cross-hexagon-unknown-linux-musl.tar.xz
+        compression: xz
+        strip: true
+        targets:
+          - name: 16.0.5
+            suffix: clang+llvm-16.0.5-cross-hexagon-unknown-linux-musl0
     clang-rocm:
       - type: s3tarballs
         dir:

--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -823,13 +823,12 @@ compilers:
     clang-hexagon:
       - type: tarballs
         check_exe: x86_64-linux-gnu/bin/clang++ --version
-        dir: clang+llvm-16.0.5-cross-hexagon-unknown-linux-musl
-        url: https://codelinaro.jfrog.io/artifactory/codelinaro-toolchain-for-hexagon/v16.0.5/clang+llvm-16.0.5-cross-hexagon-unknown-linux-musl.tar.xz
+        dir: clang+llvm-{name}-{suffix}
+        url: https://codelinaro.jfrog.io/artifactory/codelinaro-toolchain-for-hexagon/v{name}/clang+llvm-{name}-{suffix}.tar.xz
         compression: xz
-        strip: true
         targets:
           - name: 16.0.5
-            suffix: clang+llvm-16.0.5-cross-hexagon-unknown-linux-musl0
+            suffix: cross-hexagon-unknown-linux-musl
     clang-rocm:
       - type: s3tarballs
         dir:


### PR DESCRIPTION
Some changes have been made to cpp.yaml to allow hexagon-clang++ compiler to be installed.

Related to: compiler-explorer/compiler-explorer#5330