### PR TITLE
Update Kokkos 4.4.01 and 4.5.00

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -695,6 +695,8 @@ libraries:
       - 4.3.00
       - 4.3.01
       - 4.4.00
+      - 4.4.01
+      - 4.5.00
       type: github
     kumi:
       check_file: README.md


### PR DESCRIPTION
Add [the latest minor kokkos release 4.5.00](https://github.com/kokkos/kokkos/releases/tag/4.5.00) and a missing patch release (4.4.01).