### PR TITLE
Add vast-trunk compiler

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1235,3 +1235,16 @@ compilers:
         - name: 4.9.4
           tag: v2.6
           name_no_dots: 494
+    vast:
+      type: tarballs
+      check_exe: bin/vast-front --version
+      url: https://github.com/trailofbits/vast/releases/download/latest/VAST-0.0.0-x86_64-Linux.tar.xz
+      compression: xz
+      untar_dir: VAST-0.0.0-x86_64-Linux
+      dir: vast-trunk
+      path_name: vast-trunk
+      strip: true
+      targets:
+        - name: trunk
+          after_stage_script:
+            - chmod 0755 VAST-0.0.0-x86_64-Linux/bin/vast-front


### PR DESCRIPTION
## Goal

Provide Compiler Explorer functionality to facilitate experimentation with VAST,
an MLIR frontend for C/C++, based on the clang tooling.

## Presumed info needed to move forward

VAST serves as an experimental frontend, generating a stack of IRs 
based on MLIR (https://trailofbits.github.io/vast/), akin
to ClangIR. While leveraging most of the Clang infrastructure, it introduces a
custom frontend. By integrating with Compiler Explorer, we can inspect MLIR
files and experiment with the currently supported C/C++ languages.

It would be great if we can incorporate support for our project, thanks! :)

## Pull Requests

I have already created 2 PRs based on previous integrations:
infra: https://github.com/compiler-explorer/infra/pull/1209
compiler-explorer: https://github.com/compiler-explorer/compiler-explorer/pull/5973
