### PR TITLE
Support latest versions of spdlog

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1826,6 +1826,10 @@ libraries:
       - 1.6.1
       - 1.7.0
       - 1.8.0
+      - 1.9.2
+      - 1.10.0
+      - 1.11.0
+      - 1.12.0
       type: github
     spy:
       check_file: README.md


### PR DESCRIPTION
Related PR: https://github.com/compiler-explorer/compiler-explorer/pull/5588

Add spdlog 1.9.2, 1.10.0, 1.11.0, 1.12.0