### PR TITLE
Support for Android's D8 compiler

### DIFF
--- a/bin/yaml/android-java.yaml
+++ b/bin/yaml/android-java.yaml
@@ -2,8 +2,10 @@ compilers:
   android-d8:
     type: singleFile
     dir: r8-{name}
+    depends:
+      - compilers/java 16.0.1
+    check_exe: "%DEP0%/bin/java -cp {dir}/{filename} com.android.tools.r8.D8 --version"
+    filename: r8-{name}.jar
+    url: https://dl.google.com/android/maven2/com/android/tools/r8/{name}/r8-{name}.jar
     targets:
-      - name: 8.1.56
-        filename: r8-8.1.56.jar
-        check_file: r8-8.1.56.jar
-        url: https://dl.google.com/android/maven2/com/android/tools/r8/8.1.56/r8-8.1.56.jar
+      - 8.1.56

--- a/bin/yaml/android-java.yaml
+++ b/bin/yaml/android-java.yaml
@@ -1,0 +1,9 @@
+compilers:
+  android-d8:
+    type: singleFile
+    dir: r8-{name}
+    targets:
+      - name: 8.1.56
+        filename: r8-8.1.56.jar
+        check_file: r8-8.1.56.jar
+        url: https://dl.google.com/android/maven2/com/android/tools/r8/8.1.56/r8-8.1.56.jar


### PR DESCRIPTION
Adds version 8.1.56 (latest public). The jar file for running D8 is pulled from Google's Maven repository:

https://maven.google.com/web/index.html#com.android.tools:r8