### PR TITLE
Add library clad (clang plugin)

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -233,6 +233,20 @@ libraries:
       targets:
       - 5.5.2
       type: github
+    clad:
+      type: github
+      repo: vgvassilev/clad
+      build_type: cmake
+      extra_cmake_arg:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DLLVM_DIR=/opt/compiler-explorer/libs/llvm/18.1.0/build
+      use_compiler: clang1810
+      depends:
+      - libraries/c++/llvm 18.1.0
+      package_install: true
+      target_prefix: v
+      targets:
+        - 1.7
     cli11:
       build_type: none
       check_file: include/CLI/CLI.hpp


### PR DESCRIPTION
Clad is a source-transformation automatic differentiation (AD) library for C++,
implemented as a plugin for the Clang compiler.
Source at https://github.com/vgvassilev/clad