### PR TITLE
Add p3309 clang

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1350,6 +1350,7 @@ compilers:
           - clangir-trunk
           - bb-p2996-trunk
           - p3068-trunk
+          - p3309-trunk
           - dascandy-contracts-trunk
           - p1974-trunk
           - name: llvmflang-trunk


### PR DESCRIPTION
Adding experimental clang to support P3309 (constexpr atomic & atomic_ref)