### PR TITLE
Add nightly dex2oat compiler

### DIFF
--- a/bin/lib/installable/script.py
+++ b/bin/lib/installable/script.py
@@ -14,7 +14,7 @@ class ScriptInstallable(Installable):
         super().__init__(install_context, config)
         self.install_path = self.config_get("dir")
         self.install_path_symlink = self.config_get("symlink", False)
-        self.fetch = self.config_get("fetch")
+        self.fetch = self.config_get("fetch", [])
         self.script = self.config_get("script")
         self.strip = self.config_get("strip", False)
 

--- a/bin/yaml/android-java.yaml
+++ b/bin/yaml/android-java.yaml
@@ -10,3 +10,20 @@ compilers:
     url: https://dl.google.com/android/maven2/com/android/tools/r8/{name}/r8-{name}.jar
     targets:
       - 8.1.56
+
+  nightly:
+    if: nightly
+    type: script
+    dir: "{name}"
+    fetch:
+    script: |
+      mkdir {name}
+      cd {name}
+      sh {yaml_dir}/android-java/fetch_art_release_from_head.sh
+      unzip art_release.zip
+      rm art_release.zip
+    dex2oat:
+      targets:
+        - name: dex2oat-latest
+          target: dex2oat-latest
+          check_file: "x86_64/bin/dex2oat64"

--- a/bin/yaml/android-java/fetch_art_release_from_head.sh
+++ b/bin/yaml/android-java/fetch_art_release_from_head.sh
@@ -3,8 +3,8 @@
 # Fetches ART binaries and ART bootclasspath jars from AOSP head.
 # Saves the result at `art_release.zip`.
 
-set -e
+set -euo pipefail
 
 URL=https://ci.android.com/builds/latest/branches/aosp-main/targets/aosp_arm64-trunk_staging-userdebug/view/BUILD_INFO
 RURL=$(curl -Ls -o /dev/null -w "%{url_effective}" "${URL}")
-wget "${RURL%/view/BUILD_INFO}/raw/art_release.zip"
+curl "${RURL%/view/BUILD_INFO}/raw/art_release.zip" --location --output art_release.zip

--- a/bin/yaml/android-java/fetch_art_release_from_head.sh
+++ b/bin/yaml/android-java/fetch_art_release_from_head.sh
@@ -6,5 +6,5 @@
 set -e
 
 URL=https://ci.android.com/builds/latest/branches/aosp-main/targets/aosp_arm64-trunk_staging-userdebug/view/BUILD_INFO
-RURL=$(curl -Ls -o /dev/null -w %{url_effective} "${URL}")
+RURL=$(curl -Ls -o /dev/null -w "%{url_effective}" "${URL}")
 wget "${RURL%/view/BUILD_INFO}/raw/art_release.zip"

--- a/bin/yaml/android-java/fetch_art_release_from_head.sh
+++ b/bin/yaml/android-java/fetch_art_release_from_head.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Fetches ART binaries and ART bootclasspath jars from AOSP head.
+# Saves the result at `art_release.zip`.
+
+set -e
+
+URL=https://ci.android.com/builds/latest/branches/aosp-main/targets/aosp_arm64-trunk_staging-userdebug/view/BUILD_INFO
+RURL=$(curl -Ls -o /dev/null -w %{url_effective} "${URL}")
+wget "${RURL%/view/BUILD_INFO}/raw/art_release.zip"


### PR DESCRIPTION
This change adds dex2oat for Android as a nightly compiler. The zip file containing the compiler and other necessary artifacts is pulled from the latest AOSP build using the fetch_art_release_from_head.sh script.

The script has been uploaded into the android-java/ directory, and script.py has been modified to make the 'fetch' config optional.