### PR TITLE
option to only install nightlies

### DIFF
--- a/bin/lib/ce_install.py
+++ b/bin/lib/ce_install.py
@@ -142,6 +142,7 @@ def squash_mount_check(rootfolder, subdir, context):
     show_default=True,
 )
 @click.option("--enable", metavar="TYPE", multiple=True, help='Enable targets of type TYPE (e.g. "nightly")')
+@click.option("--only-nightly", is_flag=True, help="Only install the nightly targets")
 @click.option(
     "--cache",
     metavar="DIR",
@@ -189,6 +190,7 @@ def cli(
     s3_dir: str,
     dry_run: bool,
     enable: List[str],
+    only_nightly: bool,
     cache: Optional[Path],
     yaml_dir: Path,
     allow_unsafe_ssl: bool,
@@ -215,6 +217,7 @@ def cli(
         s3_url=f"https://s3.amazonaws.com/{s3_bucket}/{s3_dir}",
         dry_run=dry_run,
         is_nightly_enabled="nightly" in enable,
+        only_nightly=only_nightly,
         cache=cache,
         yaml_dir=yaml_dir,
         allow_unsafe_ssl=allow_unsafe_ssl,
@@ -222,7 +225,10 @@ def cli(
         keep_staging=keep_staging,
     )
     ctx.obj = CliContext(
-        installation_context=context, enabled=enable, filter_match_all=filter_match_all, parallel=parallel
+        installation_context=context,
+        enabled=enable,
+        filter_match_all=filter_match_all,
+        parallel=parallel,
     )
 
 

--- a/bin/lib/installable/installable.py
+++ b/bin/lib/installable/installable.py
@@ -91,6 +91,9 @@ class Installable:
         return True
 
     def should_install(self) -> bool:
+        if self.install_context.only_nightly and not self.nightly_like:
+            return False
+
         return self.install_always or not self.is_installed()
 
     def should_build(self):

--- a/bin/lib/installation_context.py
+++ b/bin/lib/installation_context.py
@@ -42,6 +42,7 @@ class InstallationContext:
         s3_url: str,
         dry_run: bool,
         is_nightly_enabled: bool,
+        only_nightly: bool,
         cache: Optional[Path],
         yaml_dir: Path,
         allow_unsafe_ssl: bool,
@@ -55,6 +56,7 @@ class InstallationContext:
         self.s3_url = s3_url
         self.dry_run = dry_run
         self.is_nightly_enabled = is_nightly_enabled
+        self.only_nightly = only_nightly
         retry_strategy = requests.adapters.Retry(
             total=10,
             backoff_factor=1,

--- a/bin/test/installable/git_test.py
+++ b/bin/test/installable/git_test.py
@@ -26,7 +26,16 @@ def _ensure_no_global_config():
 
 @pytest.fixture(name="fake_context")
 def fake_context_fixture():
-    return mock.Mock(spec_set=InstallationContext)
+    ctx = mock.Mock(spec=InstallationContext)
+    ctx.only_nightly = False
+    return ctx
+
+
+@pytest.fixture(name="fake_context_nightly")
+def fake_context_nightly_fixture():
+    ctx = mock.Mock(spec=InstallationContext)
+    ctx.only_nightly = True
+    return ctx
 
 
 @pytest.fixture(name="staging_path")
@@ -126,6 +135,24 @@ def test_should_install_when_not_present(fake_context, tmp_path, fake_remote_rep
     ghi = GitHubInstallable(
         fake_context,
         dict(context=["outer", "inner"], name="fake", domainrepo="", repo=fake_remote_repo, check_file="fake-none"),
+    )
+    assert ghi.should_install()
+
+
+def test_should_not_install_when_not_nightly(fake_context_nightly, tmp_path, fake_remote_repo):
+    fake_context_nightly.prior_installation = fake_context_nightly.destination = tmp_path / "nonexistent"
+    ghi = GitHubInstallable(
+        fake_context_nightly,
+        dict(context=["outer", "inner"], name="fake", domainrepo="", repo=fake_remote_repo, check_file="fake-none"),
+    )
+    assert not ghi.should_install()
+
+
+def test_should_install_when_nightly(fake_context_nightly, tmp_path, fake_remote_repo):
+    fake_context_nightly.prior_installation = fake_context_nightly.destination = tmp_path / "nonexistent"
+    ghi = GitHubInstallable(
+        fake_context_nightly,
+        dict(context=["outer", "inner"], name="fake", domainrepo="", method="nightlyclone", repo=fake_remote_repo, check_file="fake-none"),
     )
     assert ghi.should_install()
 

--- a/bin/test/installable/git_test.py
+++ b/bin/test/installable/git_test.py
@@ -152,7 +152,14 @@ def test_should_install_when_nightly(fake_context_nightly, tmp_path, fake_remote
     fake_context_nightly.prior_installation = fake_context_nightly.destination = tmp_path / "nonexistent"
     ghi = GitHubInstallable(
         fake_context_nightly,
-        dict(context=["outer", "inner"], name="fake", domainrepo="", method="nightlyclone", repo=fake_remote_repo, check_file="fake-none"),
+        dict(
+            context=["outer", "inner"],
+            name="fake",
+            domainrepo="",
+            method="nightlyclone",
+            repo=fake_remote_repo,
+            check_file="fake-none",
+        ),
     )
     assert ghi.should_install()
 


### PR DESCRIPTION
Fixes #1123 

First tried to make the filtering to only list the enabled ifs, but that caused issues with dependencies that were then not available. 

So decided to add it as a condition of should_install(), this also means it will mention that something is already installed and therefor being skipped, even if it's really not installed. It would be tricky to change that, I think.

How to use:
```
bin/ce_install --enable nightly --only-nightly install
```
