### PR TITLE
Add Flux library

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1131,6 +1131,15 @@ libraries:
         targets:
         - trunk
         type: github
+      flux:
+        build_type: none
+        check_file: README.md
+        method: nightlyclone
+        path_name: libs/flux
+        repo: tcbrindle/flux
+        targets:
+        - trunk
+        type: github
       fmt:
         build_type: cmake
         method: nightlyclone


### PR DESCRIPTION
This PR (hopefully?) adds support for [Flux](https://github.com/tcbrindle/flux), a header-only C++20 functional programming library

CE PR: https://github.com/compiler-explorer/compiler-explorer/pull/6000