### PR TITLE
Add ReactivePlusPlus library

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1728,6 +1728,15 @@ libraries:
       - 0.11.0
       - 0.12.0
       type: github
+    reactive_plus_plus:
+      check_file: src/rpp/rpp/rpp.hpp
+      repo: victimsnino/ReactivePlusPlus
+      if: nightly
+      method: nightlybranch
+      targets:
+      - v1
+      - v2
+      type: github
     scnlib:
       build_type: cmake
       extra_cmake_arg:

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1731,7 +1731,7 @@ libraries:
     reactive_plus_plus:
       check_file: src/rpp/rpp/rpp.hpp
       repo: victimsnino/ReactivePlusPlus
-      # if: nightly
+      if: nightly
       method: nightlybranch
       targets:
       - v0.2.3

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1731,10 +1731,10 @@ libraries:
     reactive_plus_plus:
       check_file: src/rpp/rpp/rpp.hpp
       repo: victimsnino/ReactivePlusPlus
-      if: nightly
+      # if: nightly
       method: nightlybranch
       targets:
-      - v1
+      - v0.2.3
       - v2
       type: github
     scnlib:


### PR DESCRIPTION
Adding header-only C++ ReactivePlusPlus library to compiler explorer.

If i get instruction correct, then I've configured nightly updating repository sources

I hope, i'm right in configuration =)

Main repo PR related to this one: https://github.com/compiler-explorer/compiler-explorer/pull/5448