### PR TITLE
Add bincode

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -2429,6 +2429,11 @@ libraries:
       targets:
       - 0.13.0
       type: cratesio
+    bincode:
+      build_type: cargo
+      targets:
+      - 1.3.3
+      type: cratesio
     bitflags:
       build_type: cargo
       targets:


### PR DESCRIPTION
Add the bincode library to Compiler Explorer as serialization is often performance sensitive, and having CE support to check the generated assembly for specific structs is very useful.

compiler-explorer repo PR is: https://github.com/compiler-explorer/compiler-explorer/pull/6404