### PR TITLE
Add Solidity 0.8.26

### DIFF
--- a/bin/yaml/solidity.yaml
+++ b/bin/yaml/solidity.yaml
@@ -11,6 +11,7 @@ compilers:
       - 0.6.12
       - 0.7.6
       - 0.8.25
+      - 0.8.26
   solidity_zksync:
     type: singleFile
     dir: zksync-solc-{name}


### PR DESCRIPTION
https://github.com/ethereum/solidity/releases/tag/v0.8.26
https://binaries.soliditylang.org/linux-amd64/list.json

Similar to `compilers.solidity_zksync` I added Solidity 0.8.26. Also why is https://solidity.godbolt.org still using the old compiler version 0.8.21 which is not the same as what is in this file?