### PR TITLE
Refactor EDG support

### DIFF
--- a/bin/lib/installable/archives.py
+++ b/bin/lib/installable/archives.py
@@ -364,7 +364,7 @@ class NonFreeS3TarballInstallable(S3TarballInstallable):
         super().__init__(install_context, config)
 
     def fetch_and_pipe_to(self, staging: StagingDir, s3_path: str, command: list[str]) -> None:
-        untar_dir = staging.path
+        untar_dir = staging.path / self.untar_dir
         untar_dir.mkdir(exist_ok=True, parents=True)
         with tempfile.TemporaryFile() as fd:
             amazon.s3_client.download_fileobj("compiler-explorer", f"opt-nonfree/{s3_path}", fd)

--- a/bin/lib/installable/edg.py
+++ b/bin/lib/installable/edg.py
@@ -14,19 +14,6 @@ from pathlib import Path
 
 _LOGGER = logging.getLogger(__name__)
 
-def _resolve_backend_compiler(installable: EdgCompilerInstallable) -> Path:
-    """The EDG front end generates C files and thus uses a backing C compiler
-    complete compilation. Return the path of the backend compiler."""
-    if len(installable.depends) != 1:
-        raise RuntimeError("Assumes we have the backend compiler as a dep")
-    backend_path = installable.install_context.destination / installable.depends[0].install_path
-
-    if installable._compiler_type == "default":
-        return backend_path / "bin" / "gcc"
-    else:
-        return backend_path / "bin" / installable._compiler_type
-
-
 class EdgBackendCompilerScrape:
     """This class represents a scrape of the "backend compiler" for the EDG front
     end that will compile the generated C code."""
@@ -34,65 +21,6 @@ class EdgBackendCompilerScrape:
         self.c_includes = c_includes
         self.cpp_includes = cpp_includes
         self.version = version
-
-
-def _scrape_backend_compiler(installable: EdgCompilerInstallable, staging: StagingDir, backend_compiler_path: Path) -> EdgBackendCompilerScrape:
-    """The EDG front end when emulating a compiler needs to know that
-    compiler's include paths and version. Collect and return the aforementioned
-    details if relevant."""
-    # If the compiler is in default mode the backend compiler isn't scraped.
-    if installable._compiler_type == "default":
-        return EdgBackendCompilerScrape('',  '', '')
-
-    scrapper_unzip_dir = staging.path / 'backend-scrapping'
-    scrapper_unzip_dir.mkdir(exist_ok=True, parents=True)
-
-    def _query(lang: str, query_type: str) -> str:
-        """Query the EDG compiler scrape tool for the given language and query type."""
-        command_to_run = [
-            installable._scrape_cmd,
-            f"--compiler-path={backend_compiler_path}",
-            f"--lang={lang}",
-            installable._compiler_type,
-            query_type,
-        ]
-        _LOGGER.info("Running %s", shlex.join(command_to_run))
-        return subprocess.check_output(command_to_run, cwd=scrapper_unzip_dir).decode("utf-8").strip()
-
-    # Gather the C and C++ include paths as well as the emulated compiler version number.
-    with tempfile.NamedTemporaryFile() as temp_file:
-        amazon.s3_client.download_fileobj("compiler-explorer", f"opt-nonfree/{installable._scraper}", temp_file)
-        temp_file.flush()
-        command = ["unzip", temp_file.name]
-        _LOGGER.info("Running %s", shlex.join(command))
-        subprocess.check_call(command, cwd=scrapper_unzip_dir)
-        c_includes = _query("c", "includes")
-        cpp_includes = _query("c++", "includes")
-        version = _query("c", "version")
-        return EdgBackendCompilerScrape(c_includes, cpp_includes, version)
-
-
-def _write_predefined_macros(installable: EdgCompilerInstallable, staging: StagingDir, backend_compiler_path: Path) -> None:
-    """The EDG front end when emulating a compiler needs to know what
-    predefined macros to set. Write the predefined macros file as necessary."""
-    # If the compiler is in default mode the default predefined macros are used.
-    if installable._compiler_type == "default":
-        return
-
-    # Check some prerequisites before doing further work.
-    if len(installable._macro_gen) == 0 or len(installable._macro_dir) == 0:
-        raise RuntimeError("No macro generation script provided for non-default mode EDG compiler")
-
-    # Gather the predefined macros for the emulated compiler.
-    with tempfile.NamedTemporaryFile() as temp_file:
-        amazon.s3_client.download_fileobj("compiler-explorer", f"opt-nonfree/{installable._macro_gen}", temp_file)
-        temp_file.flush()
-        command = ["bash", temp_file.name, f"--{installable._compiler_type}", str(backend_compiler_path)]
-        _LOGGER.info("Running %s", shlex.join(command))
-        output_path = staging.path / installable.untar_dir / installable._macro_dir
-        output_path.mkdir(parents=True, exist_ok=True)
-        subprocess.check_call(command, cwd=output_path)
-
 
 _COMMON_EDG_SETUP = """
 export CPFE="$EDG_INSTALL_DIR/bin/cpfe"
@@ -103,7 +31,6 @@ export EDG_PRELINK_PATH="$EDG_INSTALL_DIR/bin/edg_prelink"
 export ECCP="$EDG_INSTALL_DIR/bin/eccp"
 export EDG_RUNTIME_LIB="edgrt"
 """
