### PR TITLE
upgrade mimic++ header-only library

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -923,6 +923,9 @@ libraries:
       repo: DNKpp/mimicpp
       target_prefix: v
       targets:
+      - '6'
+      - '5'
+      - '4'
       - '3'
       - '2'
       - '1'


### PR DESCRIPTION
Adds v4, v5 and v6.

related to: [compiler-explorer/compiler-explorer](https://github.com/compiler-explorer/compiler-explorer/pull/7259)