### PR TITLE
rename beman_iterator to beman_iterator_interface

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1024,6 +1024,14 @@ libraries:
         targets:
         - trunk
         type: github
+      beman_iterator:
+        build_type: none
+        check_file: README.md
+        type: github
+        repo: beman-project/iterator_interface
+        method: nightlyclone
+        targets:
+        - main
       beman_optional26:
         build_type: none
         check_file: README.md

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1026,7 +1026,15 @@ libraries:
         - trunk
         type: github
       beman_iterator_interface:
-        build_type: none
+        build_type: cmake
+        extra_cmake_arg:
+        - -DBUILD_TESTING=OFF
+        package_install: true
+        lib_type: static
+        staticliblink:
+        - beman.iterator_interface
+        after_stage_script:
+        - sed -i 's/add_subdirectory(examples)//g' CMakeLists.txt
         check_file: README.md
         type: github
         repo: beman-project/iterator_interface

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1024,7 +1024,7 @@ libraries:
         targets:
         - trunk
         type: github
-      beman_iterator:
+      beman_iterator_interface:
         build_type: none
         check_file: README.md
         type: github


### PR DESCRIPTION
#1445

Previous PR: https://github.com/compiler-explorer/infra/pull/1446 

Per discussion in https://github.com/beman-project/iterator_interface/issues/6, we would like to rename this library to beman_iterator_interface