-
 
 def _shim_gcc_shell(install_dir: Path, gcc: Path, scrape_info: EdgBackendCompilerScrape) -> str:
     return f"""#!/bin/bash
@@ -127,8 +54,7 @@ export EDG_OBJ_TO_EXEC_DEFAULT_OPTIONS="-static -z muldefs"
 exec "$EDG_INSTALL_DIR/bin/eccp" $@
 """
 
-
-def _shim_default_shell(install_dir: Path, gcc: Path, scrape_info: EdgBackendCompilerScrape) -> str:
+def _shim_default_shell(install_dir: Path, gcc: Path, **kw_args) -> str:
     return f"""#!/bin/bash
 set -euo pipefail
 
@@ -143,29 +69,10 @@ export EDG_BASE="$EDG_INSTALL_DIR/base"
 exec "$EDG_INSTALL_DIR/bin/eccp" $@
 """
 
-
 _SHIM_SHELL_FUNCS: dict[str, Callable[..., str]] = {
     "default": _shim_default_shell,
     "gcc": _shim_gcc_shell,
 }
-
-
-def _write_compiler_shim(installable: EdgCompilerInstallable, staging: StagingDir, backend_compiler_path: Path, backend_compiler_scrape: EdgBackendCompilerScrape) -> None:
-    """The EDG front end is configured via a "shim" script in compiler
-    explorer. Generate this shim script with the collected information."""
-    output_path = staging.path / installable.untar_dir / "eccp-scripts"
-    output_path.mkdir(parents=True, exist_ok=True)
-    script_path = output_path / f"eccp-{installable._compiler_type}"
-    with script_path.open("w") as out:
-        out.write(
-            _SHIM_SHELL_FUNCS[installable._compiler_type](
-                install_dir=installable.install_context.destination / installable.install_path,
-                gcc=backend_compiler_path,
-                scrape_info=backend_compiler_scrape,
-            )
-        )
-    script_path.chmod(0o755)
-
 
 class EdgCompilerInstallable(NonFreeS3TarballInstallable):
     def __init__(self, install_context: InstallationContext, config: Dict[str, Any]):
@@ -177,14 +84,104 @@ class EdgCompilerInstallable(NonFreeS3TarballInstallable):
         self._compiler_type = self.config_get("compiler_type")
         self.install_path = self.config_get("path_name")
 
