### PR TITLE
Add Racket nightly snapshot

### DIFF
--- a/bin/yaml/racket.yaml
+++ b/bin/yaml/racket.yaml
@@ -10,3 +10,9 @@ compilers:
       racket/racket-{name}/bin/raco pkg install -i --auto disassemble
     targets:
       - "8.6"
+    nightly:
+      if: nightly
+      fetch:
+        - https://users.cs.utah.edu/plt/snapshots/current/installers/racket-current-x86_64-linux-jammy.sh racket-{name}.sh
+      targets:
+        - nightly


### PR DESCRIPTION
This extends existing Racket support (https://github.com/compiler-explorer/infra/pull/832) by adding a nightly snapshot version.

Used by https://github.com/compiler-explorer/compiler-explorer/pull/5812