### PR TITLE
use OSACA v0.6.1

### DIFF
--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -109,7 +109,7 @@ tools:
     package: osaca=={name}
     check_exe: bin/osaca --version
     targets:
-      - 0.5.2
+      - 0.6.1
   rustfmt:
     type: tarballs
     dir: rustfmt-{name}


### PR DESCRIPTION
Updated OSACA from v0.5.2 to v0.6.1, which includes bug fixes, more supported instructions for existing architectures and new architectures like Intel Sapphire Rapids, Nvidia Grace Superchip/Neoverse V2, and AMD Zen 4.

See also the related PR in [compiler-explorer/#6961](https://github.com/compiler-explorer/compiler-explorer/pull/6961)