### PR TITLE
Update LLVM Flang file names

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1194,9 +1194,9 @@ compilers:
           - ce-trunk
           - clangir-trunk
           - name: llvmflang-trunk
-            check_exe: bin/flang
+            check_exe: bin/flang-new --version
             after_stage_script:
-              - chmod 0755 bin/flang
+              - chmod 0755 bin/flang-to-external-fc
       mlir:
         type: nightly
         dir: "mlir-{name}"


### PR DESCRIPTION
The latest builds contain:
```
$ ./bin/flang-
flang-new             flang-to-external-fc
```

The project has shifted the names over time.

flang was a script that called out to gfortran, and flang-new was a compiler binary.

Then the flang script was renamed to flang-to-external-fc, but its purpose remained the same.

The project has been considering renaming flang-new to simply flang, but this has not happened yet.