### PR TITLE
[swift]: add support for dev snapshots and add 6.1

### DIFF
--- a/bin/yaml/swift.yaml
+++ b/bin/yaml/swift.yaml
@@ -36,6 +36,17 @@ compilers:
           - '5.9'
           - '5.10'
           - '6.0.3'
+    dev-snapshot:
+      dir: swift-dev-snapshot
+      type: restQueryTarballs
+      install_always: true
+      url: https://download.swift.org/swift-{name}-branch/ubuntu2204/latest-build.yml
+      query: |
+        'https://download.swift.org/swift-{name}-branch/ubuntu2204' \
+        + '/' + document['dir'] \
+        + '/' + document['download']
+      targets:
+        - '6.1'
     nightly:
       if: nightly
       type: restQueryTarballs

--- a/bin/yaml/swift.yaml
+++ b/bin/yaml/swift.yaml
@@ -36,25 +36,20 @@ compilers:
           - '5.9'
           - '5.10'
           - '6.0.3'
-    dev-snapshot:
-      dir: swift-dev-snapshot
-      type: restQueryTarballs
-      install_always: true
-      url: https://download.swift.org/swift-{name}-branch/ubuntu2204/latest-build.yml
-      query: |
-        'https://download.swift.org/swift-{name}-branch/ubuntu2204' \
-        + '/' + document['dir'] \
-        + '/' + document['download']
-      targets:
-        - '6.1'
     nightly:
       if: nightly
       type: restQueryTarballs
       install_always: true
-      url: https://download.swift.org/development/ubuntu2004/latest-build.yml
+      toolchain: development
+      url: https://download.swift.org/{toolchain}/ubuntu2004/latest-build.yml
       query: |
-        'https://download.swift.org/development/ubuntu2004/' \
-        + document['download'].replace('-ubuntu20.04.tar.gz', '') \
+        'https://download.swift.org/{toolchain}/ubuntu2004' \
+        + '/' + document['dir'] \
         + '/' + document['download']
       targets:
         - nightly
+      dev-snapshot:
+        dir: swift-dev-snapshot
+        toolchain: swift-{name}-branch
+        targets:
+          - '6.1'


### PR DESCRIPTION
- adds a new 'dev-snapshot' nightly config entry
- configures this to output these dev compilers to a `swift-dev-snapshot` directory
- sets the current target to fetch Swift 6.1 dev snapshots. this value is expected to need to be updated when new future releases are cut