### PR TITLE
[LIBRARY_REQUEST] beman_optional26: fix deployment after the library was renamed inside the Beman project

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1019,7 +1019,7 @@ libraries:
         build_type: none
         check_file: README.md
         type: github
-        repo: beman-project/Optional26
+        repo: beman-project/optional26
         method: nightlyclone
         targets:
         - main


### PR DESCRIPTION
[LIBRARY_REQUEST] beman_optional26: fix deployment after the library was renamed inside the Beman project

Related to #1348.
Library was introduced here https://github.com/compiler-explorer/infra/pull/1347.

Current naming -> https://github.com/beman-project/optional26/tree/main/include/beman/optional26.