### PR TITLE
Add Dart 3.1 release

### DIFF
--- a/bin/yaml/dart.yaml
+++ b/bin/yaml/dart.yaml
@@ -9,6 +9,7 @@ compilers:
       - find -executable -print0 | xargs -0 chmod og+x
     url: https://storage.googleapis.com/dart-archive/channels/stable/release/{name}/sdk/dartsdk-linux-x64-release.zip
     targets:
+      - 3.1.3
       - 3.0.2
       - 2.19.6
       - 2.18.5


### PR DESCRIPTION
Adds Dart 3.1.3, the current latest stable release of Dart: https://dart.dev/get-dart/archive. Thanks!