### PR TITLE
Add mimic++ as c++ header-only library

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -898,6 +898,7 @@ libraries:
       - '3'
       - '2'
       - '1'
+      type: github
     mlir:
       check_file: include/mlir/InitAllPasses.h
       path_name: libs/mlir/{name}

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -890,6 +890,14 @@ libraries:
       targets:
       - '4.7'
       type: github
+    mimicpp:
+      check_file: README.md
+      repo: DNKpp/mimicpp
+      target_prefix: v
+      targets:
+      - '3'
+      - '2'
+      - '1'
     mlir:
       check_file: include/mlir/InitAllPasses.h
       path_name: libs/mlir/{name}

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1483,6 +1483,13 @@ libraries:
         targets:
         - trunk
         type: github
+      mimicpp:
+        check_file: README.md
+        method: nightlyclone
+        repo: DNKpp/mimicpp
+        targets:
+        - trunk
+        type: github
       mlir:
         check_file: include/mlir/InitAllPasses.h
         path_name: libs/mlir/{name}


### PR DESCRIPTION
I tested this locally and it worked, but I'm not sure about the ``nightly`` part.

relates to: https://github.com/compiler-explorer/compiler-explorer/pull/6960