### PR TITLE
Add the "nix" Rust crate

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -2669,6 +2669,11 @@ libraries:
       targets:
       - 0.15.4
       type: cratesio
+    nix:
+      build_type: cargo
+      targets:
+      - 0.28.0
+      type: cratesio
     num:
       build_type: cargo
       targets:


### PR DESCRIPTION
This PR adds the "nix" crate for Rust.

It's the infra part of https://github.com/compiler-explorer/compiler-explorer/issues/6212
Compiler explorer PR: https://github.com/compiler-explorer/compiler-explorer/pull/6472