### PR TITLE
Update LLVM to latest patch versions

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -721,9 +721,13 @@ libraries:
       - 13.0.0
       - 13.0.1
       - 14.0.0
+      - 14.0.6
       - 15.0.0
+      - 15.0.7
       - 16.0.0
+      - 16.0.6
       - 17.0.1
+      - 17.0.6
       type: s3tarballs
     magic_enum:
       check_file: include/magic_enum.hpp


### PR DESCRIPTION
We probably don't need to install all the patch versions but we should rather support the latest patch version of each major LLVM release