### PR TITLE
Add DXC releases since December 2022

### DIFF
--- a/bin/yaml/hlsl.yaml
+++ b/bin/yaml/hlsl.yaml
@@ -11,6 +11,9 @@ compilers:
       type: s3tarballs
       check_exe: bin/dxc --version
       targets:
+        - "1.8.2306-preview"
+        - "1.7.2308"
+        - "1.7.2212"
         - "1.7.2207"
         - "1.6.2112"
     rga:


### PR DESCRIPTION
This adds the following DXC releases:
- 1.7.2212
- 1.7.2308
- 1.8.2306-preview