### PR TITLE
Add baksmali to infra

### DIFF
--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -114,3 +114,17 @@ tools:
     check_exe: bin/pahole
     targets:
       - trunk
+  baksmali:
+    type: github
+    repo: google/smali
+    method: clone_branch
+    after_stage_script:
+      - ./gradlew assemble
+      - ./gradlew baksmali:fatJar
+      # Fix dangling symlink created when files are copied from staging.
+      - cd baksmali/build/libs
+      # There will only be one fat jar, so the wildcard will create a valid symlink.
+      - ln -s -f baksmali*fat.jar baksmali.jar
+    check_file: baksmali/build/libs/baksmali.jar
+    targets:
+      - version-3.0.3

--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -115,16 +115,10 @@ tools:
     targets:
       - trunk
   baksmali:
-    type: github
-    repo: google/smali
-    method: clone_branch
-    after_stage_script:
-      - ./gradlew assemble
-      - ./gradlew baksmali:fatJar
-      # Fix dangling symlink created when files are copied from staging.
-      - cd baksmali/build/libs
-      # There will only be one fat jar, so the wildcard will create a valid symlink.
-      - ln -s -f baksmali*fat.jar baksmali.jar
-    check_file: baksmali/build/libs/baksmali.jar
+    type: singleFile
+    dir: baksmali-{name}
     targets:
-      - version-3.0.3
+      - name: 3.0.3
+        filename: baksmali-3.0.3-fat.jar
+        check_file: baksmali-3.0.3-fat.jar
+        url: https://storage.googleapis.com/r8-releases/smali/3.0.3/baksmali-3.0.3-fat.jar

--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -117,8 +117,10 @@ tools:
   baksmali:
     type: singleFile
     dir: baksmali-{name}
+    depends:
+      - compilers/java 16.0.1
+    check_exe: ../jdk-16.0.1/bin/java -jar {dir}/{filename} --version
     targets:
       - name: 3.0.3
         filename: baksmali-3.0.3-fat.jar
-        check_file: baksmali-3.0.3-fat.jar
         url: https://storage.googleapis.com/r8-releases/smali/3.0.3/baksmali-3.0.3-fat.jar


### PR DESCRIPTION
Adds version 3.0.3 of baksmali, a disassembler for Android's .dex format. The code for baksmali is found at the google/smali repository and can be built with gradle:

https://github.com/google/smali