### PR TITLE
updated OSACA to v0.5.2

### DIFF
--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -42,7 +42,7 @@ tools:
     package: osaca=={name}
     check_exe: bin/osaca --version
     targets:
-      - 0.5.0
+      - 0.5.2
   rustfmt:
     type: tarballs
     dir: rustfmt-{name}


### PR DESCRIPTION
Updated OSACA from v0.5.0 to v0.5.2.
See also [PR #5399 in compiler-explorer/compiler-explorer](https://github.com/compiler-explorer/compiler-explorer/pull/5399).