### PR TITLE
Add native_aarch64 install option

### DIFF
--- a/bin/lib/ce_install.py
+++ b/bin/lib/ce_install.py
@@ -148,6 +148,7 @@ def squash_mount_check(rootfolder, subdir, context):
 )
 @click.option("--enable", metavar="TYPE", multiple=True, help='Enable targets of type TYPE (e.g. "nightly")')
 @click.option("--only-nightly", is_flag=True, help="Only install the nightly targets")
+@click.option("--only-native-aarch64", is_flag=True, help="Only install the Native Aarch64 targets")
 @click.option(
     "--cache",
     metavar="DIR",
@@ -196,6 +197,7 @@ def cli(
     dry_run: bool,
     enable: List[str],
     only_nightly: bool,
+    only_native_aarch64: bool,
     cache: Optional[Path],
     yaml_dir: Path,
     allow_unsafe_ssl: bool,
@@ -224,6 +226,7 @@ def cli(
         dry_run=dry_run,
         is_nightly_enabled="nightly" in enable,
         only_nightly=only_nightly,
+        only_native_aarch64=only_native_aarch64,
         cache=cache,
         yaml_dir=yaml_dir,
         allow_unsafe_ssl=allow_unsafe_ssl,

--- a/bin/lib/installable/installable.py
+++ b/bin/lib/installable/installable.py
@@ -109,6 +109,9 @@ class Installable:
         if self.install_context.only_nightly and not self.nightly_like:
             return False
 
+        if self.install_context.only_native_aarch64 and self.config_get("if", "") != "native_aarch64":
+            return False
+
         return self.install_always or not self.is_installed()
 
     def should_build(self):

--- a/bin/lib/installation_context.py
+++ b/bin/lib/installation_context.py
@@ -43,6 +43,7 @@ class InstallationContext:
         dry_run: bool,
         is_nightly_enabled: bool,
         only_nightly: bool,
+        only_native_aarch64: bool,
         cache: Optional[Path],
         yaml_dir: Path,
         allow_unsafe_ssl: bool,
@@ -58,6 +59,7 @@ class InstallationContext:
         self.dry_run = dry_run
         self.is_nightly_enabled = is_nightly_enabled
         self.only_nightly = only_nightly
+        self.only_native_aarch64 = only_native_aarch64
         retry_strategy = requests.adapters.Retry(
             total=10,
             backoff_factor=1,

--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1302,3 +1302,17 @@ compilers:
         - name: 4.9.4
           tag: v2.6
           name_no_dots: 494
+    native_aarch64:
+      if: native_aarch64
+      armofficial:
+        type: script
+        dir: "{subdir}/arm-clang-{name}"
+        check_file: "arm-linux-compiler-23.10_Ubuntu-22.04/llvm-bin/clang++"
+        subdir: native_aarch64
+        script: |
+          tar -xf "archive.tar" --strip-components=1
+          arm-compiler-for-linux_23.10_Ubuntu-22.04/arm-compiler-for-linux_23.10_Ubuntu-22.04.sh -a -i "{destination}/{dir}"
+        targets:
+          - name: 23.10
+            fetch:
+              - https://developer.arm.com/-/media/Files/downloads/hpc/arm-compiler-for-linux/23-10/arm-compiler-for-linux_23.10_Ubuntu-22.04_aarch64.tar archive.tar


### PR DESCRIPTION
Way to install aarch64 binaries under amd64 (doesn't execute the version check)
`bin/ce_install --enable native_aarch64 --only-native-aarch64 install ...`

Side-effect: will say things are already installed when they don't fall under the `if: native_aarch64` without actually checking
