### PR TITLE
Fix libbpf build

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -663,6 +663,7 @@ libraries:
       lib_type: shared
       method: clone_branch
       repo: libbpf/libbpf
+      extra_make_arg: -C src
       sharedliblink:
       - bpf
       target_prefix: v


### PR DESCRIPTION
The Makefile for libbpf is located in the [`src`](https://github.com/libbpf/libbpf/blob/master/src/Makefile) directory. This change adds an extra make arg to build in the proper directory. I'm still not sure if this will get the libbpf shared library in the proper place.