### PR TITLE
Fix Racket nightly updates

### DIFF
--- a/bin/yaml/racket.yaml
+++ b/bin/yaml/racket.yaml
@@ -12,6 +12,7 @@ compilers:
       - "8.6"
     nightly:
       if: nightly
+      install_always: true
       fetch:
         - https://users.cs.utah.edu/plt/snapshots/current/installers/racket-current-x86_64-linux-jammy.sh racket-{name}.sh
       targets:


### PR DESCRIPTION
This tweaks the Racket nightly snapshot so that it's always installed (rather than only installing the first time).