### PR TITLE
Add scnlib v2.0.3, v3.0.2, and v4.0.1

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -2028,6 +2028,9 @@ libraries:
       - '0.4'
       - 1.1.2
       - 2.0.0
+      - 2.0.3
+      - 3.0.2
+      - 4.0.1
       type: github
     seastar:
       check_file: README.md


### PR DESCRIPTION
The latest included release, v2.0.0, is from this January. This PR updates the included versions.

Main repo PR: https://github.com/compiler-explorer/compiler-explorer/pull/7061