### PR TITLE
Build YOMM2 trunk only

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1516,12 +1516,10 @@ libraries:
         - trunk
         type: github
       yomm2:
-        build_type: cmake
-        lib_type: static
+        build_type: none
+        check_file: include/yorel/yomm2.hpp
         method: nightlyclone
         repo: jll63/yomm2
-        staticliblink:
-        - yomm2
         targets:
         - trunk
         type: github


### PR DESCRIPTION
Let's just take `xtl` as an example. There is no real need to have specific versions at this point. When I switch to 2.0, then yes.