### PR TITLE
Build shared libraries for libscn

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1854,6 +1854,7 @@ libraries:
       - -DSCN_EXAMPLES=OFF
       - -DSCN_BENCHMARKS=OFF
       - -DSCN_DOCS=OFF
+      - -DBUILD_SHARED_LIBS=ON
       make_targets:
       - scn
       repo: eliaskosunen/scnlib

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1861,7 +1861,7 @@ libraries:
       targets:
       - '0.4'
       - 1.1.2
-      - v2.0.0
+      - 2.0.0
       type: github
     seastar:
       check_file: README.md

--- a/bin/yaml/rust.yaml
+++ b/bin/yaml/rust.yaml
@@ -88,6 +88,7 @@ compilers:
         - 1.73.0
         - 1.74.0
         - 1.75.0
+        - 1.76.0
       nightly:
         if: nightly
         targets:


### PR DESCRIPTION
add `-DBUILD_SHARED_LIBS=ON` to target options for libscn 2.0.0