### PR TITLE
Kokkos `4.3.0`

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -585,6 +585,8 @@ libraries:
       - 4.0.01
       - 4.1.00
       - 4.2.00
+      - 4.2.01
+      - 4.3.00
       type: github
     kumi:
       check_file: README.md


### PR DESCRIPTION
Add [the latest kokkos release `4.3.0`](https://github.com/kokkos/kokkos/releases/tag/4.3.00) and a missing minor release (`4.2.1`).