### PR TITLE
Move dsharlet/array to the nightly section of c++ libraries

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -10,13 +10,6 @@ libraries:
       - 9.1.0
       type: github
   c++:
-    array:
-      check_file: include/array/array.h
-      repo: dsharlet/array
-      method: clone_branch
-      targets:
-      - master
-      type: github
     async_simple:
       build_type: none
       check_file: README.md
@@ -836,6 +829,13 @@ libraries:
         - absl_wyhash
         targets:
         - trunk
+        type: github
+      array:
+        check_file: include/array/array.h
+        repo: dsharlet/array
+        method: nightlyclone
+        targets:
+        - master
         type: github
       avr-libstdcpp:
         build_type: manual


### PR DESCRIPTION
As noted in https://github.com/compiler-explorer/infra/pull/1180, this needed
to be in the 'nightly' section to pull the master branch regularly.

Tested with `./bin/ce_install --enable nightly  install libraries/c++/nightly/array`
