### PR TITLE
Add last 3 stable Dart releases

### DIFF
--- a/bin/yaml/dart.yaml
+++ b/bin/yaml/dart.yaml
@@ -9,6 +9,9 @@ compilers:
       - find -executable -print0 | xargs -0 chmod og+x
     url: https://storage.googleapis.com/dart-archive/channels/stable/release/{name}/sdk/dartsdk-linux-x64-release.zip
     targets:
+      - 3.5.3
+      - 3.4.4
+      - 3.3.4
       - 3.2.2
       - 3.1.3
       - 3.0.2


### PR DESCRIPTION
Versions retrieved from https://dart.dev/get-dart/archive.

Thanks for taking a look!