### PR TITLE
Installation for Triton

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1,4 +1,12 @@
 libraries:
+  triton:
+    triton-shared:
+      type: tarballs
+      dir: triton-shared-{name}
+      compression: gz
+      url: https://github.com/microsoft/triton-shared/archive/refs/heads/main.tar.gz
+      targets:
+      - 'main'
   android-java:
     android-api-stubs:
       check_file: android.jar

--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -98,6 +98,22 @@ tools:
     check_exe: bin/osaca --version
     targets:
       - 0.5.2
+  wheel:
+    type: pip
+    dir: wheel-{name}
+    python: /usr/bin/python3
+    package: wheel=={name}
+    check_exe: wheel version
+    targets:
+      - 0.43.0
+  pybind11:
+    type: pip
+    dir: pybind11-{name}
+    python: /usr/bin/python3
+    package: pybind11=={name}
+    check_exe: bin/pybind11-config --version
+    targets:
+      - 2.13.5
   rustfmt:
     type: tarballs
     dir: rustfmt-{name}

--- a/bin/yaml/triton.yaml
+++ b/bin/yaml/triton.yaml
@@ -1,0 +1,22 @@
+compilers:
+  triton:
+    type: tarballs
+    dir: triton-{name}
+    depends:
+      - tools/cmake 3.29.2
+      - tools/ninja 1.11.1
+      - tools/wheel 0.43.0
+      - tools/pybind11 2.13.5
+      - compilers/c++/clang 18.1.0
+      - libraries/triton/triton-shared main
+    compression: gz
+    check_exe: python3 venv/lib/python3.12/site-packages/triton/tools/compile.py -h
+    url: https://github.com/triton-lang/triton/archive/refs/tags/v{name}.tar.gz
+    targets:
+      - 2.1.0
+    after_stage_script:
+      - cd triton-{name}
+      - python3 -m venv venv
+      - source venv/bin/activate
+      - cd python
+      - TRITON_BUILD_WITH_CLANG_LLD=true TRITON_PLUGIN_DIRS=/opt/compiler-explorer/triton-shared-main pip install -e .


### PR DESCRIPTION
Hello All,
This PR Integrates Triton (https://github.com/triton-lang/triton) to compiler explorer's infra. It also includes CPU backend from https://github.com/microsoft/triton-shared 

It almost works, I see the following:
```
$ ./bin/ce_install install triton
...
Successfully built triton
Installing collected packages: filelock, triton
Successfully installed filelock-3.16.0 triton-2.1.0
2024-09-16 02:40:59,801 lib.installation_context INFO     Moving from staging (/opt/compiler-explorer/staging/ed9924e0-5a73-46b5-aa3b-6a24632e455d/triton-2.1.0) to final destination (/opt/compiler-explorer/triton-2.1.0)
2024-09-16 02:40:59,831 lib.installation_context INFO     Destination /opt/compiler-explorer/triton-2.1.0 exists, temporarily moving out of the way (to /opt/compiler-explorer/staging/ed9924e0-5a73-46b5-aa3b-6a24632e455d.orig)
2024-09-16 02:40:59,831 lib.installation_context INFO     Removing temporarily moved /opt/compiler-explorer/staging/ed9924e0-5a73-46b5-aa3b-6a24632e455d.orig
2024-09-16 02:41:00,036 lib.ce_install  ERROR    compilers/triton 2.1.0 installed OK, but doesn't appear as installed after
Installing libraries/triton/triton-shared main
2024-09-16 02:41:00,036 lib.ce_install  INFO     libraries/triton/triton-shared main is already installed, skipping
0 packages installed OK, 1 skipped, and 1 failed installation
Failed:
  compilers/triton 2.1.0
```

What am missing?

Besides that, I am open for discussion, let me know what you think!
Thank you!