### PR TITLE
Add Solidity 0.8.25

### DIFF
--- a/bin/yaml/solidity.yaml
+++ b/bin/yaml/solidity.yaml
@@ -10,7 +10,7 @@ compilers:
       - 0.5.17
       - 0.6.12
       - 0.7.6
-      - 0.8.21
+      - 0.8.25
   solidity_eravm:
     type: singleFile
     dir: zksolc-{name}


### PR DESCRIPTION
https://github.com/ethereum/solidity/releases/tag/v0.8.25
https://binaries.soliditylang.org/linux-amd64/list.json

See https://github.com/compiler-explorer/infra/pull/1130#issuecomment-1774057910 for the explanation of overriding the previous version