+    def _resolve_backend_compiler(self) -> Path:
+        """The EDG front end generates C files and thus uses a backing C
+        compiler complete compilation. Return the path of the backend
+        compiler.
+        """
+        if len(self.depends) != 1:
+            raise RuntimeError("Assumes we have the backend compiler as a dep")
+        backend_path = self.install_context.destination / self.depends[0].install_path
+
+        if self._compiler_type == "default":
+            return backend_path / "bin" / "gcc"
+        else:
+            return backend_path / "bin" / self._compiler_type
+
+    def _scrape_backend_compiler(self, staging: StagingDir, backend_compiler_path: Path) -> EdgBackendCompilerScrape:
+        """The EDG front end when emulating a compiler needs to know that
+        compiler's include paths and version. Collect and return the
+        aforementioned details if relevant.
+        """
+        # If the compiler is in default mode the backend compiler isn't scraped.
+        if self._compiler_type == "default":
+            return EdgBackendCompilerScrape('',  '', '')
+
+        scrapper_unzip_dir = staging.path / 'backend-scrapping'
+        scrapper_unzip_dir.mkdir(exist_ok=True, parents=True)
+
+        def _query(lang: str, query_type: str) -> str:
+            """Query the EDG compiler scrape tool for the given language and query type."""
+            command_to_run = [
+                self._scrape_cmd,
+                f"--compiler-path={backend_compiler_path}",
+                f"--lang={lang}",
+                self._compiler_type,
+                query_type,
+            ]
+            _LOGGER.info("Running %s", shlex.join(command_to_run))
+            return subprocess.check_output(command_to_run, cwd=scrapper_unzip_dir).decode("utf-8").strip()
+
+        # Gather the C and C++ include paths as well as the emulated compiler version number.
+        with tempfile.NamedTemporaryFile() as temp_file:
+            amazon.s3_client.download_fileobj("compiler-explorer", f"opt-nonfree/{self._scraper}", temp_file)
+            temp_file.flush()
+            command = ["unzip", temp_file.name]
+            _LOGGER.info("Running %s", shlex.join(command))
+            subprocess.check_call(command, cwd=scrapper_unzip_dir)
+            c_includes = _query("c", "includes")
+            cpp_includes = _query("c++", "includes")
+            version = _query("c", "version")
+            return EdgBackendCompilerScrape(c_includes, cpp_includes, version)
+
+    def _write_predefined_macros(self, staging: StagingDir, backend_compiler_path: Path) -> None:
+        """The EDG front end when emulating a compiler needs to know what
+        predefined macros to set. Write the predefined macros file as
+        necessary.
+        """
+        # If the compiler is in default mode the default predefined macros are used.
+        if self._compiler_type == "default":
+            return
+
+        # Check some prerequisites before doing further work.
+        if len(self._macro_gen) == 0 or len(self._macro_dir) == 0:
+            raise RuntimeError("No macro generation script provided for non-default mode EDG compiler")
+
+        # Gather the predefined macros for the emulated compiler.
+        with tempfile.NamedTemporaryFile() as temp_file:
+            amazon.s3_client.download_fileobj("compiler-explorer", f"opt-nonfree/{self._macro_gen}", temp_file)
+            temp_file.flush()
+            command = ["bash", temp_file.name, f"--{self._compiler_type}", str(backend_compiler_path)]
+            _LOGGER.info("Running %s", shlex.join(command))
+            output_path = staging.path / self.untar_dir / self._macro_dir
+            output_path.mkdir(parents=True, exist_ok=True)
+            subprocess.check_call(command, cwd=output_path)
+
+    def _write_compiler_shim(self, staging: StagingDir, backend_compiler_path: Path, backend_compiler_scrape: EdgBackendCompilerScrape) -> None:
+        """The EDG front end is configured via a "shim" script in compiler
+        explorer. Generate this shim script with the collected information.
+        """
+        output_path = staging.path / self.untar_dir / "eccp-scripts"
+        output_path.mkdir(parents=True, exist_ok=True)
+        script_path = output_path / f"eccp-{self._compiler_type}"
+        with script_path.open("w") as out:
+            out.write(
+                _SHIM_SHELL_FUNCS[self._compiler_type](
+                    install_dir=self.install_context.destination / self.install_path,
+                    gcc=backend_compiler_path,
+                    scrape_info=backend_compiler_scrape,
+                )
+            )
+        script_path.chmod(0o755)
+
     def stage(self, staging: StagingDir) -> None:
         super().stage(staging)
 
