### PR TITLE
Add Kokkos 4.3.01 and 4.4.00

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -672,6 +672,8 @@ libraries:
       - 4.2.00
       - 4.2.01
       - 4.3.00
+      - 4.3.01
+      - 4.4.00
       type: github
     kumi:
       check_file: README.md


### PR DESCRIPTION
Add [the latest kokkos release 4.4.0](https://github.com/kokkos/kokkos/releases/tag/4.4.00) and a missing minor release (4.3.01).