### PR TITLE
Add dex2oat 33.10

### DIFF
--- a/bin/yaml/android-java.yaml
+++ b/bin/yaml/android-java.yaml
@@ -30,6 +30,10 @@ compilers:
       - "34.14"
       - "34.13"
       - "34.11"
+      # 33.10 doesn't support CMC or riscv64, so another script is used for boot images.
+      - name: "33.10"
+        after_stage_script:
+          - "{yaml_dir}/android-java/create_boot_images_old.sh"
 
   nightly:
     install_always: true

--- a/bin/yaml/android-java/create_boot_images_old.sh
+++ b/bin/yaml/android-java/create_boot_images_old.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Older ART versions do not support CMC or riscv64. Otherwise, this script is
+# identical to the create_boot_images.sh script.
+
+set -euo pipefail
+
+DIR_FOR_BOOT_IMAGE=app/system/framework    # Using /app directory, which is used for creating oat output in the compilation commands
+declare -a instruction_sets=("arm" "arm64" "x86" "x86_64")
+
+for instruction_set in "${instruction_sets[@]}"
+do
+    mkdir -p $DIR_FOR_BOOT_IMAGE/"$instruction_set"
+x86_64/bin/dex2oat64 \
+    --runtime-arg -Xms64m \
+    --runtime-arg -Xmx512m \
+    --runtime-arg -Xbootclasspath:bootjars/core-oj.jar:bootjars/core-libart.jar:bootjars/okhttp.jar:bootjars/bouncycastle.jar:bootjars/apache-xml.jar \
+    --runtime-arg -Xbootclasspath-locations:/apex/com.android.art/javalib/core-oj.jar:/apex/com.android.art/javalib/core-libart.jar:/apex/com.android.art/javalib/okhttp.jar:/apex/com.android.art/javalib/bouncycastle.jar:/apex/com.android.art/javalib/apache-xml.jar \
+    --instruction-set="$instruction_set" \
+    --compiler-filter=speed \
+    --dex-file=bootjars/core-oj.jar \
+    --dex-file=bootjars/core-libart.jar \
+    --dex-file=bootjars/okhttp.jar \
+    --dex-file=bootjars/bouncycastle.jar \
+    --dex-file=bootjars/apache-xml.jar \
+    --dex-location=/apex/com.android.art/javalib/core-oj.jar \
+    --dex-location=/apex/com.android.art/javalib/core-libart.jar \
+    --dex-location=/apex/com.android.art/javalib/okhttp.jar \
+    --dex-location=/apex/com.android.art/javalib/bouncycastle.jar \
+    --dex-location=/apex/com.android.art/javalib/apache-xml.jar \
+    --image=$DIR_FOR_BOOT_IMAGE/"$instruction_set"/boot.art \
+    --oat-file=$DIR_FOR_BOOT_IMAGE/"$instruction_set"/boot.oat \
+    --output-vdex=$DIR_FOR_BOOT_IMAGE/"$instruction_set"/boot.vdex \
+    --android-root=out/empty \
+    --abort-on-hard-verifier-error \
+    --no-abort-on-soft-verifier-error \
+    --compilation-reason=cloud \
+    --image-format=lz4 \
+    --force-determinism \
+    --resolve-startup-const-strings=true \
+    --avoid-storing-invocation \
+    --generate-mini-debug-info \
+    --force-allow-oj-inlines \
+    --no-watch-dog \
+    --base=0x70000000
+done

--- a/bin/yaml/android-java/create_boot_images_old.sh
+++ b/bin/yaml/android-java/create_boot_images_old.sh
@@ -30,7 +30,6 @@ x86_64/bin/dex2oat64 \
     --dex-location=/apex/com.android.art/javalib/apache-xml.jar \
     --image=$DIR_FOR_BOOT_IMAGE/"$instruction_set"/boot.art \
     --oat-file=$DIR_FOR_BOOT_IMAGE/"$instruction_set"/boot.oat \
-    --output-vdex=$DIR_FOR_BOOT_IMAGE/"$instruction_set"/boot.vdex \
     --android-root=out/empty \
     --abort-on-hard-verifier-error \
     --no-abort-on-soft-verifier-error \
@@ -40,7 +39,6 @@ x86_64/bin/dex2oat64 \
     --resolve-startup-const-strings=true \
     --avoid-storing-invocation \
     --generate-mini-debug-info \
-    --force-allow-oj-inlines \
     --no-watch-dog \
     --base=0x70000000
 done


### PR DESCRIPTION
This is an older version of dex2oat that will be helpful for
demonstrating some of the improvements made in version 34. A different
script for creating boot images has been added, as CMC GC and riscv64
aren't supported.