### PR TITLE
Add Swift 5.9 release and Swift 5.10 nightly

### DIFF
--- a/bin/yaml/swift.yaml
+++ b/bin/yaml/swift.yaml
@@ -33,18 +33,19 @@ compilers:
           - '5.6'
           - '5.7'
           - '5.8'
+          - '5.9'
     # when the pre-release becomes a release, comment out the `5.x-nightly` section to allow reuse at a later time
-    #5.7-nightly:
-    #  if: nightly
-    #  type: restQueryTarballs
-    #  install_always: true
-    #  url: https://swift.org/builds/swift-{name}-branch/ubuntu2004/latest-build.yml
-    #  query: |
-    #    'https://swift.org/builds/swift-{name}-branch/ubuntu2004/' \
-    #    + document['download'].replace('-ubuntu20.04.tar.gz', '') \
-    #    + '/' + document['download']
-    #  targets:
-    #    - '5.7'
+    5.10-nightly:
+      if: nightly
+      type: restQueryTarballs
+      install_always: true
+      url: https://swift.org/builds/swift-{name}-branch/ubuntu2004/latest-build.yml
+      query: |
+        'https://swift.org/builds/swift-{name}-branch/ubuntu2004/' \
+        + document['download'].replace('-ubuntu20.04.tar.gz', '') \
+        + '/' + document['download']
+      targets:
+        - '5.10'
     nightly:
       if: nightly
       type: restQueryTarballs


### PR DESCRIPTION
See also: https://github.com/compiler-explorer/compiler-explorer/pull/5724