### PR TITLE
add quill C++ library

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1928,7 +1928,7 @@ libraries:
       method: clone_branch
       repo: odygrd/quill
       targets:
-        - v6.1.0
+        - v6.1.1
       type: github
     raberu:
       check_file: README.md

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1922,6 +1922,14 @@ libraries:
         url: https://download.qt.io/official_releases/qt/6.6/6.6.0/submodules/qtbase-everywhere-src-6.6.0.tar.xz
       type: tarballs
       untar_dir: qtbase-everywhere-src-{{name}}
+    quill:
+      build_type: none
+      check_file: quill/include/quill/Backend.h
+      method: clone_branch
+      repo: odygrd/quill
+      targets:
+        - v6.1.0
+      type: github
     raberu:
       check_file: README.md
       repo: jfalcou/raberu


### PR DESCRIPTION
[quill](https://github.com/odygrd/quill) is a header-only C++ logging library