### PR TITLE
Add glslang trunk

### DIFF
--- a/bin/yaml/glsl.yaml
+++ b/bin/yaml/glsl.yaml
@@ -1,0 +1,10 @@
+compilers:
+  glsl:
+    glslang:
+      type: ziparchive
+      dir: glslang-{name}
+      url: https://github.com/KhronosGroup/glslang/releases/download/main-tot/glslang-main-linux-Release.zip
+      folder: bin
+      check_exe: glslang --version
+      targets:
+        - trunk

--- a/bin/yaml/glsl.yaml
+++ b/bin/yaml/glsl.yaml
@@ -3,6 +3,8 @@ compilers:
     glslang:
       type: ziparchive
       dir: glslang-{name}
+      if: nightly
+      install_always: true
       url: https://github.com/KhronosGroup/glslang/releases/download/main-tot/glslang-main-linux-Release.zip
       folder: bin
       check_exe: glslang --version


### PR DESCRIPTION
for https://github.com/compiler-explorer/compiler-explorer/pull/6883

confirmed locally this grabs the rolling release and creates a `glslang-trunk` going `./bin/ce_install glsl`