-        backend_compiler_path = _resolve_backend_compiler(self)
-        backend_compiler_scrape = _scrape_backend_compiler(self, staging, backend_compiler_path)
+        backend_compiler_path = self._resolve_backend_compiler()
+        backend_compiler_scrape = self._scrape_backend_compiler(staging, backend_compiler_path)
 
-        _write_predefined_macros(self, staging, backend_compiler_path)
-        _write_compiler_shim(self, staging, backend_compiler_path, backend_compiler_scrape)
+        self._write_predefined_macros(staging, backend_compiler_path)
+        self._write_compiler_shim(staging, backend_compiler_path, backend_compiler_scrape)
 
     def verify(self) -> bool:
         if not super().verify():

--- a/bin/lib/installable/edg.py
+++ b/bin/lib/installable/edg.py
@@ -14,6 +14,86 @@ from pathlib import Path
 
 _LOGGER = logging.getLogger(__name__)
 
+def _resolve_backend_compiler(installable: EdgCompilerInstallable) -> Path:
+    """The EDG front end generates C files and thus uses a backing C compiler
+    complete compilation. Return the path of the backend compiler."""
+    if len(installable.depends) != 1:
+        raise RuntimeError("Assumes we have the backend compiler as a dep")
+    backend_path = installable.install_context.destination / installable.depends[0].install_path
+
+    if installable._compiler_type == "default":
+        return backend_path / "bin" / "gcc"
+    else:
+        return backend_path / "bin" / installable._compiler_type
+
+
+class EdgBackendCompilerScrape:
+    """This class represents a scrape of the "backend compiler" for the EDG front
+    end that will compile the generated C code."""
+    def __init__(self, c_includes: str, cpp_includes: str, version: str):
+        self.c_includes = c_includes
+        self.cpp_includes = cpp_includes
+        self.version = version
+
+
+def _scrape_backend_compiler(installable: EdgCompilerInstallable, staging: StagingDir, backend_compiler_path: Path) -> EdgBackendCompilerScrape:
+    """The EDG front end when emulating a compiler needs to know that
+    compiler's include paths and version. Collect and return the aforementioned
+    details if relevant."""
+    # If the compiler is in default mode the backend compiler isn't scraped.
+    if installable._compiler_type == "default":
+        return EdgBackendCompilerScrape('',  '', '')
+
+    scrapper_unzip_dir = staging.path / 'backend-scrapping'
+    scrapper_unzip_dir.mkdir(exist_ok=True, parents=True)
+
+    def _query(lang: str, query_type: str) -> str:
+        """Query the EDG compiler scrape tool for the given language and query type."""
+        command_to_run = [
+            installable._scrape_cmd,
+            f"--compiler-path={backend_compiler_path}",
+            f"--lang={lang}",
+            installable._compiler_type,
+            query_type,
+        ]
+        _LOGGER.info("Running %s", shlex.join(command_to_run))
+        return subprocess.check_output(command_to_run, cwd=scrapper_unzip_dir).decode("utf-8").strip()
+
+    # Gather the C and C++ include paths as well as the emulated compiler version number.
+    with tempfile.NamedTemporaryFile() as temp_file:
+        amazon.s3_client.download_fileobj("compiler-explorer", f"opt-nonfree/{installable._scraper}", temp_file)
+        temp_file.flush()
+        command = ["unzip", temp_file.name]
+        _LOGGER.info("Running %s", shlex.join(command))
+        subprocess.check_call(command, cwd=scrapper_unzip_dir)
+        c_includes = _query("c", "includes")
+        cpp_includes = _query("c++", "includes")
+        version = _query("c", "version")
+        return EdgBackendCompilerScrape(c_includes, cpp_includes, version)
+
+
+def _write_predefined_macros(installable: EdgCompilerInstallable, staging: StagingDir, backend_compiler_path: Path) -> None:
+    """The EDG front end when emulating a compiler needs to know what
+    predefined macros to set. Write the predefined macros file as necessary."""
+    # If the compiler is in default mode the default predefined macros are used.
+    if installable._compiler_type == "default":
+        return
+
+    # Check some prerequisites before doing further work.
+    if len(installable._macro_gen) == 0 or len(installable._macro_dir) == 0:
+        raise RuntimeError("No macro generation script provided for non-default mode EDG compiler")
+
+    # Gather the predefined macros for the emulated compiler.
+    with tempfile.NamedTemporaryFile() as temp_file:
+        amazon.s3_client.download_fileobj("compiler-explorer", f"opt-nonfree/{installable._macro_gen}", temp_file)
+        temp_file.flush()
+        command = ["bash", temp_file.name, f"--{installable._compiler_type}", str(backend_compiler_path)]
+        _LOGGER.info("Running %s", shlex.join(command))
+        output_path = staging.path / installable.untar_dir / installable._macro_dir
+        output_path.mkdir(parents=True, exist_ok=True)
+        subprocess.check_call(command, cwd=output_path)
+
+
 _COMMON_EDG_SETUP = """
 export CPFE="$EDG_INSTALL_DIR/bin/cpfe"
 export ECCP_LIBDIR="$EDG_INSTALL_DIR/lib"
@@ -25,14 +105,14 @@ export EDG_RUNTIME_LIB="edgrt"
 """
 
 
