### PR TITLE
Make /opt/compiler-explorer a hard link to /efs/

### DIFF
--- a/setup-ci.sh
+++ b/setup-ci.sh
@@ -10,5 +10,7 @@ cd "${DIR}"
 env EXTRA_NFS_ARGS="" "${DIR}/setup-common.sh" ci
 
 ln -s /efs/squash-images /opt/squash-images
-ln -s /efs/compiler-explorer /opt/compiler-explorer
 ln -s /efs/wine-stable /opt/wine-stable
+
+# This link is intentionally a hard-link (nvhpc install script picked /efs/ instead of /opt/)
+ln    /efs/compiler-explorer /opt/compiler-explorer


### PR DESCRIPTION
NVHPC SDK 23.11 when run with -v in compiler explorer shows that is trying to find the GCC 12 libstdc++ in the /efs/compiler-explorer path. We believe this may be due to this link being a soft-link, instead of a hard-link, and a change in the installation script in 23.11 that resolves the soft-link to the /efs/ path. 