### PR TITLE
Add C3 0.5.5, 0.6.0 and 0.6.1 versions.

### DIFF
--- a/bin/yaml/c3.yaml
+++ b/bin/yaml/c3.yaml
@@ -12,3 +12,9 @@ compilers:
         url: https://github.com/c3lang/c3c/releases/download/0.4godbolt-v2/c3-ubuntu-20.tar.gz
       - name: 0.5
         url: https://github.com/c3lang/c3c/releases/download/release_0.5/c3-ubuntu-20.tar.gz
+      - name: 0.5.5
+        url: https://github.com/c3lang/c3c/releases/download/v0.5.5/c3-ubuntu-20-0.5.5.tar.gz
+      - name: 0.6.0
+        url: https://github.com/c3lang/c3c/releases/download/v0.6.0/c3-ubuntu-20.tar.gz
+      - name: 0.6.1
+        url: https://github.com/c3lang/c3c/releases/download/v0.6.1/c3-ubuntu-20.tar.gz


### PR DESCRIPTION
This adds 0.5.5, 0.6.0 and 0.6.1 versions of C3.