### PR TITLE
Add Mdspan Reference Implementation

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -896,6 +896,13 @@ libraries:
       targets:
       - 0.7.3
       type: github
+    mdspan:
+      check_file: include/mdspan/mdspan.hpp
+      repo: kokkos/mdspan
+      targets:
+      - 0.6
+      build_type: none
+      type: github
     mfem:
       build_type: cmake
       lib_type: static


### PR DESCRIPTION
Adds the mdspan reference implementation.

The repo is at: https://github.com/kokkos/mdspan
The Conan package file is at: https://conan.io/center/recipes/mdspan

There would also be a trunk version, which I haven't added yet.

I am unsure if this PR contains everything to open a PR at CE for library inclusion of Mdspan. It is my first PR for the CE project. Thanks for this wonderful and insightful website.   

Adding the reference implementation would be helpful because the compiler support seems lagging. The c++23 support matrix indicates that mdpsan is supported, but I still can't get it to compile on CE: https://godbolt.org/z/vnbvbhdM4 