### PR TITLE
[HLSL] Add DXC 1.8.2405 release

### DIFF
--- a/bin/yaml/hlsl.yaml
+++ b/bin/yaml/hlsl.yaml
@@ -11,6 +11,7 @@ compilers:
       type: s3tarballs
       check_exe: bin/dxc --version
       targets:
+        - "1.8.2405"
         - "1.8.2403.2"
         - "1.8.2403.1"
         - "1.8.2403"


### PR DESCRIPTION
This adds the latest DXC version 1.8.2405, the May 2024 release of DXC