### PR TITLE
Add vulkan-sdk

### DIFF
--- a/bin/yaml/khronos.yaml
+++ b/bin/yaml/khronos.yaml
@@ -18,3 +18,13 @@ compilers:
         check_exe: "bin/clspv --version"
         targets:
           - main
+  vulkan-sdk:
+    type: tarballs
+    dir: vulkan-sdk/v{name}
+    strip_components: 1
+    create_untar_dir: true
+    url: https://sdk.lunarg.com/sdk/download/{name}/linux/vulkansdk-linux-x86_64-{name}.tar.xz
+    compression: xz
+    check_exe: ./x86_64/bin/spirv-cross --help
+    targets:
+      - 1.3.296.0


### PR DESCRIPTION
CC @spencer-lunarg this adds a single version of the vulkan SDK. We can add as many versions as we like in the `target:` list.

Ends up with a directory structure like:

```
$ ls /opt/compiler-explorer/vulkan-sdk/v1.3.296.0/x86_64/bin/
dxa@      dxl-3.7*    dxv@                         gfxrecon-convert*   gfxrecon-replay*   llvm-tblgen*  spirv-cfg*          spirv-lint*     spirv-reflect-pp*  vkcubepp*
dxa-3.7*  dxopt@      dxv-3.7*                     gfxrecon-extract*   gfx.slang          slangc*       spirv-cross*        spirv-objdump*  spirv-remap*       vkcube-wayland*
dxc@      dxopt-3.7*  gfxrecon-capture.py*         gfxrecon-info*      glslang*           slangd*       spirv-dis*          spirv-opt*      spirv-val*         vkvia*
dxc-3.7*  dxr@        gfxrecon-capture-vulkan.py*  gfxrecon-optimize*  glslangValidator@  slang.slang   spirv-lesspipe.sh*  spirv-reduce*   vkconfig*          vulkanCapsViewer*
dxl@      dxr-3.7*    gfxrecon-compress*           gfxrecon.py*        glslc*             spirv-as*     spirv-link*         spirv-reflect*  vkcube*            vulkaninfo*
```

which includes `spirv-reflect` and `spirv-cross`, both of which run with no `ldd`-related issues. I can't vouch for how they run when actually pointed at code etc.

Part of #1444