### PR TITLE
Add install_always to dex2oat nightly

### DIFF
--- a/bin/yaml/android-java.yaml
+++ b/bin/yaml/android-java.yaml
@@ -12,6 +12,7 @@ compilers:
       - 8.1.56
 
   nightly:
+    install_always: true
     if: nightly
     type: script
     dir: "{name}"


### PR DESCRIPTION
This will fetch latest dex2oat regularly instead of skipping it because a version already exists.