### PR TITLE
Remove unused packaging package

### DIFF
--- a/bin/lib/rust_library_builder.py
+++ b/bin/lib/rust_library_builder.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import Dict, Any, List, Optional, Generator, TextIO
 from urllib3.exceptions import ProtocolError
 
-# from packaging import version
 import requests
 from lib.staging import StagingDir
 from lib.installation_context import InstallationContext

--- a/bin/lib/rust_library_builder.py
+++ b/bin/lib/rust_library_builder.py
@@ -25,7 +25,6 @@ from lib.amazon_properties import get_properties_compilers_and_libraries
 from lib.library_build_config import LibraryBuildConfig
 
 _TIMEOUT = 600
-# min_compiler_version = version.parse('1.56.0')
 skip_compilers = ["nightly", "beta", "gccrs-snapshot", "mrustc-master", "rustccggcc-master"]
 
 build_supported_os = ["Linux"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1040,17 +1040,14 @@ setuptools = "*"
 
 [[package]]
 name = "packaging"
-version = "21.3"
+version = "23.2"
 description = "Core utilities for Python packages"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
-    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+    {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
+    {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
 ]
-
-[package.dependencies]
-pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "paramiko"
@@ -1188,20 +1185,6 @@ cffi = ">=1.4.1"
 [package.extras]
 docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
 tests = ["hypothesis (>=3.27.0)", "pytest (>=3.2.1,!=3.3.0)"]
-
-[[package]]
-name = "pyparsing"
-version = "3.1.1"
-description = "pyparsing module - Classes and methods to define and execute parsing grammars"
-optional = false
-python-versions = ">=3.6.8"
-files = [
-    {file = "pyparsing-3.1.1-py3-none-any.whl", hash = "sha256:32c7c0b711493c72ff18a981d24f28aaf9c1fb7ed5e9667c9e84e3db623bdbfb"},
-    {file = "pyparsing-3.1.1.tar.gz", hash = "sha256:ede28a1a32462f5a9705e07aea48001a08f7cf81a021585011deba701581a0db"},
-]
-
-[package.extras]
-diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
@@ -1642,4 +1625,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4"
-content-hash = "6a46df6db27d97768cde1e20c03c40972da47e849cec982af01a2d7b76192503"
+content-hash = "8787934bb442b77a9fd3ad9825546f406e725b7cbf823eb092502a73c1cf2dfc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ boto3 = "^1.24.80"
 CacheControl = {extras = ["filecache"], version = "^0.12.11"}
 click = "^8.1.3"
 Jinja2 = "^3.1.2"
-packaging = "^21.3"
 paramiko = "^2.11.0"
 python-dateutil = "^2.8.2"
 requests = "^2.31.0"


### PR DESCRIPTION
 (it's really old and preventing some newer packages) CC @partouf - we can always reinstate a newer version but I took the time to remove it as it is only used in this one comment-edout thing.