### PR TITLE
Add clang-cl tarballs to windows.yaml

### DIFF
--- a/bin/yaml/windows.yaml
+++ b/bin/yaml/windows.yaml
@@ -19,6 +19,14 @@ windows:
             url: https://github.com/brechtsanders/winlibs_mingw/releases/download/{name}/winlibs-x86_64-posix-seh-gcc-12.1.0-llvm-14.0.6-mingw-w64ucrt-10.0.0-r3.zip
           - name: "11.3.0-14.0.3-10.0.0-ucrt-r3"
             url: https://github.com/brechtsanders/winlibs_mingw/releases/download/{name}/winlibs-x86_64-posix-seh-gcc-11.3.0-llvm-14.0.3-mingw-w64ucrt-10.0.0-r3.zip
+      clang-cl:
+        type: tarballs
+        dir: "clang-cl-{name}"
+        folder: "clang-cl"
+        check_file: "bin/clang-cl.exe"
+        target:
+          - name: "18.1.0"
+            url: https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.0/clang+llvm-18.1.0-x86_64-pc-windows-msvc.tar.xz
   tools:
     cmake:
       type: ziparchive


### PR DESCRIPTION
This patch adds Clang release archive with binaries to `windows.yaml`