### PR TITLE
add arm-unknown 13.2 config

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -112,6 +112,16 @@ compilers:
               - 12.3.0
               - 13.1.0
               - 13.2.0
+            arm-unknown:
+              - check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+                path_name: "{subdir}/gcc-arm-unknown-{name}"
+                s3_path_prefix: "arm-unknown-gcc-{name}"
+                arch_prefix: arm-unknown-eabi
+                dir: arm/gcc-arm-unknown-eabi-{name}
+                untar_dir: gcc-{name}
+                targets:
+                  - 13.2.0
+
             nightly:
               if: nightly
               type: nightly


### PR DESCRIPTION
Add a GCC 13.2 config for baremetal 32bits ARM.

refs https://github.com/compiler-explorer/compiler-explorer/issues/5545

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>