### PR TITLE
Update NASM version to 2.16.01

### DIFF
--- a/bin/yaml/asm.yaml
+++ b/bin/yaml/asm.yaml
@@ -23,6 +23,7 @@ compilers:
         - 2.13.02
         - 2.13.03
         - 2.14.02
+        - 2.16.01
     beebasm:
       type: s3tarballs
       targets:


### PR DESCRIPTION
See Issue in compiler-explorer: [#5506](https://github.com/compiler-explorer/compiler-explorer/issues/5506)

See PR in compiler-explorer: [Add NASM 2.16.01](https://github.com/compiler-explorer/compiler-explorer/pull/5528)

Decided to have a go at adding latest NASM release. Let me know if there is anything I missed.