### PR TITLE
Add the github ureact library to the live site

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1866,6 +1866,13 @@ libraries:
       - '2.0'
       - '2.1'
       type: github
+    ureact:
+      check_file: include/ureact/version.hpp
+      repo: YarikTH/ureact
+      targets:
+      - main
+      - dev
+      type: github
     vcl:
       check_file: vectorclass.h
       repo: vectorclass/version2


### PR DESCRIPTION
Proposing to add the µReact library to the live site. https://github.com/YarikTH/ureact

Followed the steps as best as I could in https://github.com/compiler-explorer/compiler-explorer/blob/main/docs/AddingALibrary.md#adding-a-new-library-to-the-live-site

Feedback on improving the hooks and the organizations of files in the repository is welcome.

See also https://github.com/compiler-explorer/compiler-explorer/pull/5339