### PR TITLE
Add rocm-6.0.2/6.1.2 to libraries.yaml

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -577,6 +577,8 @@ libraries:
       - 5.2.3
       - 5.3.2
       - 5.7.0
+      - 6.0.2
+      - 6.1.2
       type: s3tarballs
       untar_dir: hip-amd-rocm-{{name}}
     jsoncons:


### PR DESCRIPTION
currently /opt/compiler-explorer/libs/rocm/6.0.2 and /opt/compiler-explorer/libs/rocm/6.1.2 are missing at compiler-explorer, probably due to missing this change.