-def _shim_gcc_shell(install_dir: Path, gcc: Path, c_includes: str, cpp_includes: str, version: str) -> str:
+def _shim_gcc_shell(install_dir: Path, gcc: Path, scrape_info: EdgBackendCompilerScrape) -> str:
     return f"""#!/bin/bash
 set -euo pipefail
 
 export EDG_INSTALL_DIR="{install_dir}"
-export EDG_GCC_INCL_SCRAPE="{cpp_includes}"
-export EDG_GCC_CINCL_SCRAPE="{c_includes}"
-export EDG_CPFE_DEFAULT_OPTIONS="--gnu {version}"
+export EDG_GCC_INCL_SCRAPE="{scrape_info.cpp_includes}"
+export EDG_GCC_CINCL_SCRAPE="{scrape_info.c_includes}"
+export EDG_CPFE_DEFAULT_OPTIONS="--gnu {scrape_info.version}"
 export EDG_C_TO_OBJ_COMPILER="{gcc}"
 # several variables removed
 
@@ -48,7 +128,7 @@ exec "$EDG_INSTALL_DIR/bin/eccp" $@
 """
 
 
-def _shim_default_shell(install_dir: Path, gcc: Path, **_kwargs) -> str:
+def _shim_default_shell(install_dir: Path, gcc: Path, scrape_info: EdgBackendCompilerScrape) -> str:
     return f"""#!/bin/bash
 set -euo pipefail
 
@@ -70,80 +150,41 @@ _SHIM_SHELL_FUNCS: dict[str, Callable[..., str]] = {
 }
 
 
+def _write_compiler_shim(installable: EdgCompilerInstallable, staging: StagingDir, backend_compiler_path: Path, backend_compiler_scrape: EdgBackendCompilerScrape) -> None:
+    """The EDG front end is configured via a "shim" script in compiler
+    explorer. Generate this shim script with the collected information."""
+    output_path = staging.path / installable.untar_dir / "eccp-scripts"
+    output_path.mkdir(parents=True, exist_ok=True)
+    script_path = output_path / f"eccp-{installable._compiler_type}"
+    with script_path.open("w") as out:
+        out.write(
+            _SHIM_SHELL_FUNCS[installable._compiler_type](
+                install_dir=installable.install_context.destination / installable.install_path,
+                gcc=backend_compiler_path,
+                scrape_info=backend_compiler_scrape,
+            )
+        )
+    script_path.chmod(0o755)
+
+
 class EdgCompilerInstallable(NonFreeS3TarballInstallable):
     def __init__(self, install_context: InstallationContext, config: Dict[str, Any]):
         super().__init__(install_context, config)
         self._scraper = self.config_get("scraper")
-        self._macro_gen = self.config_get("macro_gen")
-        self._macro_dir = self.config_get("macro_output_dir")
-        self._scape_cmd = self.config_get("scrape_cmd")
+        self._macro_gen = self.config_get("macro_gen", "")
+        self._macro_dir = self.config_get("macro_output_dir", "")
+        self._scrape_cmd = self.config_get("scrape_cmd")
         self._compiler_type = self.config_get("compiler_type")
-        self._shim_shell_func = _SHIM_SHELL_FUNCS[self._compiler_type]
         self.install_path = self.config_get("path_name")
 
     def stage(self, staging: StagingDir) -> None:
         super().stage(staging)
-        if len(self.depends) != 1:
-            raise RuntimeError("Assumes we have the backend compiler as a dep")
-        backend_path = self.install_context.destination / self.depends[0].install_path
 
-        unzip_dir = staging.path
-        unzip_dir.mkdir(exist_ok=True, parents=True)
+        backend_compiler_path = _resolve_backend_compiler(self)
+        backend_compiler_scrape = _scrape_backend_compiler(self, staging, backend_compiler_path)
 
-        def _call(checked_command):
-            _LOGGER.info("Running %s", shlex.join(checked_command))
-            subprocess.check_call(checked_command, cwd=unzip_dir)
-
-        if self._compiler_type == "default":
-            compiler_path = backend_path / "bin" / "gcc"
-        else:
-            compiler_path = backend_path / "bin" / self._compiler_type
-
-        def _query(lang: str, query_type: str) -> str:
-            command_to_run = [
-                self._scape_cmd,
-                f"--compiler-path={compiler_path}",
-                f"--lang={lang}",
-                self._compiler_type,
-                query_type,
-            ]
-            _LOGGER.info("Running %s", shlex.join(command_to_run))
-            return subprocess.check_output(command_to_run, cwd=unzip_dir).decode("utf-8").strip()
-
-        if self._compiler_type != "default":
-            with tempfile.NamedTemporaryFile() as temp_file:
-                amazon.s3_client.download_fileobj("compiler-explorer", f"opt-nonfree/{self._scraper}", temp_file)
-                temp_file.flush()
-                _call(["unzip", temp_file.name])
-                cpp_includes = _query("c++", "includes")
-                c_includes = _query("c", "includes")
-                version = _query("c", "version")
-
-            with tempfile.NamedTemporaryFile() as temp_file:
-                amazon.s3_client.download_fileobj("compiler-explorer", f"opt-nonfree/{self._macro_gen}", temp_file)
-                temp_file.flush()
-                command = ["bash", temp_file.name, f"--{self._compiler_type}", str(compiler_path)]
-                _LOGGER.info("Running %s", shlex.join(command))
-                subprocess.check_call(command, cwd=staging.path / self.untar_dir / self._macro_dir)
-        else:
-            cpp_includes = ""
-            c_includes = ""
-            version = ""
-
-        output_path = staging.path / self.untar_dir / "eccp-scripts"
-        output_path.mkdir(exist_ok=True)
-        script_path = output_path / f"eccp-{self._compiler_type}"
-        with script_path.open("w") as out:
-            out.write(
-                self._shim_shell_func(
-                    install_dir=self.install_context.destination / self.install_path,
-                    gcc=compiler_path,
-                    c_includes=c_includes,
-                    cpp_includes=cpp_includes,
-                    version=version,
-                )
-            )
-        script_path.chmod(0o755)
+        _write_predefined_macros(self, staging, backend_compiler_path)
+        _write_compiler_shim(self, staging, backend_compiler_path, backend_compiler_scrape)
 
     def verify(self) -> bool:
         if not super().verify():

--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -859,50 +859,32 @@ compilers:
       if: non-free
       type: edg
       compression: gz
-      s3_path_prefix: edg-compiler/v{edg_version}
       untar_dir: edg-compiler
       scraper: edg-compiler/edg-scrape-compiler.2023.7.18.zip
-      macro_gen: edg-compiler/make_predef_macro_table
       scrape_cmd: bin/edg-scrape-compiler
       path_name: edg-{name}
-      old:
-        macro_output_dir: bases/gnu/lib
-        check_exe: eccp-scripts/eccp-{compiler_type} --version
+      check_exe: eccp-scripts/eccp-{compiler_type} --version
+      s3_path_prefix: edg-compiler/edg-{compiler_type}-{edg_version}
+      default:
+        compiler_type: default
         targets:
-          - name: 6.5-gcc-13
-            edg_version: '6.5'
-            compiler_type: gcc
+          - name: 6.5-default-13-20231120
+            edg_version: 'compiler-6.5-20231120'
             depends:
               - compilers/c++/x86/gcc 13.2.0
-          - name: 6.5-default-13
-            edg_version: '6.5'
-            compiler_type: default
-            depends:
-              - compilers/c++/x86/gcc 13.2.0
-      new:
+      gcc:
+        compiler_type: gcc
+        macro_gen: edg-compiler/make_predef_macro_table
         macro_output_dir: base/lib
-        check_exe: eccp-scripts/eccp-{compiler_type} --version
-        s3_path_prefix: edg-compiler/edg-{compiler_type}-compiler-{edg_version}
-        untar_dir: .
         targets:
           - name: 6.5-gcc-13-20231120
-            compiler_type: gcc
-            edg_version: '6.5-20231120'
+            edg_version: 'compiler-6.5-20231120'
             depends:
               - compilers/c++/x86/gcc 13.2.0
-          - name: 6.5-default-13-20231120
-            edg_version: '6.5-20231120'
-            compiler_type: default
+          - name: gcc-13-experimental-reflection
+            edg_version: 'edg-experimental-reflection'
             depends:
               - compilers/c++/x86/gcc 13.2.0
-        even_newer:
-          s3_path_prefix: edg-compiler/edg-{compiler_type}-edg-{edg_version}
-          targets:
-            - name: 6.5-gcc-13-experimental-reflection
-              compiler_type: gcc
-              edg_version: experimental-reflection
-              depends:
-                - compilers/c++/x86/gcc 13.2.0
     ellccs:
       check_exe: bin/clang++ --version
       dir: ellcc-{name}


### PR DESCRIPTION
This makes several changes:

- `fetch_and_pipe_to` for `NonFreeS3TarballInstallable` now puts the extracted tar into the `untar_dir` so that the extracted contents gets copied from the staging untar directory (previously most edg compilers installed the entire staging directory -- including generated supporting scripts -- unnecessarily)
- `EdgCompilerInstallable` has been refactored with the aim of better conveying what install steps are needed and what specifically needs to happen for each install step
- the `cpp.yml` entries for EDG have been simplified into two categories `default` and `gcc` matching the Compiler Explorer frontend code
  - The naming convention is simply `edg-compiler/edg-{compiler_type}-{edg_version}` for EDG compilers going forward (where edg_version might have some flexibility, e.g., `edg_version: 'edg-experimental-reflection'`)
  - Some existing "installable" compilers versions have been removed (these could be changed to conform to the new naming convention in S3 or dropped as they're currently redundant)
 

I haven't tested this with a local instance of the Compiler Explorer front end yet. I intend to do so tomorrow but I'm opening this now to collect feedback; thanks.