### PR TITLE
Add new CCCL library for CUDA

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -2045,6 +2045,13 @@ libraries:
         targets:
         - trunk
         type: github
+      cccl:
+        check_file: README.md
+        method: nightlyclone
+        repo: NVIDIA/cccl
+        targets:
+        - trunk
+        type: github
     nvtx:
       check_file: c/include/nvtx3/nvToolsExt.h
       method: clone_branch
@@ -2071,6 +2078,13 @@ libraries:
       - 1.15.0
       - 1.16.0
       - 1.17.0
+      type: github
+    cccl:
+      check_file: README.md
+      method: clone_branch
+      repo: NVIDIA/cccl
+      targets:
+      - 2.2.0
       type: github
   d:
     mir-algorithm:


### PR DESCRIPTION
The Thrust/CUB/libcudacxx repositories were recently merged to https://github.com/nvidia/cccl.

This PR adds a new `CCCL` library for the CUDA language for a nightly `trunk` and 2.2 version. 

See also: https://github.com/compiler-explorer/compiler-explorer/pull/5477 