### PR TITLE
Add Fortran Package Manager (library)

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -2518,6 +2518,14 @@ libraries:
       - 0.1.1
       type: github
   fortran:
+    fpm:
+      build_type: fpm
+      check_file: fpm.toml
+      repo: fortran-lang/fpm
+      requires_tree_copy: true
+      targets:
+      - 0.10.1
+      type: github
     http_client:
       build_type: fpm
       check_file: fpm.toml


### PR DESCRIPTION
This change adds Fpm (https://github.com/fortran-lang/fpm) for use as a library/dependency. See also https://github.com/compiler-explorer/compiler-explorer/issues/6884