### PR TITLE
Add seastar 2211 version to infra

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1782,6 +1782,7 @@ libraries:
       repo: scylladb/seastar
       targets:
       - seastar-18.08.0
+      - seastar-22.11.0
       type: github
     seqan3:
       build_type: none


### PR DESCRIPTION
The existing seastar version 1808 is more than five years old and lots of exciting changes have occurred since then. This patch adds seastar 2211 from last last year so that it can be be exposed by CE.