### PR TITLE
LLVM Flang: Check "flang" binary instead of "flang-new"

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1407,7 +1407,7 @@ compilers:
           - p1974-trunk
           - ericwf-contracts-trunk
           - name: llvmflang-trunk
-            check_exe: bin/flang-new --version
+            check_exe: bin/flang --version
       mlir:
         type: nightly
         dir: "mlir-{name}"


### PR DESCRIPTION
Since https://github.com/llvm/llvm-project/commit/06eb10dadfaeaadc5d0d95d38bea4bfb5253e077 the flang binary is named "flang" not "flang-new".

There is now a symlink "flang-new" -> "flang", but I don't see any reason not to move to "flang" now. The symlink will be removed in a couple of releases time anyway.

Relevant log from the last nightly build:
```
2024-10-11T01:27:26.5073126Z -- Installing: /root/staging/bin/flang-20
2024-10-11T01:27:26.7519042Z -- Installing: /root/staging/bin/flang
2024-10-11T01:27:26.7519829Z -- Set runtime path of "/root/staging/bin/flang-20" to "$ORIGIN/../lib"
2024-10-11T01:27:26.7520792Z -- Up-to-date: /root/staging/bin/flang-20
2024-10-11T01:27:26.7521292Z -- Up-to-date: /root/staging/bin/flang
2024-10-11T01:27:26.7543999Z -- Creating flang-new
```