### PR TITLE
MRISC32: Update URL to point to GitLab

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -403,7 +403,7 @@ compilers:
             check_exe: "mrisc32-gnu-toolchain/bin/{arch_prefix}-g++ --version"
             dir: mrisc32-{name}
             create_untar_dir: true
-            url: https://github.com/mrisc32/mrisc32-gnu-toolchain/releases/latest/download/mrisc32-gnu-toolchain-linux-x86_64.tar.gz
+            url: https://gitlab.com/mrisc32/mrisc32-gnu-toolchain/-/releases/permalink/latest/downloads/mrisc32-gnu-toolchain-linux-x86_64.tar.gz
             compression: gz
             targets:
               - trunk


### PR DESCRIPTION
The MRISC32 GNU toolchain is now hosted on GitLab instead of GitHub, so we need to use a new canonical URL to download the latest Linux build of the toolchain.