### PR TITLE
Add ZKsync solidity compiler 1.4.1 and 1.5.0

### DIFF
--- a/bin/yaml/solidity.yaml
+++ b/bin/yaml/solidity.yaml
@@ -11,11 +11,32 @@ compilers:
       - 0.6.12
       - 0.7.6
       - 0.8.25
-  solidity_eravm:
+  solidity_zksync:
+    type: singleFile
+    dir: zksync-solc-{name}
+    url: https://github.com/matter-labs/era-solidity/releases/download/{name}/solc-linux-amd64-{name}
+    filename: solc
+    check_exe: solc --version
+    targets:
+      - 0.4.26-1.0.1
+      - 0.5.17-1.0.1
+      - 0.6.12-1.0.1
+      - 0.7.6-1.0.1
+      - 0.8.25-1.0.1
+      - 0.8.26-1.0.1
+  zksolc:
     type: singleFile
     dir: zksolc-{name}
+    depends:
+      - compilers/solidity_zksync 0.4.26-1.0.1
+      - compilers/solidity_zksync 0.5.17-1.0.1
+      - compilers/solidity_zksync 0.6.12-1.0.1
+      - compilers/solidity_zksync 0.7.6-1.0.1
+      - compilers/solidity_zksync 0.8.25-1.0.1
+      - compilers/solidity_zksync 0.8.26-1.0.1
     url: https://github.com/matter-labs/era-compiler-solidity/releases/download/{name}/zksolc-linux-amd64-musl-v{name}
     filename: zksolc
     check_exe: zksolc --version
     targets:
-      - 1.4.0
+      - 1.4.1
+      - 1.5.0


### PR DESCRIPTION
## ZKsync solidity compiler

* [x] Adds two latest releases of **ZK**sync solidity compiler (`zksolc`) `v1.4.1` and `v1.5.0`.
* [x] Adds independent `solidity_zksync` (ZKsync fork of `solc`) that is used as a mandatory dependency