### PR TITLE
Add gcc-p1144-trunk, and(!!) fix what looks like a typo

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1162,11 +1162,12 @@ compilers:
         targets:
           - name: trunk
             symlink: gcc-snapshot
+          - contracts-nonattr-trunk
+          - cxx-coroutines-trunk
+          - cxx-modules-trunk
           - lock3-contracts-trunk
           - lock3-contracts-labels-trunk
-          - contracts-nonattr-trunk
-          - cxx-modules-trunk
-          - cxx-coroutines-trunk
+          - p1144-trunk
       clang:
         type: nightly
         check_exe: bin/clang++ --version

--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1163,7 +1163,7 @@ compilers:
           - name: trunk
             symlink: gcc-snapshot
           - lock3-contracts-trunk
-          - lock3-contract-labels-trunk
+          - lock3-contracts-labels-trunk
           - contracts-nonattr-trunk
           - cxx-modules-trunk
           - cxx-coroutines-trunk


### PR DESCRIPTION
See https://github.com/compiler-explorer/infra/issues/1157

Also, sort the gcc builders alphabetically (ignoring the trailing `trunk`)
so it's less arbitrary where a new one would be added.

Also!! — fix what looks like a typo — `lock3-contract-labels` should be `lock3-contracts-labels` if it's intending to match what's in the other repositories. Please double-check me on this.