### PR TITLE
Add Beman.Optional26 library trunk version

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -955,6 +955,14 @@ libraries:
         targets:
         - trunk
         type: github
+      beman_optional26:
+        build_type: none
+        check_file: README.md
+        type: github
+        repo: beman-project/Optional26
+        method: nightlyclone
+        targets:
+        - main
       benchmark:
         build_type: cmake
         check_file: README.md


### PR DESCRIPTION
Add Beman.Optional26 library trunk version - #1348 

* `compiler-explorer` library request issue - [#6651](https://github.com/compiler-explorer/compiler-explorer/issues/6651) - PR [#6652](https://github.com/compiler-explorer/compiler-explorer/pull/6652).
* `Beman.Optional26` issue: [#21](https://github.com/beman-project/Optional26/issues/21)

=========================================================================================

* `Beman.Optional26` is a library within the [Beman Project](https://discourse.boost.org/), used by WG21 to get implementation experience for proposed library features for C++ latest versions.
* The library can be found at https://github.com/beman-project/Optional26. 
* Tested these changes on my local VM, Ubuntu 24.04, arm64 - check video with [local deployment of Beman.Optional26](https://github.com/compiler-explorer/infra/assets/8947836/075c29cf-1417-4110-beb3-caa46c21054d) inside Compiler Explorer:  
```shell
dariusn@pc:/opt/compiler-explorer/libs/beman_optional26$ ls -l
total 4
drwxrwxr-x 11 dariusn dariusn 4096 Jun 24 22:34 main
dariusn@pc:/opt/compiler-explorer/libs/beman_optional26$ ls -l main
total 60
-rw-rw-r-- 1 dariusn dariusn   158 Jun 24 22:34 CITATION.cff
-rw-rw-r-- 1 dariusn dariusn  1011 Jun 24 22:34 CMakeLists.txt
-rw-rw-r-- 1 dariusn dariusn  2949 Jun 24 22:34 CMakePresets.json
-rw-rw-r-- 1 dariusn dariusn 12263 Jun 24 22:34 LICENSE
-rwxrwxr-x 1 dariusn dariusn  2359 Jun 24 22:34 Makefile
-rw-rw-r-- 1 dariusn dariusn  3134 Jun 24 22:34 README.md
drwxrwxr-x 2 dariusn dariusn  4096 Jun 24 22:34 cmake
drwxrwxr-x 2 dariusn dariusn  4096 Jun 24 22:34 etc
drwxrwxr-x 2 dariusn dariusn  4096 Jun 24 22:34 examples
drwxrwxr-x 3 dariusn dariusn  4096 Jun 24 22:34 extern
drwxrwxr-x 3 dariusn dariusn  4096 Jun 24 22:34 include
drwxrwxr-x 3 dariusn dariusn  4096 Jun 24 22:34 papers
drwxrwxr-x 3 dariusn dariusn  4096 Jun 24 22:34 src
```

=========================================================================================

Notes: 
* It's not clear for me if the infrastructure will automatically re-install `main` version of this library over night (`nightly`). If not, but it can be done, please help me to adjust my diff.
* Currently we don't have an official release version. We would like to be able to play with latest `main` from Beman.Optional26 this week in WG21 Saint Louis meeting. Please help us to deploy this "alpha" version.



