### PR TITLE
Add autofs and install cefs configuration

### DIFF
--- a/setup-admin.sh
+++ b/setup-admin.sh
@@ -14,7 +14,23 @@ fi
 
 env EXTRA_NFS_ARGS="" INSTALL_TYPE="admin" "${DIR}/setup-common.sh"
 
-apt -y install mosh fish jq cronic subversion upx gdb autojump zlib1g-dev m4 python3 python3-venv python3.8 python3.8-venv libc6-dev-i386
+apt -y install \
+  autojump \
+  cronic \
+  fish \
+  gdb \
+  jq \
+  libc6-dev-i386 \
+  m4 \
+  mosh \
+  python3 \
+  python3-venv \
+  python3.8 \
+  python3.8-venv \
+  squashfs-tools-ng \
+  subversion \
+  upx \
+  zlib1g-dev
 chsh ubuntu -s /usr/bin/fish
 
 cd /home/ubuntu/infra

--- a/setup-common.sh
+++ b/setup-common.sh
@@ -25,6 +25,7 @@ apt-get -y update
 apt-get -y dist-upgrade --force-yes
 
 apt-get -y install \
+  autofs \
   jq \
   libc6-arm64-cross \
   libdatetime-perl \
@@ -45,7 +46,6 @@ hash -r pip
 
 # This returns amd64 or arm64
 ARCH=$(dpkg --print-architecture)
-
 
 if [ "$INSTALL_TYPE" != 'ci' ]; then
   mkdir /tmp/aws-install
@@ -187,3 +187,11 @@ aws s3 sync s3://compiler-explorer/authorized_keys /tmp/auth_keys
 cat /tmp/auth_keys/* >>/home/ubuntu/.ssh/authorized_keys
 rm -rf /tmp/auth_keys
 chown -R ubuntu /home/ubuntu/.ssh
+
+setup_cefs() {
+    mkdir /cefs
+    echo "* -fstype=squashfs,loop,nosuid,nodev,ro :/efs/cefs-images/&.sqfs" > /etc/auto.cefs
+    echo "/cefs /etc/auto.cefs --negative-timeout 1" > /etc/auto.master.d/cefs.autofs
+    service autofs restart
+}
+setup_cefs

--- a/terraform/lc.tf
+++ b/terraform/lc.tf
@@ -1,6 +1,6 @@
 locals {
   image_id                 = "ami-0cfaa1f31737d26b4"
-  staging_image_id         = "ami-0cfaa1f31737d26b4"
+  staging_image_id         = "ami-0410d305cc1eac4c1"
   beta_image_id            = "ami-0cfaa1f31737d26b4"
   gpu_image_id             = "ami-0e49c31db87fb4332"
   aarch64prod_image_id     = "ami-0940f416984ac4e8b"


### PR DESCRIPTION
Extracted part of #798 

Large formatting changes are only me adding autofs and sorted the lines (even though the python versions seem ... odd I haven't touched that).

cefs changes tested and only affect paths pointing at `/cefs` which will automount stuff in `/efs/cefs-images`