### PR TITLE
LLVM 17

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -820,6 +820,8 @@ compilers:
           - assertions-15.0.0
           - 16.0.0
           - assertions-16.0.0
+          - 17.0.1
+          - assertions-17.0.1
     clang-hexagon:
       - type: tarballs
         check_exe: x86_64-linux-gnu/bin/clang++ --version

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -709,6 +709,7 @@ libraries:
       - 14.0.0
       - 15.0.0
       - 16.0.0
+      - 17.0.1
       type: s3tarballs
     magic_enum:
       check_file: include/magic_enum.hpp


### PR DESCRIPTION
Version 17.0.1 is used, given [1]:

> Note that 17.0.0 was pushed out, but contained errors in the version
> information, so we decided to quickly follow up with 17.0.1 - the
> first public version of LLVM 17.x.

Link: https://discourse.llvm.org/t/llvm-17-0-1-released/73549 [1]