### PR TITLE
Add C3 0.5.5, 0.6.0 and 0.6.1

### DIFF
--- a/bin/yaml/c3.yaml
+++ b/bin/yaml/c3.yaml
@@ -8,7 +8,7 @@ compilers:
     create_untar_dir: true
     check_exe: c3c --version
     targets:
-      - name: 0.4.pre
+      - name: 0.4.0
         url: https://github.com/c3lang/c3c/releases/download/0.4godbolt-v2/c3-ubuntu-20.tar.gz
       - name: 0.5.0
         url: https://github.com/c3lang/c3c/releases/download/release_0.5/c3-ubuntu-20.tar.gz

--- a/bin/yaml/c3.yaml
+++ b/bin/yaml/c3.yaml
@@ -8,7 +8,13 @@ compilers:
     create_untar_dir: true
     check_exe: c3c --version
     targets:
-      - name: 0.4
+      - name: 0.4.pre
         url: https://github.com/c3lang/c3c/releases/download/0.4godbolt-v2/c3-ubuntu-20.tar.gz
-      - name: 0.5
+      - name: 0.5.0
         url: https://github.com/c3lang/c3c/releases/download/release_0.5/c3-ubuntu-20.tar.gz
+      - name: 0.5.5
+        url: https://github.com/c3lang/c3c/releases/download/v0.5.5/c3-ubuntu-20-0.5.5.tar.gz
+      - name: 0.6.0
+        url: https://github.com/c3lang/c3c/releases/download/v0.6.0/c3-ubuntu-20.tar.gz
+      - name: 0.6.1
+        url: https://github.com/c3lang/c3c/releases/download/v0.6.1/c3-ubuntu-20.tar.gz


### PR DESCRIPTION
This renames C3 0.4 to 0.4.pre and 0.5 to 0.5.0 (which was the actual version running). It also adds 0.5.5 (last 0.5 version) and 0.6.0 and 0.6.1 (latest released version)