### PR TITLE
feat: added Fortran stdlib

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -2344,6 +2344,14 @@ libraries:
       targets:
       - 8.3.0
       type: github
+    stdlib:
+      build_type: fpm
+      check_file: fpm.toml
+      repo: fortran-lang/stdlib
+      requires_tree_copy: true
+      targets:
+      - 'stdlib-fpm'
+      type: github
     nightly:
       forcompile:
         build_type: fpm


### PR DESCRIPTION
This PR adds the Fortran stdlib as an fpm package. The version of stdlib that is compatible with `fpm` lives on the `stdlib-fpm` branch and not the `main`, so I am not sure if I have setup the library correctly.