### PR TITLE
Changes for NVIDIA HPC SDK 24.11

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1363,7 +1363,7 @@ compilers:
           version: "24.9"
           dot_removed_version: "249"
           year: "2024"
-          ctk_ver: "12.6.1"
+          ctk_ver: "12.6"
           fetch:
             - https://developer.download.nvidia.com/hpc-sdk/{version}/nvhpc_{year}_{dot_removed_version}_Linux_{arch}_cuda_{ctk_ver}.tar.gz nvhpc_sdk_{version}_{arch}.tar.gz
         - name: x86_64_24_11
@@ -1371,7 +1371,7 @@ compilers:
           version: "24.11"
           dot_removed_version: "2411"
           year: "2024"
-          ctk_ver: "12.6.2"
+          ctk_ver: "12.6"
           fetch:
             - https://developer.download.nvidia.com/hpc-sdk/{version}/nvhpc_{year}_{dot_removed_version}_Linux_{arch}_cuda_{ctk_ver}.tar.gz nvhpc_sdk_{version}_{arch}.tar.gz
     nightly:

--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1363,7 +1363,15 @@ compilers:
           version: "24.9"
           dot_removed_version: "249"
           year: "2024"
-          ctk_ver: "12.6"
+          ctk_ver: "12.6.1"
+          fetch:
+            - https://developer.download.nvidia.com/hpc-sdk/{version}/nvhpc_{year}_{dot_removed_version}_Linux_{arch}_cuda_{ctk_ver}.tar.gz nvhpc_sdk_{version}_{arch}.tar.gz
+        - name: x86_64_24_11
+          arch: x86_64
+          version: "24.11"
+          dot_removed_version: "2411"
+          year: "2024"
+          ctk_ver: "12.6.2"
           fetch:
             - https://developer.download.nvidia.com/hpc-sdk/{version}/nvhpc_{year}_{dot_removed_version}_Linux_{arch}_cuda_{ctk_ver}.tar.gz nvhpc_sdk_{version}_{arch}.tar.gz
     nightly:

--- a/bin/yaml/cuda.yaml
+++ b/bin/yaml/cuda.yaml
@@ -77,3 +77,5 @@ compilers:
         build: 555.42.06
       - name: 12.6.1
         build: 560.35.03
+      - name: 12.6.2
+        build: 560.35.03


### PR DESCRIPTION
Fixed incorrect URL definition in bin/yaml/cpp.yaml for HCP SDK 24.11
