### PR TITLE
Remove single-`{` handling entirely - jinja across the board

### DIFF
--- a/.idea/terraform.xml
+++ b/.idea/terraform.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="TerraformProjectSettings">
+    <option name="toolPath" value="$USER_HOME$/.ozy/bin/terraform" />
+  </component>
+</project>

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
-    "python.defaultInterpreterPath": ".env/bin/python"
+    "python.defaultInterpreterPath": ".env/bin/python",
+    "python.testing.pytestArgs": [
+        "bin"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
 }

--- a/bin/lib/config_expand.py
+++ b/bin/lib/config_expand.py
@@ -29,7 +29,7 @@ def is_value_type(value: Any) -> bool:
 
 
 def string_needs_expansion(value: str) -> bool:
-    return "{" in value
+    return "{%" in value or "{{" in value or "{#" in value
 
 
 def needs_expansion(target: MutableMapping[str, Any]) -> bool:
@@ -45,8 +45,7 @@ def needs_expansion(target: MutableMapping[str, Any]) -> bool:
 
 def expand_one(template_string: str, configuration: Mapping[str, Any]) -> str:
     try:
-        jinjad = _JINJA_ENV.from_string(template_string).render(**configuration)
-        return jinjad.format(**configuration)
+        return _JINJA_ENV.from_string(template_string).render(**configuration)
     except jinja2.exceptions.TemplateError:
         # in python 3.11 we would...
         # e.add_note(f"Template '{template_string}'")
@@ -54,7 +53,7 @@ def expand_one(template_string: str, configuration: Mapping[str, Any]) -> str:
         raise
 
 
-def expand_target(target: MutableMapping[str, Any], context):
+def expand_target(target: MutableMapping[str, Any], context: list[str]) -> MutableMapping[str, str]:
     iterations = 0
     while needs_expansion(target):
         iterations += 1

--- a/bin/lib/config_expand.py
+++ b/bin/lib/config_expand.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, MutableMapping
+from typing import Any, Mapping, MutableMapping
 
 import jinja2
 
@@ -28,19 +28,22 @@ def is_value_type(value: Any) -> bool:
     )
 
 
-def needs_expansion(target):
+def string_needs_expansion(value: str) -> bool:
+    return "{" in value
+
+
+def needs_expansion(target: MutableMapping[str, Any]) -> bool:
     for value in target.values():
         if is_list_of_strings(value):
-            for v in value:
-                if "{" in v:
-                    return True
+            if any(string_needs_expansion(v) for v in value):
+                return True
         elif isinstance(value, str):
-            if "{" in value:
+            if string_needs_expansion(value):
                 return True
     return False
 
 
-def expand_one(template_string, configuration):
+def expand_one(template_string: str, configuration: Mapping[str, Any]) -> str:
     try:
         jinjad = _JINJA_ENV.from_string(template_string).render(**configuration)
         return jinjad.format(**configuration)

--- a/bin/lib/installation.py
+++ b/bin/lib/installation.py
@@ -29,7 +29,7 @@ def targets_from(node, enabled, base_config=None):
 
 
 def _check_if(enabled, node) -> bool:
-    if "if" not in node:
+    if "if" not in node or enabled is True:
         return True
     if isinstance(node["if"], list):
         condition = set(node["if"])

--- a/bin/test/config_expand_test.py
+++ b/bin/test/config_expand_test.py
@@ -1,6 +1,35 @@
-from lib.config_expand import expand_one
+import re
+
+import pytest
+from lib.config_expand import expand_one, expand_target
 
 
 def test_expand_one():
     assert expand_one("moo", {}) == "moo"
-    assert expand_one("a{badger}b", {"badger": "moose"}) == "amooseb"
+    assert expand_one("a{{badger}}b", {"badger": "moose"}) == "amooseb"
+
+
+def test_expand_one_ignores_single_braces():
+    assert expand_one("a{badger}b", {"badger": "moose"}) == "a{badger}b"
+
+
+def test_expand_one_allows_escapes():
+    assert expand_one("a{% raw %}{badger}{% endraw %}b", {"badger": "moose"}) == "a{badger}b"
+
+
+def test_expand_target_handles_self_references():
+    assert expand_target({"sponge": "bob_{{bob}}", "bob": "robert"}, []) == {"sponge": "bob_robert", "bob": "robert"}
+
+
+def test_expand_target_handles_multiple_self_references():
+    assert expand_target({"sponge": "bob_{{bob}}", "bob": "{{ian}}", "ian": "will{{iam}}", "iam": "y"}, []) == {
+        "sponge": "bob_willy",
+        "bob": "willy",
+        "ian": "willy",
+        "iam": "y",
+    }
+
+
+def test_expand_target_handles_infinite_recursion():
+    with pytest.raises(RuntimeError, match=re.escape("Too many mutual references (in moo/shmoo)")):
+        assert expand_target({"bob": "{{ian}}", "ian": "ooh{{bob}}"}, ["moo", "shmoo"])

--- a/bin/test/installation_test.py
+++ b/bin/test/installation_test.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import pytest
@@ -64,11 +65,11 @@ def test_codependent_configs():
         """
 compilers:
   gcc:
-    check_exe: "bin/{arch_prefix}/blah"
+    check_exe: "bin/{{arch_prefix}}/blah"
     subdir: arm
     mips:
-      arch_prefix: "{subdir}-arch"
-      check_exe: "{arch_prefix}/blah"
+      arch_prefix: "{{subdir}}-arch"
+      check_exe: "{{arch_prefix}}/blah"
       targets:
         - name: 5.4.0
           subdir: mips
@@ -78,13 +79,13 @@ compilers:
 
 
 def test_codependent_throws():
-    with pytest.raises(RuntimeError, match=r"Too many mutual references \(in compilers/mips\)"):
+    with pytest.raises(RuntimeError, match=re.escape("Too many mutual references (in compilers/mips)")):
         parse_targets(
             """
 compilers:
   mips:
-    x: "{y}"
-    y: "{x}"
+    x: "{{y}}"
+    y: "{{x}}"
     targets:
       - name: 5.4.0
         subdir: mips
@@ -166,7 +167,7 @@ def test_jinja_expansion_with_filters_refering_forward():
         """
 boost:
   underscore_name: "{{ name | replace('.', '_') }}"
-  url: https://dl.bintray.com/boostorg/release/{name}/source/boost_{underscore_name}.tar.bz2
+  url: https://dl.bintray.com/boostorg/release/{{name}}/source/boost_{{underscore_name}}.tar.bz2
   targets:
     - 1.64.0
       """

--- a/bin/yaml/ada.yaml
+++ b/bin/yaml/ada.yaml
@@ -2,13 +2,13 @@ compilers:
   ada:
     gnat:
       type: tarballs
-      untar_dir: "gnat-{target}-linux64-{name}"
-      dir: "{subdir}/gnat-{target}-linux64-{name}"
-      url: https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-{version}/gnat-{target}-linux64-{version}.tar.gz
+      untar_dir: "gnat-{{target}}-linux64-{{name}}"
+      dir: "{{subdir}}/gnat-{{target}}-linux64-{{name}}"
+      url: https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-{{version}}/gnat-{{target}}-linux64-{{version}}.tar.gz
       compression: gz
-      check_exe: bin/{toolprefix}gcc -v
+      check_exe: bin/{{toolprefix}}gcc -v
       check_stderr_on_stdout: true
-      name: "{version}"
+      name: "{{version}}"
 
       arm:
         subdir: arm

--- a/bin/yaml/android-java.yaml
+++ b/bin/yaml/android-java.yaml
@@ -1,13 +1,13 @@
 compilers:
   android-d8:
     type: singleFile
-    dir: r8-{name}
+    dir: r8-{{name}}
     depends:
       - compilers/java 16.0.1
       - compilers/kotlin 1.9.20 # d8 runs on .class files, so kotlinc is applicable as well.
-    check_exe: "%DEP0%/bin/java -cp {dir}/{filename} com.android.tools.r8.D8 --version"
-    filename: r8-{name}.jar
-    url: https://dl.google.com/android/maven2/com/android/tools/r8/{name}/r8-{name}.jar
+    check_exe: "%DEP0%/bin/java -cp {{dir}}/{{filename}} com.android.tools.r8.D8 --version"
+    filename: r8-{{name}}.jar
+    url: https://dl.google.com/android/maven2/com/android/tools/r8/{{name}}/r8-{{name}}.jar
     targets:
       - 8.7.18
       - 8.7.14
@@ -25,12 +25,12 @@ compilers:
       - 8.1.56
   dex2oat:
     type: ziparchive
-    dir: dex2oat-{name}
+    dir: dex2oat-{{name}}
     extract_into_folder: true
     check_file: "x86_64/bin/dex2oat64"
-    url: https://dl.google.com/android/maven2/com/android/art/art/{name}/art-{name}.zip
+    url: https://dl.google.com/android/maven2/com/android/art/art/{{name}}/art-{{name}}.zip
     after_stage_script:
-      - "{yaml_dir}/android-java/create_boot_images.sh"
+      - "{{yaml_dir}}/android-java/create_boot_images.sh"
     targets:
       - "35.11"
       - "35.10"
@@ -46,20 +46,20 @@ compilers:
       # 33.10 doesn't support CMC or riscv64, so another script is used for boot images.
       - name: "33.10"
         after_stage_script:
-          - "{yaml_dir}/android-java/create_boot_images_old.sh"
+          - "{{yaml_dir}}/android-java/create_boot_images_old.sh"
 
   nightly:
     install_always: true
     if: nightly
     type: script
-    dir: "{name}"
+    dir: "{{name}}"
     script: |
-      mkdir {name}
-      cd {name}
-      {yaml_dir}/android-java/fetch_art_release_from_head.sh
+      mkdir {{name}}
+      cd {{name}}
+      {{yaml_dir}}/android-java/fetch_art_release_from_head.sh
       unzip art_release.zip
       rm art_release.zip
-      {yaml_dir}/android-java/create_boot_images.sh
+      {{yaml_dir}}/android-java/create_boot_images.sh
     dex2oat:
       targets:
         - name: dex2oat-latest

--- a/bin/yaml/c.yaml
+++ b/bin/yaml/c.yaml
@@ -18,16 +18,16 @@ compilers:
       check_exe:
         - /bin/bash
         - -c
-        - "/usr/bin/env PYTHONPATH=$(pwd)/ppci-{name} $(command -v python3) -B -mppci --version"
-      dir: ppci-{name}
-      untar_dir: ppci-{name}
-      url: https://pypi.io/packages/source/p/ppci/ppci-{name}.tar.gz
+        - "/usr/bin/env PYTHONPATH=$(pwd)/ppci-{{name}} $(command -v python3) -B -mppci --version"
+      dir: ppci-{{name}}
+      untar_dir: ppci-{{name}}
+      url: https://pypi.io/packages/source/p/ppci/ppci-{{name}}.tar.gz
       targets:
         - 0.5.5
     cc65:
       type: s3tarballs
       subdir: '6502'
-      s3_path_prefix: cc65-{name}
+      s3_path_prefix: cc65-{{name}}
       check_exe: bin/cc65 --version
       check_stderr_on_stdout: true
       targets:
@@ -44,20 +44,20 @@ compilers:
       type: tarballs
       compression: gz
       subdir: upmem-dpu
-      dir: "{subdir}/upmem-{name}-Linux-x86_64"
-      untar_dir: "upmem-{name}-Linux-x86_64"
+      dir: "{{subdir}}/upmem-{{name}}-Linux-x86_64"
+      untar_dir: "upmem-{{name}}-Linux-x86_64"
       check_exe: bin/clang --version
-      url: http://sdk-releases.upmem.com/{name}/ubuntu_22.04/upmem-{name}-Linux-x86_64.tar.gz
+      url: http://sdk-releases.upmem.com/{{name}}/ubuntu_22.04/upmem-{{name}}-Linux-x86_64.tar.gz
       targets:
         - 2023.2.0
     sdcc:
       type: tarballs
       compression: bz2
-      dir: sdcc-{name}
+      dir: sdcc-{{name}}
       check_exe: bin/sdcc --version
-      url: https://downloads.sourceforge.net/project/sdcc/sdcc-linux-amd64/{name}/sdcc-{name}-amd64-unknown-linux2.5.tar.bz2
+      url: https://downloads.sourceforge.net/project/sdcc/sdcc-linux-amd64/{{name}}/sdcc-{{name}}-amd64-unknown-linux2.5.tar.bz2
       older:
-        untar_dir: sdcc-{name}
+        untar_dir: sdcc-{{name}}
         targets:
           - 4.0.0
           - 4.2.0
@@ -76,7 +76,7 @@ compilers:
       if: nightly
       cc65:
         subdir: '6502'
-        s3_path_prefix: cc65-{name}
+        s3_path_prefix: cc65-{{name}}
         check_exe: bin/cc65 --version
         type: nightly
         targets:
@@ -103,11 +103,11 @@ compilers:
       arch_prefix:
 
       compcert:
-        s3_path_prefix: "ccomp-{name}-{arch}"
+        s3_path_prefix: "ccomp-{{name}}-{{arch}}"
         check_exe: "bin/ccomp --version"
-        untar_dir: "CompCert-{arch}-{name}"
+        untar_dir: "CompCert-{{arch}}-{{name}}"
         subdir: "compcert"
-        path_name: "{subdir}/CompCert-{arch}-{name}"
+        path_name: "{{subdir}}/CompCert-{{arch}}-{{name}}"
         x86_32:
           arch: "x86_32"
           targets:
@@ -124,17 +124,17 @@ compilers:
             - "3.9"
 
       gcc:
-        s3_path_prefix: "{subdir}-gcc-{name}"
-        path_name: "{subdir}/gcc-{name}"
-        untar_dir: "gcc-{name}"
-        check_exe: "bin/{arch_prefix}-gcc --version"
+        s3_path_prefix: "{{subdir}}-gcc-{{name}}"
+        path_name: "{{subdir}}/gcc-{{name}}"
+        untar_dir: "gcc-{{name}}"
+        check_exe: "bin/{{arch_prefix}}-gcc --version"
         arm64morello:
           type: tarballs
           subdir: arm64morello
           arch_prefix: aarch64-none-elf
           create_untar_dir: True
-          dir: arm64morello/{name}
-          untar_dir: '{name}'
+          dir: arm64morello/{{name}}
+          untar_dir: '{{name}}'
           compression: xz
           targets:
               - name: gcc-aarch64-none-elf-10.1.morello-alp1-x86_64
@@ -146,7 +146,7 @@ compilers:
         msp430:
           arch_prefix: "msp430-unknown-elf"
           subdir: msp430
-          check_exe: "{arch_prefix}/bin/{arch_prefix}-gcc --version"
+          check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-gcc --version"
           targets:
             - 12.1.0
             - 12.2.0

--- a/bin/yaml/c3.yaml
+++ b/bin/yaml/c3.yaml
@@ -2,7 +2,7 @@ compilers:
   c3:
     type: tarballs
     compression: gz
-    dir: c3-{name}
+    dir: c3-{{name}}
     folder: linux
     strip_components: 1
     create_untar_dir: true

--- a/bin/yaml/circle.yaml
+++ b/bin/yaml/circle.yaml
@@ -5,8 +5,8 @@ compilers:
     check_exe: circle --version
     create_untar_dir: true
     strip: true
-    url: https://circle-lang.org/linux/build_{name}.tgz
-    dir: circle-{name}
+    url: https://circle-lang.org/linux/build_{{name}}.tgz
+    dir: circle-{{name}}
     targets:
       - '128'
       - '129'

--- a/bin/yaml/clean.yaml
+++ b/bin/yaml/clean.yaml
@@ -2,10 +2,10 @@ compilers:
   clean:
     type: tarballs
     compression: gz
-    url: https://ftp.cs.ru.nl/Clean/Clean{name_no_dots}/linux/clean{name}{suffix}.tar.gz
+    url: https://ftp.cs.ru.nl/Clean/Clean{{name_no_dots}}/linux/clean{{name}}{{suffix}}.tar.gz
     check_exe: bin/patch_bin /dev/null installation_test
     check_stderr_on_stdout: true
-    dir: clean32-{name}
+    dir: clean32-{{name}}
     strip_components: 1
     create_untar_dir: true
     clean32_old:
@@ -19,7 +19,7 @@ compilers:
       targets:
         - '3.0'
     clean64:
-      dir: clean64-{name}
+      dir: clean64-{{name}}
       suffix: _64
       targets:
         - name: '2.4'

--- a/bin/yaml/cobol.yaml
+++ b/bin/yaml/cobol.yaml
@@ -2,8 +2,8 @@ compilers:
  cobol:
    subdir: cobol
    gnucobol:
-     path_name: "{subdir}/gnucobol-{name}"
-     s3_path_prefix: "gnucobol-{name}"
+     path_name: "{{subdir}}/gnucobol-{{name}}"
+     s3_path_prefix: "gnucobol-{{name}}"
      type: s3tarballs
      check_exe: bin/cobc --version
      targets:

--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -88,17 +88,17 @@ compilers:
       type: s3tarballs
       arch_prefix:
       gcc:
-        s3_path_prefix: "{subdir}-gcc-{name}"
-        path_name: "{subdir}/gcc-{name}"
-        untar_dir: "gcc-{name}"
-        check_exe: "bin/{arch_prefix}-g++ --version"
+        s3_path_prefix: "{{subdir}}-gcc-{{name}}"
+        path_name: "{{subdir}}/gcc-{{name}}"
+        untar_dir: "gcc-{{name}}"
+        check_exe: "bin/{{arch_prefix}}-g++ --version"
         subdir: arm
         arm-wince:
-          path_name: "{subdir}/gcc-ce-{name}"
+          path_name: "{{subdir}}/gcc-ce-{{name}}"
           arch_prefix: arm-mingw32ce
           subdir: arm-wince
-          untar_dir: "gcc-ce-{name}"
-          s3_path_prefix: "gcc-ce-{name}"
+          untar_dir: "gcc-ce-{{name}}"
+          s3_path_prefix: "gcc-ce-{{name}}"
           targets:
             - 8.2.0
         arm:
@@ -106,7 +106,7 @@ compilers:
             targets:
               - 4.5.4
               - 4.6.4
-          - check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          - check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
             arch_prefix: arm-unknown-linux-gnueabi
             targets:
               - 6.3.0
@@ -115,7 +115,7 @@ compilers:
               - 7.5.0
               - 8.2.0
               - 8.5.0
-          - check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          - check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
             arch_prefix: arm-unknown-linux-gnueabihf
             targets:
               - 5.4.0
@@ -140,12 +140,12 @@ compilers:
               - 14.1.0
               - 14.2.0
             arm-unknown:
-              - check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
-                path_name: "{subdir}/gcc-arm-unknown-{name}"
-                s3_path_prefix: "arm-unknown-gcc-{name}"
+              - check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
+                path_name: "{{subdir}}/gcc-arm-unknown-{{name}}"
+                s3_path_prefix: "arm-unknown-gcc-{{name}}"
                 arch_prefix: arm-unknown-eabi
-                dir: arm/gcc-arm-unknown-eabi-{name}
-                untar_dir: gcc-{name}
+                dir: arm/gcc-arm-unknown-eabi-{{name}}
+                untar_dir: gcc-{{name}}
                 targets:
                   - 13.2.0
                   - 13.3.0
@@ -237,18 +237,18 @@ compilers:
           - type: tarballs
             frc:
               compression: gz
-              dir: arm/frc{year}-{name}
-              check_exe: bin/arm-frc{year}-linux-gnueabi-g++ --version
+              dir: arm/frc{{year}}-{{name}}
+              check_exe: bin/arm-frc{{year}}-linux-gnueabi-g++ --version
               untar_dir: roborio-academic
-              url: https://github.com/wpilibsuite/opensdk/releases/download/v{year}-{build}/cortexa9_vfpv3-roborio-academic-{year}-x86_64-linux-gnu-Toolchain-{name}.tgz
+              url: https://github.com/wpilibsuite/opensdk/releases/download/v{{year}}-{{build}}/cortexa9_vfpv3-roborio-academic-{{year}}-x86_64-linux-gnu-Toolchain-{{name}}.tgz
               targets:
                 - year: 2023
                   build: 9
                   name: 12.1.0
               older:
-                check_exe: roborio/bin/arm-frc{year}-linux-gnueabi-g++ --version
-                untar_dir: frc{year}
-                url: https://github.com/wpilibsuite/toolchain-builder/releases/download/v{year}-{build}/FRC-{year}-Linux-Toolchain-{name}.tar.gz
+                check_exe: roborio/bin/arm-frc{{year}}-linux-gnueabi-g++ --version
+                untar_dir: frc{{year}}
+                url: https://github.com/wpilibsuite/toolchain-builder/releases/download/v{{year}}-{{build}}/FRC-{{year}}-Linux-Toolchain-{{name}}.tar.gz
                 targets:
                   - year: 2019
                     build: 3
@@ -256,23 +256,23 @@ compilers:
                   - year: 2020
                     build: 1
                     name: 7.3.0
-                    url: https://github.com/wpilibsuite/roborio-toolchain/releases/download/v{year}-{build}/FRC-{year}-Linux-Toolchain-{name}.tar.gz
+                    url: https://github.com/wpilibsuite/roborio-toolchain/releases/download/v{{year}}-{{build}}/FRC-{{year}}-Linux-Toolchain-{{name}}.tar.gz
           - type: tarballs
             arduino:
               check_exe: hardware/tools/avr/bin/avr-g++ --version
               compression: xz
-              dir: avr/arduino-{name}
-              untar_dir: arduino-{name}
-              url: http://downloads.arduino.cc/arduino-{name}-linux64.tar.xz
+              dir: avr/arduino-{{name}}
+              untar_dir: arduino-{{name}}
+              url: http://downloads.arduino.cc/arduino-{{name}}-linux64.tar.xz
               targets:
                 - 1.8.9
           - type: tarballs
             raspbian:
-              check_exe: bin/arm-raspbian{dist}-linux-gnueabihf-g++ --version
+              check_exe: bin/arm-raspbian{{dist}}-linux-gnueabihf-g++ --version
               compression: gz
-              dir: arm/raspbian{dist}-{name}
-              untar_dir: raspbian{dist}
-              url: https://github.com/wpilibsuite/raspbian-toolchain/releases/download/v{build}/Raspbian{dist}-Linux-Toolchain-{name}.tar.gz
+              dir: arm/raspbian{{dist}}-{{name}}
+              untar_dir: raspbian{{dist}}
+              url: https://github.com/wpilibsuite/raspbian-toolchain/releases/download/v{{build}}/Raspbian{{dist}}-Linux-Toolchain-{{name}}.tar.gz
               targets:
                 - dist: 9
                   build: 1.3.0
@@ -283,47 +283,47 @@ compilers:
         avr:
           arch_prefix: avr
           subdir: avr
-          untar_dir: "avr-gcc-{name}"
+          untar_dir: "avr-gcc-{{name}}"
           targets:
             - name: 4.5.4
-              untar_dir: "gcc-{name}"
+              untar_dir: "gcc-{{name}}"
             - name: 4.6.4
-              untar_dir: "gcc-{name}"
+              untar_dir: "gcc-{{name}}"
             - 9.2.0
             - 9.3.0
             - 10.3.0
             - 11.1.0
             - name: 12.1.0
-              untar_dir: "gcc-{name}"
-              check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+              untar_dir: "gcc-{{name}}"
+              check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
             - name: 12.2.0
-              untar_dir: "gcc-{name}"
-              check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+              untar_dir: "gcc-{{name}}"
+              check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
             - name: 12.3.0
-              untar_dir: "gcc-{name}"
-              check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+              untar_dir: "gcc-{{name}}"
+              check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
             - name: 12.4.0
-              untar_dir: "gcc-{name}"
-              check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+              untar_dir: "gcc-{{name}}"
+              check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
             - name: 13.1.0
-              untar_dir: "gcc-{name}"
-              check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+              untar_dir: "gcc-{{name}}"
+              check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
             - name: 13.2.0
-              untar_dir: "gcc-{name}"
-              check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+              untar_dir: "gcc-{{name}}"
+              check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
             - name: 13.3.0
-              untar_dir: "gcc-{name}"
-              check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+              untar_dir: "gcc-{{name}}"
+              check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
             - name: 14.1.0
-              untar_dir: "gcc-{name}"
-              check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+              untar_dir: "gcc-{{name}}"
+              check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
             - name: 14.2.0
-              untar_dir: "gcc-{name}"
-              check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+              untar_dir: "gcc-{{name}}"
+              check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
 
         arm64:
           arch_prefix: aarch64-unknown-linux-gnu
-          check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
           subdir: arm64
           eabi:
             arch_prefix: aarch64-unknown-linux-gnueabi
@@ -367,7 +367,7 @@ compilers:
               - trunk
         bpf:
           arch_prefix: "bpf-unknown-none"
-          check_exe: "{arch_prefix}/bin/bpf-unknown-g++ --version"
+          check_exe: "{{arch_prefix}}/bin/bpf-unknown-g++ --version"
           subdir: bpf
           targets:
             - 13.1.0
@@ -383,8 +383,8 @@ compilers:
             targets:
               - trunk
         mips:
-          - arch_prefix: "{subdir}-unknown-linux-gnu"
-            check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          - arch_prefix: "{{subdir}}-unknown-linux-gnu"
+            check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
             mips:
               subdir: mips
               targets:
@@ -404,16 +404,16 @@ compilers:
                 - 14.2.0
             mipsel:
               subdir: mipsel
-              arch_prefix: "{subdir}-multilib-linux-gnu"
+              arch_prefix: "{{subdir}}-multilib-linux-gnu"
               targets:
                 - name: 4.9.4
-                  arch_prefix: "{subdir}-unknown-linux-gnu"
+                  arch_prefix: "{{subdir}}-unknown-linux-gnu"
                 - name: 5.4.0
-                  arch_prefix: "{subdir}-unknown-linux-gnu"
+                  arch_prefix: "{{subdir}}-unknown-linux-gnu"
                 - name: 5.5.0
-                  arch_prefix: "{subdir}-unknown-linux-gnu"
+                  arch_prefix: "{{subdir}}-unknown-linux-gnu"
                 - name: 9.5.0
-                  arch_prefix: "{subdir}-unknown-linux-gnu"
+                  arch_prefix: "{{subdir}}-unknown-linux-gnu"
                 - 12.1.0
                 - 12.2.0
                 - 12.3.0
@@ -442,16 +442,16 @@ compilers:
                 - 14.2.0
             mips64el:
               subdir: mips64el
-              arch_prefix: "{subdir}-multilib-linux-uclibc"
+              arch_prefix: "{{subdir}}-multilib-linux-uclibc"
               targets:
                 - name: 4.9.4
-                  arch_prefix: "{subdir}-unknown-linux-gnu"
+                  arch_prefix: "{{subdir}}-unknown-linux-gnu"
                 - name: 5.5.0
-                  arch_prefix: "{subdir}-unknown-linux-gnu"
+                  arch_prefix: "{{subdir}}-unknown-linux-gnu"
                 - name: 5.4.0
-                  arch_prefix: "{subdir}-unknown-linux-gnu"
+                  arch_prefix: "{{subdir}}-unknown-linux-gnu"
                 - name: 9.5.0
-                  arch_prefix: "{subdir}-unknown-linux-gnu"
+                  arch_prefix: "{{subdir}}-unknown-linux-gnu"
                 - 12.1.0
                 - 12.2.0
                 - 12.3.0
@@ -484,7 +484,7 @@ compilers:
         m68k:
           subdir: m68k
           arch_prefix: m68k-unknown-elf
-          check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
           targets:
             - 13.1.0
             - 13.2.0
@@ -497,8 +497,8 @@ compilers:
             type: nightlytarballs
             subdir: mrisc32
             arch_prefix: "mrisc32-elf"
-            check_exe: "mrisc32-gnu-toolchain/bin/{arch_prefix}-g++ --version"
-            dir: mrisc32-{name}
+            check_exe: "mrisc32-gnu-toolchain/bin/{{arch_prefix}}-g++ --version"
+            dir: mrisc32-{{name}}
             create_untar_dir: true
             url: https://gitlab.com/mrisc32/mrisc32-gnu-toolchain/-/releases/permalink/latest/downloads/mrisc32-gnu-toolchain-linux-x86_64.tar.gz
             compression: gz
@@ -513,8 +513,8 @@ compilers:
             type: tarballs
             strip: true
             compression: bz2
-            untar_dir: msp430-gcc-{name}_linux{arch}
-            dir: msp430-gcc-{name}_linux{arch}
+            untar_dir: msp430-gcc-{{name}}_linux{{arch}}
+            dir: msp430-gcc-{{name}}_linux{{arch}}
             check_exe: bin/msp430-elf-g++ --version
             targets:
               - name: 5.3.0.219
@@ -527,7 +527,7 @@ compilers:
                 rev: 5_00_00_00
         riscv64:
           arch_prefix: "riscv64-unknown-linux-gnu"
-          check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
           subdir: riscv64
           targets:
             - 8.2.0
@@ -556,7 +556,7 @@ compilers:
               - trunk
         riscv32:
           arch_prefix: "riscv32-unknown-elf"
-          check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
           subdir: riscv32
           targets:
             - 8.2.0
@@ -595,7 +595,7 @@ compilers:
               - trunk
         k1:
           arch_prefix: "k1-unknown-elf"
-          check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
           subdir: k1
           targets:
             - 7.4.1
@@ -603,11 +603,11 @@ compilers:
         kvx:
           type: tarballs
           compression: gz
-          untar_dir: gcc-kalray-kvx-v{name}
-          dir: "kvx/acb-{name}"
+          untar_dir: gcc-kalray-kvx-v{{name}}
+          dir: "kvx/acb-{{name}}"
           arch_prefix: kvx-elf
-          url: https://github.com/kalray/build-scripts/releases/download/v{name}/gcc-kalray-kvx-v{name}.tar.gz
-          check_exe: "bin/{arch_prefix}-g++ --version"
+          url: https://github.com/kalray/build-scripts/releases/download/v{{name}}/gcc-kalray-kvx-v{{name}}.tar.gz
+          check_exe: "bin/{{arch_prefix}}-g++ --version"
           targets:
             - 4.1.0-cd1
             - 4.1.0-rc6
@@ -619,17 +619,17 @@ compilers:
             - 4.9.0
             - 4.10.0
             - name: 4.11.1
-              url: https://github.com/kalray/build-scripts/releases/download/v{name}/gcc-kalray-kvx-ubuntu-20.04-v{name}.tar.gz
+              url: https://github.com/kalray/build-scripts/releases/download/v{{name}}/gcc-kalray-kvx-ubuntu-20.04-v{{name}}.tar.gz
             - name: 4.12.0
-              url: https://github.com/kalray/build-scripts/releases/download/v{name}/gcc-kalray-kvx-ubuntu-20.04-v{name}.tar.gz
+              url: https://github.com/kalray/build-scripts/releases/download/v{{name}}/gcc-kalray-kvx-ubuntu-20.04-v{{name}}.tar.gz
             - name: 5.0.0
-              url: https://github.com/kalray/build-scripts/releases/download/v{name}/gcc-kalray-kvx-ubuntu-22.04-v{name}.tar.gz
+              url: https://github.com/kalray/build-scripts/releases/download/v{{name}}/gcc-kalray-kvx-ubuntu-22.04-v{{name}}.tar.gz
             - name: 5.2.0
-              url: https://github.com/kalray/build-scripts/releases/download/v{name}/gcc-kalray-kvx-ubuntu-22.04-v{name}.tar.gz
+              url: https://github.com/kalray/build-scripts/releases/download/v{{name}}/gcc-kalray-kvx-ubuntu-22.04-v{{name}}.tar.gz
 
         s390x:
-          arch_prefix: "{subdir}-ibm-linux-gnu"
-          check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          arch_prefix: "{{subdir}}-ibm-linux-gnu"
+          check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
           subdir: s390x
           targets:
             - 11.2.0
@@ -644,7 +644,7 @@ compilers:
             - 14.2.0
         sh:
           arch_prefix: "sh-unknown-elf"
-          check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
           subdir: sh
           targets:
             - 4.9.4
@@ -659,7 +659,7 @@ compilers:
             - 14.2.0
         c6x:
           arch_prefix: "tic6x-elf"
-          check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
           subdir: c6x
           targets:
             - 12.2.0
@@ -672,13 +672,13 @@ compilers:
             - 14.2.0
         hppa:
           arch_prefix: "hppa-unknown-linux-gnu"
-          check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
           subdir: hppa
           targets:
             - 14.2.0
         sparc:
           arch_prefix: "sparc-unknown-linux-gnu"
-          check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
           subdir: sparc
           targets:
             - 12.2.0
@@ -691,7 +691,7 @@ compilers:
             - 14.2.0
         sparc64:
           arch_prefix: "sparc64-multilib-linux-gnu"
-          check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
           subdir: sparc64
           targets:
             - 12.2.0
@@ -704,7 +704,7 @@ compilers:
             - 14.2.0
         sparc-leon:
           arch_prefix: "sparc-leon-linux-uclibc"
-          check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
           subdir: sparc-leon
           targets:
             - 12.2.0-1
@@ -716,8 +716,8 @@ compilers:
             - 14.1.0
             - 14.2.0
         loongarch64:
-          arch_prefix: "{subdir}-unknown-linux-gnu"
-          check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          arch_prefix: "{{subdir}}-unknown-linux-gnu"
+          check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
           subdir: loongarch64
           targets:
             - 12.2.0
@@ -729,13 +729,13 @@ compilers:
             - 14.1.0
             - 14.2.0
         powerpc:
-          arch_prefix: "{subdir}-unknown-linux-gnu"
-          check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          arch_prefix: "{{subdir}}-unknown-linux-gnu"
+          check_exe: "{{arch_prefix}}/bin/{{arch_prefix}}-g++ --version"
           powerpc:
             subdir: powerpc
             targets:
               - name: 4.8.5
-                check_exe: "{arch_prefix}/bin/g++ --version"
+                check_exe: "{{arch_prefix}}/bin/g++ --version"
               - 11.2.0
               - 12.1.0
               - 12.2.0
@@ -796,32 +796,32 @@ compilers:
         vax:
           subdir: vax
           type: s3tarballs
-          path_name: "{subdir}/gcc-{name}"
-          s3_path_prefix: "gcc-vax--netbsdelf-{name}"
-          untar_dir: "gcc-vax--netbsdelf-{name}"
+          path_name: "{{subdir}}/gcc-{{name}}"
+          s3_path_prefix: "gcc-vax--netbsdelf-{{name}}"
+          untar_dir: "gcc-vax--netbsdelf-{{name}}"
           check_exe: "bin/vax--netbsdelf-g++ --version"
           targets:
             - name: 10.4.0
-              s3_path_prefix: "vax-netbsdelf-gcc-{name}"
-              untar_dir: "gcc-{name}"
+              s3_path_prefix: "vax-netbsdelf-gcc-{{name}}"
+              untar_dir: "gcc-{{name}}"
             - name: 10.5.0-2023-11-16
         xtensa:
           subdir: xtensa
-          url: https://github.com/espressif/crosstool-NG/releases/download/esp-{name}/{arch_prefix}-{release_name}-{host_type}.tar.{compression}
-          untar_dir: "{arch_prefix}"
-          dir: "xtensa/{arch_prefix}-{release_name}"
-          check_exe: "bin/{arch_prefix}-g++ --version"
+          url: https://github.com/espressif/crosstool-NG/releases/download/esp-{{name}}/{{arch_prefix}}-{{release_name}}-{{host_type}}.tar.{{compression}}
+          untar_dir: "{{arch_prefix}}"
+          dir: "xtensa/{{arch_prefix}}-{{release_name}}"
+          check_exe: "bin/{{arch_prefix}}-g++ --version"
           type: tarballs
           compression: gz
           host_type: linux-amd64
-          release_name: "gcc{base}-esp-{name}"
+          release_name: "gcc{{base}}-esp-{{name}}"
           esp:
             arch_prefix: xtensa-esp-elf
             targets:
               - name: 14.2.0_20241119
                 base: "14.2.0_20241119"
                 host_type: x86_64-linux-gnu
-                release_name: "{base}"
+                release_name: "{{base}}"
                 compression: xz
           esp32:
             arch_prefix: xtensa-esp32-elf
@@ -844,7 +844,7 @@ compilers:
               - name: 12.2.0_20230208
                 base: "12.2.0_20230208"
                 host_type: x86_64-linux-gnu
-                release_name: "{base}"
+                release_name: "{{base}}"
                 compression: xz
           esp32s2:
             arch_prefix: xtensa-esp32s2-elf
@@ -867,7 +867,7 @@ compilers:
               - name: 12.2.0_20230208
                 base: "12.2.0_20230208"
                 host_type: x86_64-linux-gnu
-                release_name: "{base}"
+                release_name: "{{base}}"
                 compression: xz
           esp32s3:
             arch_prefix: xtensa-esp32s3-elf
@@ -884,13 +884,13 @@ compilers:
               - name: 12.2.0_20230208
                 base: "12.2.0_20230208"
                 host_type: x86_64-linux-gnu
-                release_name: "{base}"
+                release_name: "{{base}}"
                 compression: xz
     clang:
       - type: tarballs
         check_exe: bin/clang++ --version
-        dir: clang+llvm-{name}-{suffix}
-        url: https://llvm.org/releases/{name}/clang+llvm-{name}-{suffix}.tar.gz
+        dir: clang+llvm-{{name}}-{{suffix}}
+        url: https://llvm.org/releases/{{name}}/clang+llvm-{{name}}-{{suffix}}.tar.gz
         compression: gz
         strip: true
         targets:
@@ -900,8 +900,8 @@ compilers:
             suffix: x86_64-linux-ubuntu_12.04
       - type: tarballs
         check_exe: bin/clang++ --version
-        dir: clang+llvm-{name}-{suffix}
-        url: https://llvm.org/releases/{name}/clang+llvm-{name}-{suffix}.tar.xz
+        dir: clang+llvm-{{name}}-{{suffix}}
+        url: https://llvm.org/releases/{{name}}/clang+llvm-{{name}}-{{suffix}}.tar.xz
         compression: xz
         strip: true
         targets:
@@ -931,10 +931,10 @@ compilers:
         check_exe: bin/clang++ --version
         endilll-assertions:
           type: s3tarballs
-          s3_path_prefix: clang-assertions-{name}-from-endilll
-          dir: clang-assertions-{name}
-          untar_dir: clang-{name}-assert
-          path_name: clang-assertions-{name}
+          s3_path_prefix: clang-assertions-{{name}}-from-endilll
+          dir: clang-assertions-{{name}}
+          untar_dir: clang-{{name}}-assert
+          path_name: clang-assertions-{{name}}
           targets:
             - name: 2.6.0
               check_exe: bin/clang --version
@@ -1017,8 +1017,8 @@ compilers:
     clang-hexagon:
       - type: tarballs
         check_exe: x86_64-linux-gnu/bin/clang++ --version
-        dir: clang+llvm-{name}-{suffix}
-        url: https://codelinaro.jfrog.io/artifactory/codelinaro-toolchain-for-hexagon/v{name}/clang+llvm-{name}-{suffix}.tar.xz
+        dir: clang+llvm-{{name}}-{{suffix}}
+        url: https://codelinaro.jfrog.io/artifactory/codelinaro-toolchain-for-hexagon/v{{name}}/clang+llvm-{{name}}-{{suffix}}.tar.xz
         compression: xz
         targets:
           - name: 16.0.5
@@ -1038,7 +1038,7 @@ compilers:
           - 6.1.2
     plugins:
       clad:
-        path_name: clang-plugins/clad-{name}
+        path_name: clang-plugins/clad-{{name}}
         type: s3tarballs
         check_file: lib/clad.so
         targets:
@@ -1046,7 +1046,7 @@ compilers:
         nightly:
           if: nightly
           subdir: clang-plugins
-          compiler_name: clad-{name}
+          compiler_name: clad-{{name}}
           type: nightly
           targets:
           - trunk-clang-18.1.0
@@ -1065,9 +1065,9 @@ compilers:
       untar_dir: edg-compiler
       scraper: edg-compiler/edg-scrape-compiler.2023.7.18.zip
       scrape_cmd: bin/edg-scrape-compiler
-      path_name: edg-{name}
-      check_exe: eccp-scripts/eccp-{compiler_type} --version
-      s3_path_prefix: edg-compiler/edg-{compiler_type}-{edg_version}
+      path_name: edg-{{name}}
+      check_exe: eccp-scripts/eccp-{{compiler_type}} --version
+      s3_path_prefix: edg-compiler/edg-{{compiler_type}}-{{edg_version}}
       default:
         compiler_type: default
         targets:
@@ -1098,25 +1098,25 @@ compilers:
               - compilers/c++/x86/gcc 13.2.0
     ellccs:
       check_exe: bin/clang++ --version
-      dir: ellcc-{name}
+      dir: ellcc-{{name}}
       untar_dir: ellcc
       strip: true
       older:
         type: tarballs
-        url: http://ellcc.org/releases/older-releases/ellcc-x86_64-linux-{name}.tgz
+        url: http://ellcc.org/releases/older-releases/ellcc-x86_64-linux-{{name}}.tgz
         compression: gz
         targets:
           - 0.1.33
           - 0.1.34
       newer:
         type: tarballs
-        url: http://ellcc.org/releases/release-{name}/ellcc-x86_64-linux-{name}.bz2
+        url: http://ellcc.org/releases/release-{{name}}/ellcc-x86_64-linux-{{name}}.bz2
         compression: bz2
         targets:
           - 2017-07-16
     mlir:
       type: s3tarballs
-      dir: "mlir-{name}"
+      dir: "mlir-{{name}}"
       check_exe: bin/mlir-translate --version
       targets:
         - 14.0.0
@@ -1124,127 +1124,127 @@ compilers:
         - 16.0.0
     tinycc:
       type: s3tarballs
-      dir: "tinycc-{name}"
+      dir: "tinycc-{{name}}"
       check_exe: bin/tcc -v
       targets:
         - 0.9.27
     cl430:
       type: script
-      dir: "ti-cgt-msp430_{name}"
+      dir: "ti-cgt-msp430_{{name}}"
       check_exe: bin/cl430 -version
       targets:
         - name: 21.6.1.LTS
           fetch:
-            - https://dr-download.ti.com/software-development/ide-configuration-compiler-or-debugger/MD-p4jWEYpR8n/{name}/ti_cgt_msp430_{name}_linux-x64_installer.bin installer.bin
+            - https://dr-download.ti.com/software-development/ide-configuration-compiler-or-debugger/MD-p4jWEYpR8n/{{name}}/ti_cgt_msp430_{{name}}_linux-x64_installer.bin installer.bin
           script: |
             chmod +x installer.bin
             ./installer.bin --unattendedmodeui none --mode unattended --prefix .
             rm installer.bin
     intel-cpp:
       type: script
-      dir: "intel-cpp-{name}"
+      dir: "intel-cpp-{{name}}"
       check_exe: compiler/latest/linux/bin/intel64/icc -V
       check_stderr_on_stdout: true
       script_filename: install.sh
       targets:
         - name: 2021.1.2.63
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/irc_nas/17513/l_dpcpp-cpp-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/irc_nas/17513/l_dpcpp-cpp-compiler_p_{{name}}_offline.sh install.sh
           script: &intel-one-install-script |
             rm -Rf ~/.intel
             rm -Rf ~/intel
             rm -Rf /var/intel/installercache
-            bash {script_filename} -s -a -s --action install --eula accept --install-dir $CE_STAGING_DIR/{dir}
+            bash {{script_filename}} -s -a -s --action install --eula accept --install-dir $CE_STAGING_DIR/{{dir}}
             rm -Rf ~/.intel
             rm -Rf ~/intel
             rm -Rf /var/intel/installercache
         - name: 2021.2.0.118
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/irc_nas/17749/l_dpcpp-cpp-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/irc_nas/17749/l_dpcpp-cpp-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2021.3.0.3168
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/irc_nas/17928/l_dpcpp-cpp-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/irc_nas/17928/l_dpcpp-cpp-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2021.4.0.3201
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/irc_nas/18209/l_dpcpp-cpp-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/irc_nas/18209/l_dpcpp-cpp-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2022.0.1.71
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/irc_nas/18435/l_dpcpp-cpp-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/irc_nas/18435/l_dpcpp-cpp-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2022.1.0.137
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/irc_nas/18717/l_dpcpp-cpp-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/irc_nas/18717/l_dpcpp-cpp-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2022.2.0.8772
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/irc_nas/18849/l_dpcpp-cpp-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/irc_nas/18849/l_dpcpp-cpp-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2022.2.1.16991
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/irc_nas/19049/l_dpcpp-cpp-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/irc_nas/19049/l_dpcpp-cpp-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2023.0.0.25393
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/irc_nas/19123/l_dpcpp-cpp-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/irc_nas/19123/l_dpcpp-cpp-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2023.1.0.46347
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/IRC_NAS/89283df8-c667-47b0-b7e1-c4573e37bd3e/l_dpcpp-cpp-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/IRC_NAS/89283df8-c667-47b0-b7e1-c4573e37bd3e/l_dpcpp-cpp-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2023.2.1.8
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm//IRC_NAS/ebf5d9aa-17a7-46a4-b5df-ace004227c0e/l_dpcpp-cpp-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm//IRC_NAS/ebf5d9aa-17a7-46a4-b5df-ace004227c0e/l_dpcpp-cpp-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2024.0.0.49524
           check_exe: compiler/latest/bin/icx -V
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/IRC_NAS/5c8e686a-16a7-4866-b585-9cf09e97ef36/l_dpcpp-cpp-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/IRC_NAS/5c8e686a-16a7-4866-b585-9cf09e97ef36/l_dpcpp-cpp-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2024.1.0.468
           check_exe: compiler/latest/bin/icx -V
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2e562b6e-5d0f-4001-8121-350a828332fb/l_dpcpp-cpp-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2e562b6e-5d0f-4001-8121-350a828332fb/l_dpcpp-cpp-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2024.2.0.495
           check_exe: compiler/latest/bin/icx -V
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/IRC_NAS/6780ac84-6256-4b59-a647-330eb65f32b6/l_dpcpp-cpp-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/IRC_NAS/6780ac84-6256-4b59-a647-330eb65f32b6/l_dpcpp-cpp-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2025.0.0.740
           check_exe: compiler/latest/bin/icx -V
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ac92f2bb-4818-4e53-a432-f8b34d502f23/intel-dpcpp-cpp-compiler-{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ac92f2bb-4818-4e53-a432-f8b34d502f23/intel-dpcpp-cpp-compiler-{{name}}_offline.sh install.sh
           script: *intel-one-install-script
 
     nvhpc-sdk:
       type: script
-      dir: hpc_sdk/Linux_{arch}/{version}
+      dir: hpc_sdk/Linux_{{arch}}/{{version}}
       check_stderr_on_stdout: true
       check_exe: compilers/bin/nvc++ --version
       script: |
-        mkdir -p "nvhpc_sdk_{version}_{arch}";
-        tar -f "nvhpc_sdk_{version}_{arch}.tar.gz" -C "nvhpc_sdk_{version}_{arch}" --wildcards --strip-components=1 -pzx "nvhpc_*/*"
-        rm -rf "nvhpc_sdk_{version}_{arch}.tar.gz"
+        mkdir -p "nvhpc_sdk_{{version}}_{{arch}}";
+        tar -f "nvhpc_sdk_{{version}}_{{arch}}.tar.gz" -C "nvhpc_sdk_{{version}}_{{arch}}" --wildcards --strip-components=1 -pzx "nvhpc_*/*"
+        rm -rf "nvhpc_sdk_{{version}}_{{arch}}.tar.gz"
 
         NVHPC_SILENT=true \
         NVHPC_INSTALL_DIR=$CE_STAGING_DIR/hpc_sdk \
-          bash "nvhpc_sdk_{version}_{arch}/install"
+          bash "nvhpc_sdk_{{version}}_{{arch}}/install"
 
-        rm -rf "nvhpc_sdk_{version}_{arch}"
+        rm -rf "nvhpc_sdk_{{version}}_{{arch}}"
 
-        if [[ "{arch}" == "x86_64" ]]; then
-          bash "$CE_STAGING_DIR/hpc_sdk/Linux_{arch}/{version}/compilers/bin/makelocalrc" \
-            -x "$CE_STAGING_DIR/hpc_sdk/Linux_{arch}/{version}/compilers/bin" \
+        if [[ "{{arch}}" == "x86_64" ]]; then
+          bash "$CE_STAGING_DIR/hpc_sdk/Linux_{{arch}}/{{version}}/compilers/bin/makelocalrc" \
+            -x "$CE_STAGING_DIR/hpc_sdk/Linux_{{arch}}/{{version}}/compilers/bin" \
             -gcc /opt/compiler-explorer/gcc-12.2.0/bin/gcc \
             -gpp /opt/compiler-explorer/gcc-12.2.0/bin/g++ \
             -g77 /opt/compiler-explorer/gcc-12.2.0/bin/gfortran \
             ;
-        elif [[ "{arch}" == "aarch64" ]]; then
-          bash "$CE_STAGING_DIR/hpc_sdk/Linux_{arch}/{version}/compilers/bin/makelocalrc" \
-            -x "$CE_STAGING_DIR/hpc_sdk/Linux_{arch}/{version}/compilers/bin" \
+        elif [[ "{{arch}}" == "aarch64" ]]; then
+          bash "$CE_STAGING_DIR/hpc_sdk/Linux_{{arch}}/{{version}}/compilers/bin/makelocalrc" \
+            -x "$CE_STAGING_DIR/hpc_sdk/Linux_{{arch}}/{{version}}/compilers/bin" \
             -gcc /opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc \
             -gpp /opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++ \
             -g77 /opt/compiler-explorer/arm64/gcc-12.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gfortran \
@@ -1256,19 +1256,19 @@ compilers:
           version: "22.7"
           dot_removed_version: "227"
           fetch:
-            - https://developer.download.nvidia.com/hpc-sdk/{version}/nvhpc_2022_{dot_removed_version}_Linux_{arch}_cuda_11.7.tar.gz nvhpc_sdk_{version}_{arch}.tar.gz
+            - https://developer.download.nvidia.com/hpc-sdk/{{version}}/nvhpc_2022_{{dot_removed_version}}_Linux_{{arch}}_cuda_11.7.tar.gz nvhpc_sdk_{{version}}_{{arch}}.tar.gz
         - name: x86_64_22_9
           arch: x86_64
           version: "22.9"
           dot_removed_version: "229"
           fetch:
-            - https://developer.download.nvidia.com/hpc-sdk/{version}/nvhpc_2022_{dot_removed_version}_Linux_{arch}_cuda_11.7.tar.gz nvhpc_sdk_{version}_{arch}.tar.gz
+            - https://developer.download.nvidia.com/hpc-sdk/{{version}}/nvhpc_2022_{{dot_removed_version}}_Linux_{{arch}}_cuda_11.7.tar.gz nvhpc_sdk_{{version}}_{{arch}}.tar.gz
         - name: x86_64_22_11
           arch: x86_64
           version: "22.11"
           dot_removed_version: "2211"
           fetch:
-            - https://developer.download.nvidia.com/hpc-sdk/{version}/nvhpc_2022_{dot_removed_version}_Linux_{arch}_cuda_11.8.tar.gz nvhpc_sdk_{version}_{arch}.tar.gz
+            - https://developer.download.nvidia.com/hpc-sdk/{{version}}/nvhpc_2022_{{dot_removed_version}}_Linux_{{arch}}_cuda_11.8.tar.gz nvhpc_sdk_{{version}}_{{arch}}.tar.gz
         - name: x86_64_23_1
           arch: x86_64
           version: "23.1"
@@ -1276,7 +1276,7 @@ compilers:
           year: "2023"
           ctk_ver: "12.0"
           fetch:
-            - https://developer.download.nvidia.com/hpc-sdk/{version}/nvhpc_{year}_{dot_removed_version}_Linux_{arch}_cuda_{ctk_ver}.tar.gz nvhpc_sdk_{version}_{arch}.tar.gz
+            - https://developer.download.nvidia.com/hpc-sdk/{{version}}/nvhpc_{{year}}_{{dot_removed_version}}_Linux_{{arch}}_cuda_{{ctk_ver}}.tar.gz nvhpc_sdk_{{version}}_{{arch}}.tar.gz
         - name: x86_64_23_3
           arch: x86_64
           version: "23.3"
@@ -1284,7 +1284,7 @@ compilers:
           year: "2023"
           ctk_ver: "12.0"
           fetch:
-            - https://developer.download.nvidia.com/hpc-sdk/{version}/nvhpc_{year}_{dot_removed_version}_Linux_{arch}_cuda_{ctk_ver}.tar.gz nvhpc_sdk_{version}_{arch}.tar.gz
+            - https://developer.download.nvidia.com/hpc-sdk/{{version}}/nvhpc_{{year}}_{{dot_removed_version}}_Linux_{{arch}}_cuda_{{ctk_ver}}.tar.gz nvhpc_sdk_{{version}}_{{arch}}.tar.gz
         - name: x86_64_23_5
           arch: x86_64
           version: "23.5"
@@ -1292,7 +1292,7 @@ compilers:
           year: "2023"
           ctk_ver: "12.1"
           fetch:
-            - https://developer.download.nvidia.com/hpc-sdk/{version}/nvhpc_{year}_{dot_removed_version}_Linux_{arch}_cuda_{ctk_ver}.tar.gz nvhpc_sdk_{version}_{arch}.tar.gz
+            - https://developer.download.nvidia.com/hpc-sdk/{{version}}/nvhpc_{{year}}_{{dot_removed_version}}_Linux_{{arch}}_cuda_{{ctk_ver}}.tar.gz nvhpc_sdk_{{version}}_{{arch}}.tar.gz
         - name: x86_64_23_7
           arch: x86_64
           version: "23.7"
@@ -1300,7 +1300,7 @@ compilers:
           year: "2023"
           ctk_ver: "12.2"
           fetch:
-            - https://developer.download.nvidia.com/hpc-sdk/{version}/nvhpc_{year}_{dot_removed_version}_Linux_{arch}_cuda_{ctk_ver}.tar.gz nvhpc_sdk_{version}_{arch}.tar.gz
+            - https://developer.download.nvidia.com/hpc-sdk/{{version}}/nvhpc_{{year}}_{{dot_removed_version}}_Linux_{{arch}}_cuda_{{ctk_ver}}.tar.gz nvhpc_sdk_{{version}}_{{arch}}.tar.gz
         - name: x86_64_23_9
           arch: x86_64
           version: "23.9"
@@ -1308,7 +1308,7 @@ compilers:
           year: "2023"
           ctk_ver: "12.2"
           fetch:
-            - https://developer.download.nvidia.com/hpc-sdk/{version}/nvhpc_{year}_{dot_removed_version}_Linux_{arch}_cuda_{ctk_ver}.tar.gz nvhpc_sdk_{version}_{arch}.tar.gz
+            - https://developer.download.nvidia.com/hpc-sdk/{{version}}/nvhpc_{{year}}_{{dot_removed_version}}_Linux_{{arch}}_cuda_{{ctk_ver}}.tar.gz nvhpc_sdk_{{version}}_{{arch}}.tar.gz
         - name: x86_64_23_11
           arch: x86_64
           version: "23.11"
@@ -1316,7 +1316,7 @@ compilers:
           year: "2023"
           ctk_ver: "12.3"
           fetch:
-            - https://developer.download.nvidia.com/hpc-sdk/{version}/nvhpc_{year}_{dot_removed_version}_Linux_{arch}_cuda_{ctk_ver}.tar.gz nvhpc_sdk_{version}_{arch}.tar.gz
+            - https://developer.download.nvidia.com/hpc-sdk/{{version}}/nvhpc_{{year}}_{{dot_removed_version}}_Linux_{{arch}}_cuda_{{ctk_ver}}.tar.gz nvhpc_sdk_{{version}}_{{arch}}.tar.gz
         - name: x86_64_24_1
           arch: x86_64
           version: "24.1"
@@ -1324,7 +1324,7 @@ compilers:
           year: "2024"
           ctk_ver: "12.3"
           fetch:
-            - https://developer.download.nvidia.com/hpc-sdk/{version}/nvhpc_{year}_{dot_removed_version}_Linux_{arch}_cuda_{ctk_ver}.tar.gz nvhpc_sdk_{version}_{arch}.tar.gz
+            - https://developer.download.nvidia.com/hpc-sdk/{{version}}/nvhpc_{{year}}_{{dot_removed_version}}_Linux_{{arch}}_cuda_{{ctk_ver}}.tar.gz nvhpc_sdk_{{version}}_{{arch}}.tar.gz
         - name: x86_64_24_3
           arch: x86_64
           version: "24.3"
@@ -1332,7 +1332,7 @@ compilers:
           year: "2024"
           ctk_ver: "12.3"
           fetch:
-            - https://developer.download.nvidia.com/hpc-sdk/{version}/nvhpc_{year}_{dot_removed_version}_Linux_{arch}_cuda_{ctk_ver}.tar.gz nvhpc_sdk_{version}_{arch}.tar.gz
+            - https://developer.download.nvidia.com/hpc-sdk/{{version}}/nvhpc_{{year}}_{{dot_removed_version}}_Linux_{{arch}}_cuda_{{ctk_ver}}.tar.gz nvhpc_sdk_{{version}}_{{arch}}.tar.gz
         - name: x86_64_24_5
           arch: x86_64
           version: "24.5"
@@ -1340,7 +1340,7 @@ compilers:
           year: "2024"
           ctk_ver: "12.4"
           fetch:
-            - https://developer.download.nvidia.com/hpc-sdk/{version}/nvhpc_{year}_{dot_removed_version}_Linux_{arch}_cuda_{ctk_ver}.tar.gz nvhpc_sdk_{version}_{arch}.tar.gz
+            - https://developer.download.nvidia.com/hpc-sdk/{{version}}/nvhpc_{{year}}_{{dot_removed_version}}_Linux_{{arch}}_cuda_{{ctk_ver}}.tar.gz nvhpc_sdk_{{version}}_{{arch}}.tar.gz
         - name: x86_64_24_7
           arch: x86_64
           version: "24.7"
@@ -1348,7 +1348,7 @@ compilers:
           year: "2024"
           ctk_ver: "12.5"
           fetch:
-            - https://developer.download.nvidia.com/hpc-sdk/{version}/nvhpc_{year}_{dot_removed_version}_Linux_{arch}_cuda_{ctk_ver}.tar.gz nvhpc_sdk_{version}_{arch}.tar.gz
+            - https://developer.download.nvidia.com/hpc-sdk/{{version}}/nvhpc_{{year}}_{{dot_removed_version}}_Linux_{{arch}}_cuda_{{ctk_ver}}.tar.gz nvhpc_sdk_{{version}}_{{arch}}.tar.gz
         - name: x86_64_24_9
           arch: x86_64
           version: "24.9"
@@ -1356,7 +1356,7 @@ compilers:
           year: "2024"
           ctk_ver: "12.6"
           fetch:
-            - https://developer.download.nvidia.com/hpc-sdk/{version}/nvhpc_{year}_{dot_removed_version}_Linux_{arch}_cuda_{ctk_ver}.tar.gz nvhpc_sdk_{version}_{arch}.tar.gz
+            - https://developer.download.nvidia.com/hpc-sdk/{{version}}/nvhpc_{{year}}_{{dot_removed_version}}_Linux_{{arch}}_cuda_{{ctk_ver}}.tar.gz nvhpc_sdk_{{version}}_{{arch}}.tar.gz
         - name: x86_64_24_11
           arch: x86_64
           version: "24.11"
@@ -1364,7 +1364,7 @@ compilers:
           year: "2024"
           ctk_ver: "12.6"
           fetch:
-            - https://developer.download.nvidia.com/hpc-sdk/{version}/nvhpc_{year}_{dot_removed_version}_Linux_{arch}_cuda_{ctk_ver}.tar.gz nvhpc_sdk_{version}_{arch}.tar.gz
+            - https://developer.download.nvidia.com/hpc-sdk/{{version}}/nvhpc_{{year}}_{{dot_removed_version}}_Linux_{{arch}}_cuda_{{ctk_ver}}.tar.gz nvhpc_sdk_{{version}}_{{arch}}.tar.gz
         - name: x86_64_25_1
           arch: x86_64
           version: "25.1"
@@ -1372,7 +1372,7 @@ compilers:
           year: "2025"
           ctk_ver: "12.6"
           fetch:
-            - https://developer.download.nvidia.com/hpc-sdk/{version}/nvhpc_{year}_{dot_removed_version}_Linux_{arch}_cuda_{ctk_ver}.tar.gz nvhpc_sdk_{version}_{arch}.tar.gz
+            - https://developer.download.nvidia.com/hpc-sdk/{{version}}/nvhpc_{{year}}_{{dot_removed_version}}_Linux_{{arch}}_cuda_{{ctk_ver}}.tar.gz nvhpc_sdk_{{version}}_{{arch}}.tar.gz
     nightly:
       if: nightly
       gcc:
@@ -1427,7 +1427,7 @@ compilers:
             check_exe: bin/flang --version
       mlir:
         type: nightly
-        dir: "mlir-{name}"
+        dir: "mlir-{{name}}"
         check_exe: bin/mlir-opt --version
         targets:
           - trunk
@@ -1451,7 +1451,7 @@ compilers:
       llvmmos:
         type: nightlytarballs
         compression: xz
-        dir: llvm-mos-{name}
+        dir: llvm-mos-{{name}}
         check_exe: bin/clang --version
         url: https://github.com/llvm-mos/llvm-mos-sdk/releases/latest/download/llvm-mos-linux.tar.xz
         untar_dir: llvm-mos
@@ -1460,10 +1460,10 @@ compilers:
     djgpp:
       type: tarballs
       check_exe: bin/i586-pc-msdosdjgpp-g++ --version
-      url: https://github.com/andrewwutw/build-djgpp/releases/download/{tag}/djgpp-linux64-gcc{name_no_dots}.tar.bz2
+      url: https://github.com/andrewwutw/build-djgpp/releases/download/{{tag}}/djgpp-linux64-gcc{{name_no_dots}}.tar.bz2
       compression: bz2
       untar_dir: djgpp
-      dir: djgpp-{name}
+      dir: djgpp-{{name}}
       strip: true
       targets:
         - name: 7.2.0

--- a/bin/yaml/cppfront.yaml
+++ b/bin/yaml/cppfront.yaml
@@ -2,7 +2,7 @@ compilers:
   cppfront:
     if: nightly
     type: nightly
-    s3_path_prefix: cppfront-{name}
+    s3_path_prefix: cppfront-{{name}}
     check_exe: cppfront -version
     targets:
       - trunk

--- a/bin/yaml/crystal.yaml
+++ b/bin/yaml/crystal.yaml
@@ -1,11 +1,11 @@
 compilers:
   crystal:
     type: tarballs
-    url: https://github.com/crystal-lang/crystal/releases/download/{name}/crystal-{name}-1-linux-x86_64.tar.gz
+    url: https://github.com/crystal-lang/crystal/releases/download/{{name}}/crystal-{{name}}-1-linux-x86_64.tar.gz
     compression: gz
     create_untar_dir: true
     strip_components: 1
-    dir: crystal-{name}
+    dir: crystal-{{name}}
     check_exe: bin/crystal --version
     after_stage_script:
       - cd lib/crystal

--- a/bin/yaml/cuda.yaml
+++ b/bin/yaml/cuda.yaml
@@ -1,17 +1,17 @@
 compilers:
   cuda:
     type: script
-    dir: cuda/{name}
+    dir: cuda/{{name}}
     check_exe: bin/nvcc --version && bin/nvrtc_cli --version
     depends:
       - compilers/c++/x86/gcc 10.2.0
     fetch:
-      - https://developer.download.nvidia.com/compute/cuda/{name}/local_installers/cuda_{name}_{build}_linux.run combined.sh
+      - https://developer.download.nvidia.com/compute/cuda/{{name}}/local_installers/cuda_{{name}}_{{build}}_linux.run combined.sh
       - https://raw.githubusercontent.com/NVIDIA/jitify/6bc6e25e13300a8bc7520ed3bf977865201183b7/nvrtc_cli.cpp nvrtc_cli.cpp
     script: |
-      mkdir -p cuda/{name}
-      sh combined.sh --silent --toolkit --toolkitpath=$(pwd)/cuda/{name}
-      /opt/compiler-explorer/gcc-10.2.0/bin/g++ nvrtc_cli.cpp -o cuda/{name}/bin/nvrtc_cli -O3 -Wall -Wextra -std=c++11 -Icuda/{name}/include -Lcuda/{name}/lib64 -lnvrtc -Wl,--disable-new-dtags,-rpath,'$ORIGIN/../lib64'
+      mkdir -p cuda/{{name}}
+      sh combined.sh --silent --toolkit --toolkitpath=$(pwd)/cuda/{{name}}
+      /opt/compiler-explorer/gcc-10.2.0/bin/g++ nvrtc_cli.cpp -o cuda/{{name}}/bin/nvrtc_cli -O3 -Wall -Wextra -std=c++11 -Icuda/{{name}}/include -Lcuda/{{name}}/lib64 -lnvrtc -Wl,--disable-new-dtags,-rpath,'$ORIGIN/../lib64'
     targets:
       - name: 11.0.2
         build: 450.51.05

--- a/bin/yaml/d.yaml
+++ b/bin/yaml/d.yaml
@@ -4,14 +4,14 @@ compilers:
       type: tarballs
       build: 2.066.1
       compression: xz
-      check_exe: "{arch}/bin/gdc --version"
-      url: https://gdcproject.org/downloads/binaries/{name}/x86_64-linux-gnu/gdc-{name}+{build}.tar.xz
+      check_exe: "{{arch}}/bin/gdc --version"
+      url: https://gdcproject.org/downloads/binaries/{{name}}/x86_64-linux-gnu/gdc-{{name}}+{{build}}.tar.xz
       create_untar_dir: true
-      dir: gdc{name}
+      dir: gdc{{name}}
       arch: x86_64-pc-linux-gnu
       strip: # stripping the D libraries seems to upset them, so just strip the exes
-        - gdc{name}/{arch}/bin
-        - gdc{name}/{arch}/libexec
+        - gdc{{name}}/{{arch}}/bin
+        - gdc{{name}}/{{arch}}/libexec
       targets:
         - name: 4.8.2
           build: 2.064.2
@@ -20,13 +20,13 @@ compilers:
         - 5.2.0
     ldc:
       type: tarballs
-      url: https://github.com/ldc-developers/ldc/releases/download/v{name}/ldc2-{name}-linux-x86_64.tar.xz
+      url: https://github.com/ldc-developers/ldc/releases/download/v{{name}}/ldc2-{{name}}-linux-x86_64.tar.xz
       compression: xz
-      dir: ldc{name}
+      dir: ldc{{name}}
       create_untar_dir: true
       # any kind of stripping upsets ldc
       strip: false
-      check_exe: ldc2-{name}-linux-x86_64/bin/ldc2 --version
+      check_exe: ldc2-{{name}}-linux-x86_64/bin/ldc2 --version
       targets:
         - 0.17.2
         - 1.0.0
@@ -72,9 +72,9 @@ compilers:
         # the ldc2-* files on s3 from "getldc_s3" in the install bash scripts are now unused (TODO remove once we move over and are sure (25/4/2020)
     dmd:
       type: tarballs
-      url: http://downloads.dlang.org/releases/2.x/{name}/dmd.{name}.linux.tar.xz
+      url: http://downloads.dlang.org/releases/2.x/{{name}}/dmd.{{name}}.linux.tar.xz
       compression: xz
-      dir: dmd-{name}
+      dir: dmd-{{name}}
       create_untar_dir: true
       check_exe: dmd2/linux/bin64/dmd --version
       targets:
@@ -105,20 +105,20 @@ compilers:
       type: script
       fetch:
         - https://dlang.org/install.sh install.sh
-      dir: "{name}"
+      dir: "{{name}}"
       pre: |
-        mkdir {name}
-        cd {name}
+        mkdir {{name}}
+        cd {{name}}
       script_filename: ../install.sh
       script: |
-        {pre}
-        chmod +x {script_filename}
+        {{pre}}
+        chmod +x {{script_filename}}
         # Download and unpack into current directory
-        ACTIVATE_PATH=$({script_filename} install {target} -a -p $(pwd))
+        ACTIVATE_PATH=$({{script_filename}} install {{target}} -a -p $(pwd))
         # Rename the downloaded package directory to a constant name
-        mv $(dirname $ACTIVATE_PATH) {to}
+        mv $(dirname $ACTIVATE_PATH) {{to}}
         # Make directory readable for other users too
-        chmod +rx {to}
+        chmod +rx {{to}}
       ldc:
         targets:
           - name: ldc-latest-ci
@@ -132,7 +132,7 @@ compilers:
             to: ldcbeta
             check_exe: "bin/ldc2 --version"
       dmd:
-        dir: "{name}"
+        dir: "{{name}}"
         targets:
           - name: dmd2-nightly
             target: dmd-nightly

--- a/bin/yaml/dart.yaml
+++ b/bin/yaml/dart.yaml
@@ -1,13 +1,13 @@
 compilers:
   dart:
     type: ziparchive
-    dir: dart-{name}
+    dir: dart-{{name}}
     folder: dart-sdk
     check_exe: bin/dart --version
     after_stage_script:
       - chmod -R og+r .
       - find -executable -print0 | xargs -0 chmod og+x
-    url: https://storage.googleapis.com/dart-archive/channels/stable/release/{name}/sdk/dartsdk-linux-x64-release.zip
+    url: https://storage.googleapis.com/dart-archive/channels/stable/release/{{name}}/sdk/dartsdk-linux-x64-release.zip
     targets:
       - 3.5.3
       - 3.4.4
@@ -30,6 +30,6 @@ compilers:
     nightly:
       if: nightly
       install_always: true
-      url: https://storage.googleapis.com/dart-archive/channels/{name}/release/latest/sdk/dartsdk-linux-x64-release.zip
+      url: https://storage.googleapis.com/dart-archive/channels/{{name}}/release/latest/sdk/dartsdk-linux-x64-release.zip
       targets:
         - dev

--- a/bin/yaml/dotnet.yaml
+++ b/bin/yaml/dotnet.yaml
@@ -1,8 +1,8 @@
 compilers:
   dotnet:
     type: s3tarballs
-    dir: dotnet-{name}
-    path_name: dotnet-{name}
+    dir: dotnet-{{name}}
+    path_name: dotnet-{{name}}
     untar_dir: Core_Root
     check_exe: .dotnet/dotnet --version
     check_env:
@@ -12,8 +12,8 @@ compilers:
         if: nightly
         type: nightly
     newer:
-      s3_path_prefix: dotnet-{name}
-      untar_dir: dotnet-{name}
+      s3_path_prefix: dotnet-{{name}}
+      untar_dir: dotnet-{{name}}
       targets:
         - v6.0.11
         - v6.0.14

--- a/bin/yaml/fortran.yaml
+++ b/bin/yaml/fortran.yaml
@@ -2,70 +2,70 @@ compilers:
   fortran:
     intel-fortran:
       type: script
-      dir: "intel-fortran-{name}"
+      dir: "intel-fortran-{{name}}"
       check_exe: compiler/latest/linux/bin/intel64/ifort -V
       check_stderr_on_stdout: true
       script_filename: install.sh
       targets:
         - name: 2021.1.2.62
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/irc_nas/17508/l_fortran-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/irc_nas/17508/l_fortran-compiler_p_{{name}}_offline.sh install.sh
           script: &intel-one-install-script |
             rm -Rf ~/.intel
             rm -Rf ~/intel
             rm -Rf /var/intel/installercache
-            bash {script_filename} -s -a -s --action install --eula accept --install-dir $CE_STAGING_DIR/{dir}
+            bash {{script_filename}} -s -a -s --action install --eula accept --install-dir $CE_STAGING_DIR/{{dir}}
             rm -Rf ~/.intel
             rm -Rf ~/intel
             rm -Rf /var/intel/installercache
         - name: 2021.2.0.136
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/irc_nas/17756/l_fortran-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/irc_nas/17756/l_fortran-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2021.3.0.3168
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/irc_nas/17959/l_fortran-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/irc_nas/17959/l_fortran-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2021.4.0.3224
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/irc_nas/18210/l_fortran-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/irc_nas/18210/l_fortran-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2022.0.1.70
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/irc_nas/18436/l_fortran-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/irc_nas/18436/l_fortran-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2022.1.0.134
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/irc_nas/18703/l_fortran-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/irc_nas/18703/l_fortran-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2022.2.0.8773
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/irc_nas/18909/l_fortran-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/irc_nas/18909/l_fortran-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2022.2.1.16992
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/irc_nas/18998/l_fortran-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/irc_nas/18998/l_fortran-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2023.0.0.25394
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/irc_nas/19105/l_fortran-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/irc_nas/19105/l_fortran-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2023.1.0.46348
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/IRC_NAS/150e0430-63df-48a0-8469-ecebff0a1858/l_fortran-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/IRC_NAS/150e0430-63df-48a0-8469-ecebff0a1858/l_fortran-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2023.2.1.8
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/IRC_NAS/0d65c8d4-f245-4756-80c4-6712b43cf835/l_fortran-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/IRC_NAS/0d65c8d4-f245-4756-80c4-6712b43cf835/l_fortran-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
         - name: 2024.0.0.49493
           check_exe: compiler/latest/bin/ifx -V
           fetch:
-            - https://registrationcenter-download.intel.com/akdlm/IRC_NAS/89b0fcf9-5c00-448a-93a1-5ee4078e008e/l_fortran-compiler_p_{name}_offline.sh install.sh
+            - https://registrationcenter-download.intel.com/akdlm/IRC_NAS/89b0fcf9-5c00-448a-93a1-5ee4078e008e/l_fortran-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
     lfortran:
       check_exe: bin/lfortran --version
-      path_name: "lfortran/v{name}"
+      path_name: "lfortran/v{{name}}"
       type: s3tarballs
       targets:
         - 0.42.0

--- a/bin/yaml/glsl.yaml
+++ b/bin/yaml/glsl.yaml
@@ -2,7 +2,7 @@ compilers:
   glsl:
     glslang:
       type: ziparchive
-      dir: glslang-{name}
+      dir: glslang-{{name}}
       if: nightly
       install_always: true
       url: https://github.com/KhronosGroup/glslang/releases/download/main-tot/glslang-main-linux-Release.zip

--- a/bin/yaml/go.yaml
+++ b/bin/yaml/go.yaml
@@ -3,11 +3,11 @@ compilers:
     golang:
       type: tarballs
       compression: gz
-      url: https://storage.googleapis.com/golang/go{name}.linux-amd64.tar.gz
+      url: https://storage.googleapis.com/golang/go{{name}}.linux-amd64.tar.gz
       check_env:
         - GOROOT=%PATH%/go
       check_exe: go/bin/go version
-      dir: golang-{name}
+      dir: golang-{{name}}
       create_untar_dir: true
       strip: true
       targets:
@@ -35,9 +35,9 @@ compilers:
     tinygo:
       type: tarballs
       compression: gz
-      url: https://github.com/tinygo-org/tinygo/releases/download/v{name}/tinygo{name}.linux-amd64.tar.gz
+      url: https://github.com/tinygo-org/tinygo/releases/download/v{{name}}/tinygo{{name}}.linux-amd64.tar.gz
       check_exe: bin/tinygo version
-      dir: tinygo-{name}
+      dir: tinygo-{{name}}
       untar_dir: tinygo
       targets:
         - 0.25.0

--- a/bin/yaml/haskell.yaml
+++ b/bin/yaml/haskell.yaml
@@ -3,21 +3,21 @@ compilers:
     ghc:
       type: tarballs
       compression: xz
-      dir: ghc-{name}
-      url: https://downloads.haskell.org/~ghc/{name}/ghc-{name}-x86_64-deb{deb}-linux.tar.xz
+      dir: ghc-{{name}}
+      url: https://downloads.haskell.org/~ghc/{{name}}/ghc-{{name}}-x86_64-deb{{deb}}-linux.tar.xz
       check_exe: bin/ghc --version
       deb: 8
       after_stage_script:
         - mkdir install
-        - cd {dir}
+        - cd {{dir}}
         # ghc needs to be built "as if" it's about to land in the destination
-        - ./configure --prefix={destination}/{dir}
+        - ./configure --prefix={{destination}}/{{dir}}
         # ...but we "dest" to somewhere in staging.
         - make install DESTDIR=`cd ../install && pwd`
         - cd ..
-        - rm -rf {dir}
-        # ...and then we undo this so the staging dir is just staging/{dir}
-        - mv install/{destination}/{dir} {dir}
+        - rm -rf {{dir}}
+        # ...and then we undo this so the staging dir is just staging/{{dir}}
+        - mv install/{{destination}}/{{dir}} {{dir}}
         - rm -rf install
       targets:
         - 8.0.2
@@ -39,7 +39,7 @@ compilers:
           deb: 10
         - name: 9.4.5
           deb: 10
-          dir: ghc-{name}-x86_64-unknown-linux
+          dir: ghc-{{name}}-x86_64-unknown-linux
         - name: 9.6.1
           deb: 10
-          dir: ghc-{name}-x86_64-unknown-linux
+          dir: ghc-{{name}}-x86_64-unknown-linux

--- a/bin/yaml/hlsl.yaml
+++ b/bin/yaml/hlsl.yaml
@@ -23,9 +23,9 @@ compilers:
         - "1.6.2112"
     rga:
       type: tarballs
-      url: https://github.com/GPUOpen-Tools/radeon_gpu_analyzer/releases/download/{name}/rga-linux-{name}.tgz
+      url: https://github.com/GPUOpen-Tools/radeon_gpu_analyzer/releases/download/{{name}}/rga-linux-{{name}}.tgz
       compression: gz
-      dir: rga-{name}.{extra_number} # The folder inside has an additional build number
+      dir: rga-{{name}}.{{extra_number}} # The folder inside has an additional build number
       check_exe: rga --version
       strip_components: 1
       targets:

--- a/bin/yaml/hook.yaml
+++ b/bin/yaml/hook.yaml
@@ -4,8 +4,8 @@ compilers:
     type: nightlytarballs
     compression: gz
     check_exe: bin/hook --version
-    url: https://github.com/hook-lang/hook/releases/download/{name}/hook-{name}-linux-x64.tar.gz
-    untar_dir: hook-{name}-linux-x64
-    dir: hook/hook-{name}
+    url: https://github.com/hook-lang/hook/releases/download/{{name}}/hook-{{name}}-linux-x64.tar.gz
+    untar_dir: hook-{{name}}-linux-x64
+    dir: hook/hook-{{name}}
     targets:
       - 0.1.0  # 0.1.0 is a nightly, per discussion on Discord with fabio

--- a/bin/yaml/ispc.yaml
+++ b/bin/yaml/ispc.yaml
@@ -3,9 +3,9 @@ compilers:
     type: tarballs
     compression: gz
     suffix: ''
-    url: https://github.com/ispc/ispc/releases/download/v{name}/ispc-v{name}{suffix}-linux.tar.gz
-    dir: ispc-{name}
-    untar_dir: ispc-v{name}-linux
+    url: https://github.com/ispc/ispc/releases/download/v{{name}}/ispc-v{{name}}{{suffix}}-linux.tar.gz
+    dir: ispc-{{name}}
+    untar_dir: ispc-v{{name}}-linux
     check_exe: bin/ispc --version
     targets:
       - 1.25.3
@@ -38,7 +38,7 @@ compilers:
           - 1.9.1
     nightly:
       if: nightly
-      compiler_name: ispc-{name}
+      compiler_name: ispc-{{name}}
       type: nightly
       targets:
         - trunk

--- a/bin/yaml/jakt.yaml
+++ b/bin/yaml/jakt.yaml
@@ -2,7 +2,7 @@ compilers:
   jakt:
     if: nightly
     type: nightly
-    s3_path_prefix: jakt-{name}
+    s3_path_prefix: jakt-{{name}}
     check_exe: bin/jakt --version
     targets:
       - trunk

--- a/bin/yaml/java.yaml
+++ b/bin/yaml/java.yaml
@@ -2,7 +2,7 @@ compilers:
   java:
     type: tarballs
     compression: gz
-    dir: jdk-{name}
+    dir: jdk-{{name}}
     check_exe: bin/javac -version
     targets:
       - name: 8u402b06

--- a/bin/yaml/julia.yaml
+++ b/bin/yaml/julia.yaml
@@ -2,7 +2,7 @@ compilers:
   julia:
     type: tarballs
     compression: gz
-    dir: julia-{name}
+    dir: julia-{{name}}
     check_exe: bin/julia --version
     targets:
       - name: 1.11.2

--- a/bin/yaml/khronos.yaml
+++ b/bin/yaml/khronos.yaml
@@ -20,10 +20,10 @@ compilers:
           - main
   vulkan-sdk:
     type: tarballs
-    dir: vulkan-sdk/v{name}
+    dir: vulkan-sdk/v{{name}}
     strip_components: 1
     create_untar_dir: true
-    url: https://sdk.lunarg.com/sdk/download/{name}/linux/vulkansdk-linux-x86_64-{name}.tar.xz
+    url: https://sdk.lunarg.com/sdk/download/{{name}}/linux/vulkansdk-linux-x86_64-{{name}}.tar.xz
     compression: xz
     check_exe: ./x86_64/bin/spirv-cross --help
     targets:

--- a/bin/yaml/kotlin-native.yaml
+++ b/bin/yaml/kotlin-native.yaml
@@ -1,14 +1,14 @@
 compilers:
   kotlin-native:
     type: tarballs
-    dir: kotlin-native-linux-{name}
+    dir: kotlin-native-linux-{{name}}
     compression: gz
     check_exe: bin/kotlinc-native -version
     check_env:
       - JAVA_HOME=%DEP0%
-    filename: kotlin-native-linux-{name}
-    url: https://github.com/JetBrains/kotlin/releases/download/v{name}/{filename}.tar.gz
-    untar_dir: '{filename}'
+    filename: kotlin-native-linux-{{name}}
+    url: https://github.com/JetBrains/kotlin/releases/download/v{{name}}/{{filename}}.tar.gz
+    untar_dir: '{{filename}}'
     depends:
       - compilers/java 16.0.1
     targets:
@@ -27,7 +27,7 @@ compilers:
       - 1.5.20
       - 1.5.21
     newer:
-      filename: kotlin-native-linux-x86_64-{name}
+      filename: kotlin-native-linux-x86_64-{{name}}
       targets:
         - 1.5.30
         - 1.5.31
@@ -42,7 +42,7 @@ compilers:
         - 1.9.10
         - 1.9.20
     k2:
-      filename: kotlin-native-prebuilt-linux-x86_64-{name}
+      filename: kotlin-native-prebuilt-linux-x86_64-{{name}}
       targets:
         - 2.0.0
         - 2.0.10

--- a/bin/yaml/kotlin.yaml
+++ b/bin/yaml/kotlin.yaml
@@ -1,14 +1,14 @@
 compilers:
   kotlin:
     type: ziparchive
-    dir: kotlin-jvm-{name}
+    dir: kotlin-jvm-{{name}}
     folder: kotlinc
     depends:
       - compilers/java 15.0.2
     check_env:
       - JAVA_HOME=%DEP0%
     check_exe: bin/kotlinc-jvm -version
-    url: https://github.com/JetBrains/kotlin/releases/download/v{name}/kotlin-compiler-{name}.zip
+    url: https://github.com/JetBrains/kotlin/releases/download/v{{name}}/kotlin-compiler-{{name}}.zip
     targets:
       - 1.4.0
       - 1.4.10

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -2,12 +2,12 @@ libraries:
   android-java:
     android-api-stubs:
       check_file: android.jar
-      dir: android-api-stubs-{name}
-      script: 'mkdir {dir}
+      dir: android-api-stubs-{{name}}
+      script: 'mkdir {{dir}}
 
-        cd {dir}
+        cd {{dir}}
 
-        {yaml_dir}/android-java/fetch_android_jar.sh {name}
+        {{yaml_dir}}/android-java/fetch_android_jar.sh {{name}}
 
         '
       targets:
@@ -15,7 +15,7 @@ libraries:
       type: script
     androidx-annotation:
       check_file: annotation-jvm.jar
-      dir: androidx-annotation-{name}
+      dir: androidx-annotation-{{name}}
       filename: annotation-jvm.jar
       targets:
       - 1.9.1
@@ -27,10 +27,10 @@ libraries:
       - 1.7.0
       - 1.6.0
       type: singleFile
-      url: https://dl.google.com/android/maven2/androidx/annotation/annotation-jvm/{name}/annotation-jvm-{name}.jar
+      url: https://dl.google.com/android/maven2/androidx/annotation/annotation-jvm/{{name}}/annotation-jvm-{{name}}.jar
     r8-keep-annotations:
       check_file: keepanno-annotations.jar
-      dir: r8-{name}-keepanno
+      dir: r8-{{name}}-keepanno
       filename: keepanno-annotations.jar
       targets:
       - 8.7.18
@@ -46,7 +46,7 @@ libraries:
       - 8.2.42
       - 8.2.33
       type: singleFile
-      url: https://storage.googleapis.com/r8-releases/raw/{name}/keepanno-annotations.jar
+      url: https://storage.googleapis.com/r8-releases/raw/{{name}}/keepanno-annotations.jar
   c:
     cs50:
       build_type: manual
@@ -638,9 +638,9 @@ libraries:
       type: github
     hip-amd:
       check_file: include/hip/hip_runtime.h
-      path_name: libs/rocm/{name}
-      s3_path_prefix: hip-amd-rocm-{name}
-      subdir: libs/rocm/{name}
+      path_name: libs/rocm/{{name}}
+      s3_path_prefix: hip-amd-rocm-{{name}}
+      subdir: libs/rocm/{{name}}
       targets:
       - 4.5.2
       - 5.0.2
@@ -862,9 +862,9 @@ libraries:
       type: github
     llvm:
       check_file: include/llvm/Config/llvm-config.h
-      path_name: libs/llvm/{name}
-      s3_path_prefix: llvm-{name}
-      subdir: libs/llvm/{name}
+      path_name: libs/llvm/{{name}}
+      s3_path_prefix: llvm-{{name}}
+      subdir: libs/llvm/{{name}}
       targets:
       - 4.0.1
       - 5.0.0
@@ -908,8 +908,8 @@ libraries:
       targets:
       - '0.6.0'
       build_type: none
-      path_name: libs/mdspan-{name}
-      untar_dir: mdspan-mdspan-{name}
+      path_name: libs/mdspan-{{name}}
+      untar_dir: mdspan-mdspan-{{name}}
       type: github
     mfem:
       build_type: cmake
@@ -936,9 +936,9 @@ libraries:
       type: github
     mlir:
       check_file: include/mlir/InitAllPasses.h
-      path_name: libs/mlir/{name}
-      s3_path_prefix: mlir-{name}
-      subdir: libs/mlir/{name}
+      path_name: libs/mlir/{{name}}
+      s3_path_prefix: mlir-{{name}}
+      subdir: libs/mlir/{{name}}
       targets:
       - 14.0.0
       - 14.0.5
@@ -1525,7 +1525,7 @@ libraries:
         build_type: none
         check_file: include/llvm/Config/llvm-config.h
         subdir: libs/llvm
-        symlink: libs/llvm/{name}
+        symlink: libs/llvm/{{name}}
         targets:
         - trunk
         type: nightly
@@ -1545,9 +1545,9 @@ libraries:
         type: github
       mlir:
         check_file: include/mlir/InitAllPasses.h
-        path_name: libs/mlir/{name}
-        s3_path_prefix: mlir-{name}
-        subdir: libs/mlir/{name}
+        path_name: libs/mlir/{{name}}
+        s3_path_prefix: mlir-{{name}}
+        subdir: libs/mlir/{{name}}
         targets:
         - trunk
         type: nightly
@@ -1901,15 +1901,15 @@ libraries:
       type: github
     nsimd:
       check_file: x86_64/include/nsimd/nsimd.h
-      path_name: libs/nsimd/{name}
-      s3_path_prefix: nsimd-{name}
-      subdir: libs/nsimd/{name}
+      path_name: libs/nsimd/{{name}}
+      s3_path_prefix: nsimd-{{name}}
+      subdir: libs/nsimd/{{name}}
       targets:
       - v2.2
       type: s3tarballs
     openssl:
       after_stage_script:
-      - cd {untar_dir}
+      - cd {{untar_dir}}
       - ./config --prefix="$PWD/x86_64/opt" --openssldir="$PWD/x86_64/ssl"
       - make
       - make install
@@ -1917,14 +1917,14 @@ libraries:
       build_type: none
       check_file: x86_64/opt/lib/libssl.so.1.1
       compression: gz
-      dir: libs/openssl/openssl_{name}
+      dir: libs/openssl/openssl_{{name}}
       lib_type: shared
       targets:
       - 1_1_1c
       - 1_1_1g
       type: tarballs
-      untar_dir: openssl-OpenSSL_{name}
-      url: https://github.com/openssl/openssl/archive/OpenSSL_{name}.tar.gz
+      untar_dir: openssl-OpenSSL_{{name}}
+      url: https://github.com/openssl/openssl/archive/OpenSSL_{{name}}.tar.gz
     option:
       check_file: README.md
       repo: NUCLEAR-BOMB/option
@@ -2001,7 +2001,7 @@ libraries:
       build_type: cmake
       check_file: CMakeLists.txt
       compression: xz
-      dir: libs/qt/{name}
+      dir: libs/qt/{{name}}
       extra_cmake_arg:
       - -DBUILD_EXAMPLES=OFF
       - -DQT_BUILD_EXAMPLES_BY_DEFAULT=OFF
@@ -2135,11 +2135,11 @@ libraries:
       build_type: cmake
       make_targets:
       - spdlog
-      path_name: libs/spdlog/{name}
+      path_name: libs/spdlog/{{name}}
       repo: gabime/spdlog
       skip_compilers:
       - clang_autonsdmi
-      subdir: spdlog-{name}
+      subdir: spdlog-{{name}}
       target_prefix: v
       targets:
       - 1.5.0
@@ -2370,7 +2370,7 @@ libraries:
       build_type: make
       check_file: configure
       compression: gz
-      dir: libs/zlib/{name}
+      dir: libs/zlib/{{name}}
       lib_type: static
       make_targets:
       - all
@@ -2380,8 +2380,8 @@ libraries:
       targets:
       - 1.3.1
       type: tarballs
-      untar_dir: zlib-{name}
-      url: https://www.zlib.net/zlib-{name}.tar.gz
+      untar_dir: zlib-{{name}}
+      url: https://www.zlib.net/zlib-{{name}}.tar.gz
   cuda:
     cccl:
       check_file: README.md
@@ -2489,7 +2489,7 @@ libraries:
   d:
     mir-algorithm:
       check_file: README.md
-      path_name: libs/d/mir-algorithm-v{name}
+      path_name: libs/d/mir-algorithm-v{{name}}
       repo: libmir/mir-algorithm
       target_prefix: v
       targets:
@@ -2503,7 +2503,7 @@ libraries:
       type: github
     mir-glas:
       check_file: README.md
-      path_name: libs/d/mir-glas-v{name}
+      path_name: libs/d/mir-glas-v{{name}}
       repo: libmir/mir-glas
       target_prefix: v
       targets:

--- a/bin/yaml/nim.yaml
+++ b/bin/yaml/nim.yaml
@@ -3,10 +3,10 @@ compilers:
     type: tarballs
     compression: xz
     check_exe: bin/nim --version
-    url: https://nim-lang.org/download/nim-{name}-linux_x64.tar.xz
+    url: https://nim-lang.org/download/nim-{{name}}-linux_x64.tar.xz
     strip:
-      - nim-{name}/bin
-    dir: nim-{name}
+      - nim-{{name}}/bin
+    dir: nim-{{name}}
     targets:
       - 1.0.4
       - 1.0.6
@@ -21,8 +21,8 @@ compilers:
     nightly:
       install_always: true
       if: nightly
-      url: https://github.com/nim-lang/nightlies/releases/download/latest-{name}/linux_x64.tar.xz
-      untar_dir: nim-{name}
+      url: https://github.com/nim-lang/nightlies/releases/download/latest-{{name}}/linux_x64.tar.xz
+      untar_dir: nim-{{name}}
       create_untar_dir: true
       strip_components: 1
       targets:

--- a/bin/yaml/odin.yaml
+++ b/bin/yaml/odin.yaml
@@ -3,8 +3,8 @@ compilers:
     type: ziparchive
     check_exe: odin version
     os: ubuntu
-    url: https://github.com/odin-lang/Odin/releases/download/{name}/odin-{os}-amd64-{name}.zip
-    dir: odin-{name}
+    url: https://github.com/odin-lang/Odin/releases/download/{{name}}/odin-{{os}}-amd64-{{name}}.zip
+    dir: odin-{{name}}
     extract_into_folder: true
     folder: odin
     after_stage_script:

--- a/bin/yaml/pascal.yaml
+++ b/bin/yaml/pascal.yaml
@@ -3,21 +3,21 @@ compilers:
     fpc:
       type: tarballs
       compression: tar
-      dir: fpc-{name}.x86_64-linux
-      url: https://downloads.sourceforge.net/project/freepascal/Linux/{name}/{dir}.tar
+      dir: fpc-{{name}}.x86_64-linux
+      url: https://downloads.sourceforge.net/project/freepascal/Linux/{{name}}/{{dir}}.tar
       check_exe: bin/fpc -iV
       after_stage_script:
-        - cd {dir}
+        - cd {{dir}}
         - rm demo.tar.gz
         - rm doc-pdf.tar.gz
         - rm install.sh
-        - cp {yaml_dir}/pascal/install_fpc.sh .
-        - . install_fpc.sh {name} $CE_STAGING_DIR/install
+        - cp {{yaml_dir}}/pascal/install_fpc.sh .
+        - . install_fpc.sh {{name}} $CE_STAGING_DIR/install
         - cd ..
-        - rm -rf {dir}
-        - mv install {dir}
-        - mkdir -p {destination}/fpc
-        - cp {yaml_dir}/pascal/fpc.cfg {destination}/fpc/fpc.cfg
+        - rm -rf {{dir}}
+        - mv install {{dir}}
+        - mkdir -p {{destination}}/fpc
+        - cp {{yaml_dir}}/pascal/fpc.cfg {{destination}}/fpc/fpc.cfg
       targets:
         - 2.6.0
         - 2.6.2
@@ -25,7 +25,7 @@ compilers:
         - 3.0.2
         - 3.0.4
         - name: 3.2.0
-          dir: fpc-{name}-x86_64-linux
+          dir: fpc-{{name}}-x86_64-linux
         - 3.2.2
     nightly:
       if: nightly
@@ -47,14 +47,14 @@ compilers:
           - rm demo.tar.gz
           - rm doc-pdf.tar.gz
           - rm install.sh
-          - cp {yaml_dir}/pascal/install_fpc.sh .
-          - . install_fpc.sh {name} $CE_STAGING_DIR/install
+          - cp {{yaml_dir}}/pascal/install_fpc.sh .
+          - . install_fpc.sh {{name}} $CE_STAGING_DIR/install
           - cd ..
-          - mv {dir} old
+          - mv {{dir}} old
           - cp old/ce_script.sh install
           - mv install/lib/fpc/3.3.1 install/lib/fpc/trunk
-          - mv install {dir}
-          - mkdir -p {destination}/fpc
-          - cp {yaml_dir}/pascal/fpc-trunk.cfg {destination}/fpc/fpc-trunk.cfg
+          - mv install {{dir}}
+          - mkdir -p {{destination}}/fpc
+          - cp {{yaml_dir}}/pascal/fpc-trunk.cfg {{destination}}/fpc/fpc-trunk.cfg
         targets:
           - trunk

--- a/bin/yaml/pony.yaml
+++ b/bin/yaml/pony.yaml
@@ -2,9 +2,9 @@ compilers:
   pony:
     type: tarballs
     compression: gz
-    url: https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/{name}/ponyc-x86-64-unknown-linux-gnu.tar.gz
+    url: https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/{{name}}/ponyc-x86-64-unknown-linux-gnu.tar.gz
     check_exe: bin/ponyc -v
-    dir: ponyc-{name}
+    dir: ponyc-{{name}}
     strip_components: 1
     create_untar_dir: true
     targets:

--- a/bin/yaml/python.yaml
+++ b/bin/yaml/python.yaml
@@ -15,9 +15,9 @@ compilers:
   pypy:
     type: tarballs
     compression: bz2
-    url: https://downloads.python.org/pypy/pypy{name}-linux64.tar.bz2
+    url: https://downloads.python.org/pypy/pypy{{name}}-linux64.tar.bz2
     check_exe: bin/pypy --version
-    dir: pypy{name}
+    dir: pypy{{name}}
     strip_components: 1
     create_untar_dir: true
     targets:

--- a/bin/yaml/pythran.yaml
+++ b/bin/yaml/pythran.yaml
@@ -2,7 +2,7 @@ compilers:
   pythran:
     type: s3tarballs
     subdir: pythran
-    s3_path_prefix: "pythran-{name}"
+    s3_path_prefix: "pythran-{{name}}"
     check_exe: "bin/pythran --version"
     targets:
       - "0.15"

--- a/bin/yaml/racket.yaml
+++ b/bin/yaml/racket.yaml
@@ -2,18 +2,18 @@ compilers:
   racket:
     type: script
     check_exe: bin/racket --version
-    dir: racket/racket-{name}
+    dir: racket/racket-{{name}}
     fetch:
-      - https://download.racket-lang.org/releases/{name}/installers/racket-{name}-x86_64-linux-cs.sh racket-{name}.sh
+      - https://download.racket-lang.org/releases/{{name}}/installers/racket-{{name}}-x86_64-linux-cs.sh racket-{{name}}.sh
     script: |
-      sh racket-{name}.sh --in-place --dest ./racket/racket-{name}
-      racket/racket-{name}/bin/raco pkg install -i --auto disassemble
+      sh racket-{{name}}.sh --in-place --dest ./racket/racket-{{name}}
+      racket/racket-{{name}}/bin/raco pkg install -i --auto disassemble
     targets:
       - "8.6"
     nightly:
       if: nightly
       install_always: true
       fetch:
-        - https://users.cs.utah.edu/plt/snapshots/current/installers/racket-current-x86_64-linux-jammy.sh racket-{name}.sh
+        - https://users.cs.utah.edu/plt/snapshots/current/installers/racket-current-x86_64-linux-jammy.sh racket-{{name}}.sh
       targets:
         - nightly

--- a/bin/yaml/rust.yaml
+++ b/bin/yaml/rust.yaml
@@ -1,11 +1,11 @@
 compilers:
   rust:
     type: rust
-    dir: rust-{name}
+    dir: rust-{{name}}
     check_exe: "bin/rustc --version --verbose"
     patchelf: tools/patchelf 0.15.0
     older:
-      base_package: rustc-{name}-x86_64-unknown-linux-gnu
+      base_package: rustc-{{name}}-x86_64-unknown-linux-gnu
       targets:
         - 1.0.0
         - 1.1.0
@@ -13,7 +13,7 @@ compilers:
         - 1.3.0
         - 1.4.0
     newer:
-      base_package: rust-{name}-x86_64-unknown-linux-gnu
+      base_package: rust-{{name}}-x86_64-unknown-linux-gnu
       targets:
         - 1.5.0
         - 1.6.0
@@ -122,7 +122,7 @@ compilers:
   rust-linux:
     type: s3tarballs
     subdir: rust-linux
-    s3_path_prefix: rust-linux-{name}
+    s3_path_prefix: rust-linux-{{name}}
     check_file: rust/libkernel.rmeta
     targets:
     - '6.3'

--- a/bin/yaml/sail.yaml
+++ b/bin/yaml/sail.yaml
@@ -2,9 +2,9 @@ compilers:
   sail:
     type: tarballs
     compression: gz
-    url: https://github.com/rems-project/sail/releases/download/{name}-linux-binary/sail.tar.gz
+    url: https://github.com/rems-project/sail/releases/download/{{name}}-linux-binary/sail.tar.gz
     check_exe: bin/sail --version
-    dir: sail-{name}
+    dir: sail-{{name}}
     strip_components: 1
     create_untar_dir: true
     targets:

--- a/bin/yaml/scala.yaml
+++ b/bin/yaml/scala.yaml
@@ -2,7 +2,7 @@ compilers:
   scala:
     type: tarballs
     compression: gz
-    dir: scala-{name}
+    dir: scala-{{name}}
     folder: scalac
     check_exe: bin/scalac -version
     depends:
@@ -18,25 +18,25 @@ compilers:
         url: https://downloads.lightbend.com/scala/2.13.15/scala-2.13.15.tgz
       - name: 3.0.0
         url: https://github.com/scala/scala3/releases/download/3.0.0/scala3-3.0.0.tar.gz
-        dir: scala3-{name}
+        dir: scala3-{{name}}
       - name: 3.1.0
         url: https://github.com/lampepfl/dotty/releases/download/3.1.0/scala3-3.1.0.tar.gz
-        dir: scala3-{name}
+        dir: scala3-{{name}}
       - name: 3.2.0
         url: https://github.com/lampepfl/dotty/releases/download/3.2.0/scala3-3.2.0.tar.gz
-        dir: scala3-{name}
+        dir: scala3-{{name}}
       - name: 3.3.0
         url: https://github.com/lampepfl/dotty/releases/download/3.3.0/scala3-3.3.0.tar.gz
-        dir: scala3-{name}
+        dir: scala3-{{name}}
       - name: 3.3.4
         url: https://github.com/lampepfl/dotty/releases/download/3.3.4/scala3-3.3.4.tar.gz
-        dir: scala3-{name}
+        dir: scala3-{{name}}
       - name: 3.4.0
         url: https://github.com/lampepfl/dotty/releases/download/3.4.0/scala3-3.4.0.tar.gz
-        dir: scala3-{name}
+        dir: scala3-{{name}}
       - name: 3.5.0
         url: https://github.com/lampepfl/dotty/releases/download/3.5.0/scala3-3.5.0.tar.gz
-        dir: scala3-{name}
+        dir: scala3-{{name}}
       - name: 3.6.2
         url: https://github.com/lampepfl/dotty/releases/download/3.6.2/scala3-3.6.2.tar.gz
-        dir: scala3-{name}
+        dir: scala3-{{name}}

--- a/bin/yaml/slang.yaml
+++ b/bin/yaml/slang.yaml
@@ -2,9 +2,9 @@ compilers:
   slang:
     slangc:
       type: tarballs
-      dir: slang-{name}
+      dir: slang-{{name}}
       untar_dir: .
-      url: https://github.com/shader-slang/slang/releases/download/v{name}/slang-{name}-linux-x86_64-glibc-2.17.tar.gz
+      url: https://github.com/shader-slang/slang/releases/download/v{{name}}/slang-{{name}}-linux-x86_64-glibc-2.17.tar.gz
       compression: gz
       check_exe: bin/slangc -version
       targets:

--- a/bin/yaml/snowball.yaml
+++ b/bin/yaml/snowball.yaml
@@ -2,12 +2,12 @@ compilers:
   snowball:
     type: tarballs
     compression: gz
-    dir: snowball-{name}
+    dir: snowball-{{name}}
     create_untar_dir: true
     strip_components: 1
-    build: snowball-{name}-release
+    build: snowball-{{name}}-release
     toolchain: cmake
     check_exe: bin/snowball --version
-    url: https://github.com/snowball-lang/snowball/releases/download/v{name}/snowball-ce-specific-x86_64.tar.gz
+    url: https://github.com/snowball-lang/snowball/releases/download/v{{name}}/snowball-ce-specific-x86_64.tar.gz
     targets:
       - '0.1.0'

--- a/bin/yaml/solidity.yaml
+++ b/bin/yaml/solidity.yaml
@@ -1,7 +1,7 @@
 compilers:
   solidity:
     type: solidity
-    dir: solc-{name}
+    dir: solc-{{name}}
     url: https://binaries.soliditylang.org/linux-amd64
     filename: solc
     check_exe: solc --version
@@ -14,8 +14,8 @@ compilers:
       - 0.8.26
   solidity_zksync:
     type: singleFile
-    dir: zksync-solc-{name}
-    url: https://github.com/matter-labs/era-solidity/releases/download/{name}/solc-linux-amd64-{name}
+    dir: zksync-solc-{{name}}
+    url: https://github.com/matter-labs/era-solidity/releases/download/{{name}}/solc-linux-amd64-{{name}}
     filename: solc
     check_exe: solc --version
     targets:
@@ -27,7 +27,7 @@ compilers:
       - 0.8.26-1.0.1
   zksolc:
     type: singleFile
-    dir: zksolc-{name}
+    dir: zksolc-{{name}}
     depends:
       - compilers/solidity_zksync 0.4.26-1.0.1
       - compilers/solidity_zksync 0.5.17-1.0.1
@@ -35,7 +35,7 @@ compilers:
       - compilers/solidity_zksync 0.7.6-1.0.1
       - compilers/solidity_zksync 0.8.25-1.0.1
       - compilers/solidity_zksync 0.8.26-1.0.1
-    url: https://github.com/matter-labs/era-compiler-solidity/releases/download/{name}/zksolc-linux-amd64-musl-v{name}
+    url: https://github.com/matter-labs/era-compiler-solidity/releases/download/{{name}}/zksolc-linux-amd64-musl-v{{name}}
     filename: zksolc
     check_exe: zksolc --version
     targets:

--- a/bin/yaml/spice.yaml
+++ b/bin/yaml/spice.yaml
@@ -2,11 +2,11 @@ compilers:
   spice:
     type: tarballs
     compression: gz
-    url: https://github.com/spicelang/spice/releases/download/{name}/spice_linux_amd64.tar.gz
+    url: https://github.com/spicelang/spice/releases/download/{{name}}/spice_linux_amd64.tar.gz
     check_env:
       - SPICE_STD_DIR=%PATH%/std
     check_exe: spice --version
-    dir: spice-{name}
+    dir: spice-{{name}}
     create_untar_dir: true
     targets:
       - 0.19.2

--- a/bin/yaml/swift.yaml
+++ b/bin/yaml/swift.yaml
@@ -2,17 +2,17 @@ compilers:
   swift:
     type: tarballs
     compression: gz
-    dir: swift-{name}
+    dir: swift-{{name}}
     create_untar_dir: true
     strip_components: 1
-    build: swift-{name}-release
-    toolchain: swift-{name}-RELEASE
+    build: swift-{{name}}-release
+    toolchain: swift-{{name}}-RELEASE
     check_exe: usr/bin/swiftc --version
     after_stage_script:
       # work around insane installation issue
       - chmod og+r ./usr/lib/swift/CoreFoundation/*
     older:
-      url: https://download.swift.org/{build}/ubuntu1604/{toolchain}/{toolchain}-ubuntu16.04.tar.gz
+      url: https://download.swift.org/{{build}}/ubuntu1604/{{toolchain}}/{{toolchain}}-ubuntu16.04.tar.gz
       targets:
         - 3.1.1
         - 4.0.2
@@ -26,7 +26,7 @@ compilers:
         - '5.2'
         - '5.3'
     newer:
-      url: https://download.swift.org/{build}/ubuntu2004/{toolchain}/{toolchain}-ubuntu20.04.tar.gz
+      url: https://download.swift.org/{{build}}/ubuntu2004/{{toolchain}}/{{toolchain}}-ubuntu20.04.tar.gz
       targets:
           - '5.4'
           - '5.5'
@@ -41,15 +41,15 @@ compilers:
       type: restQueryTarballs
       install_always: true
       toolchain: development
-      url: https://download.swift.org/{toolchain}/ubuntu2004/latest-build.yml
+      url: https://download.swift.org/{{toolchain}}/ubuntu2004/latest-build.yml
       query: |
-        'https://download.swift.org/{toolchain}/ubuntu2004' \
+        'https://download.swift.org/{{toolchain}}/ubuntu2004' \
         + '/' + document['dir'] \
         + '/' + document['download']
       targets:
         - nightly
       dev-snapshot:
         dir: swift-dev-snapshot
-        toolchain: swift-{name}-branch
+        toolchain: swift-{{name}}-branch
         targets:
           - '6.1'

--- a/bin/yaml/toit.yaml
+++ b/bin/yaml/toit.yaml
@@ -4,8 +4,8 @@ compilers:
     compression: gz
     strip_components: 1
     check_exe: bin/toit.run --version
-    url: https://github.com/toitlang/toit/releases/download/v{name}/toit-linux.tar.gz
-    dir: toit-{name}
+    url: https://github.com/toitlang/toit/releases/download/v{{name}}/toit-linux.tar.gz
+    dir: toit-{{name}}
     create_untar_dir: true
     targets:
       - "1.6.14"

--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -2,9 +2,9 @@ tools:
   cmake:
     type: tarballs
     compression: gz
-    url: https://github.com/Kitware/CMake/releases/download/v{name}/cmake-{name}-Linux-x86_64.tar.gz
+    url: https://github.com/Kitware/CMake/releases/download/v{{name}}/cmake-{{name}}-Linux-x86_64.tar.gz
     strip_components: 1
-    dir: cmake-v{name}
+    dir: cmake-v{{name}}
     create_untar_dir: true
     check_exe: bin/cmake --help
     targets:
@@ -21,9 +21,9 @@ tools:
     experimental:
       type: tarballs
       compression: gz
-      url: https://cmake.org/files/dev/cmake-{name}-linux-x86_64.tar.gz
+      url: https://cmake.org/files/dev/cmake-{{name}}-linux-x86_64.tar.gz
       strip_components: 1
-      dir: cmake-v{name}
+      dir: cmake-v{{name}}
       create_untar_dir: true
       check_exe: bin/cmake --help
       targets:
@@ -31,9 +31,9 @@ tools:
   ninja:
     type: ziparchive
     extract_into_folder: true
-    folder: ninja-v{name}
-    url: https://github.com/ninja-build/ninja/releases/download/v{name}/ninja-linux.zip
-    dir: ninja-v{name}
+    folder: ninja-v{{name}}
+    url: https://github.com/ninja-build/ninja/releases/download/v{{name}}/ninja-linux.zip
+    dir: ninja-v{{name}}
     create_untar_dir: true
     check_exe: ninja --version
     symlink: ninja
@@ -49,48 +49,48 @@ tools:
       - x86_64-v1.3.0
       - aarch64-v1.3.0
     after_stage_script:
-      - /opt/compiler-explorer/patchelf-0.15.0/bin/patchelf --set-rpath /opt/compiler-explorer/heaptrack-{name}/lib heaptrack-{name}/bin/heaptrack_print
+      - /opt/compiler-explorer/patchelf-0.15.0/bin/patchelf --set-rpath /opt/compiler-explorer/heaptrack-{{name}}/lib heaptrack-{{name}}/bin/heaptrack_print
   glibc-tools-x86_64:
     type: tarballs
     compression: xz
     check_exe: tracer --help
     symlink: glibc-tools-x86_64
-    dir: glibc-tools-x86_64-{name}
+    dir: glibc-tools-x86_64-{{name}}
     untar_dir: glibc-tools-x86_64
     create_untar_dir: true
     targets:
       - v1.4
-    url: https://github.com/compiler-explorer/glibc-tools/releases/download/{name}/glibc-tools-x86_64.tar.xz
+    url: https://github.com/compiler-explorer/glibc-tools/releases/download/{{name}}/glibc-tools-x86_64.tar.xz
   glibc-tools-arm64:
     type: tarballs
     compression: xz
     # not x86, so we can't execute
     check_file: tracer
     symlink: glibc-tools-arm64
-    dir: glibc-tools-arm64-{name}
+    dir: glibc-tools-arm64-{{name}}
     untar_dir: glibc-tools-arm64
     create_untar_dir: true
     targets:
       - v1.5
-    url: https://github.com/compiler-explorer/glibc-tools/releases/download/{name}/glibc-tools-arm64.tar.xz
+    url: https://github.com/compiler-explorer/glibc-tools/releases/download/{{name}}/glibc-tools-arm64.tar.xz
   iwyu:
     type: s3tarballs
     compression: xz
     check_exe: bin/include-what-you-use --version
-    path_name: iwyu/{name}
+    path_name: iwyu/{{name}}
     targets:
       - name: '0.12'
         after_stage_script:
-          - ln -s /opt/compiler-explorer/clang-8.0.0/lib iwyu-{name}/lib
+          - ln -s /opt/compiler-explorer/clang-8.0.0/lib iwyu-{{name}}/lib
       - name: '0.20'
         after_stage_script:
-          - ln -s /opt/compiler-explorer/clang-16.0.0/lib iwyu-{name}/lib
+          - ln -s /opt/compiler-explorer/clang-16.0.0/lib iwyu-{{name}}/lib
       - name: '0.21'
         after_stage_script:
-          - ln -s /opt/compiler-explorer/clang-17.0.1/lib iwyu-{name}/lib
+          - ln -s /opt/compiler-explorer/clang-17.0.1/lib iwyu-{{name}}/lib
       - name: '0.22'
         after_stage_script:
-          - ln -s /opt/compiler-explorer/clang-18.1.0/lib iwyu-{name}/lib
+          - ln -s /opt/compiler-explorer/clang-18.1.0/lib iwyu-{{name}}/lib
   pvs-studio:
     if:
       - non-free
@@ -109,15 +109,15 @@ tools:
     type: pip
     depends:
       - compilers/python 3.13.0
-    dir: osaca-{name}
+    dir: osaca-{{name}}
     python: '%DEP0%/bin/python3'
-    package: osaca=={name}
+    package: osaca=={{name}}
     check_exe: bin/osaca --version
     targets:
       - 0.6.1
   rustfmt:
     type: tarballs
-    dir: rustfmt-{name}
+    dir: rustfmt-{{name}}
     compression: gz
     check_exe: rustfmt --version
     targets:
@@ -192,18 +192,18 @@ tools:
     - 0.9.0
   baksmali:
     type: singleFile
-    dir: baksmali-{name}
+    dir: baksmali-{{name}}
     depends:
       - compilers/java 16.0.1
-    check_exe: "%DEP0%/bin/java -jar {dir}/{filename} --version"
-    filename: baksmali-{name}-fat.jar
-    url: https://storage.googleapis.com/r8-releases/smali/{name}/{filename}
+    check_exe: "%DEP0%/bin/java -jar {{dir}}/{{filename}} --version"
+    filename: baksmali-{{name}}-fat.jar
+    url: https://storage.googleapis.com/r8-releases/smali/{{name}}/{{filename}}
     targets:
       - 3.0.3
   bloaty:
     type: s3tarballs
     compression: xz
-    dir: bloaty-{name}
+    dir: bloaty-{{name}}
     check_exe: bin/bloaty --help
     targets:
       - "1.1"

--- a/bin/yaml/typescript.yaml
+++ b/bin/yaml/typescript.yaml
@@ -1,21 +1,21 @@
 compilers:
   tsc-native:
     type: tarballs
-    dir: tsc-{name}
+    dir: tsc-{{name}}
     untar_dir: tsc-ninja-release
     compression: gz
     check_exe: bin/tsc --version
-    url: https://github.com/ASDAlexander77/TypeScriptCompiler/releases/download/v{name}/tsc.tar.gz
+    url: https://github.com/ASDAlexander77/TypeScriptCompiler/releases/download/v{{name}}/tsc.tar.gz
     targets:
       - 0.0-pre-alpha20
       - 0.0-pre-alpha26
   tsc-native-ub20:
     type: tarballs
-    dir: tsc-{name}
+    dir: tsc-{{name}}
     untar_dir: tsc-ninja-release
     compression: gz
     check_exe: bin/tsc --version
-    url: https://github.com/ASDAlexander77/TypeScriptCompiler/releases/download/v{name}/tsc-ub20.tar.gz
+    url: https://github.com/ASDAlexander77/TypeScriptCompiler/releases/download/v{{name}}/tsc-ub20.tar.gz
     targets:
       - 0.0-pre-alpha27
       - 0.0-pre-alpha33

--- a/bin/yaml/v.yaml
+++ b/bin/yaml/v.yaml
@@ -1,8 +1,8 @@
 compilers:
   v:
     type: ziparchive
-    dir: v-{name}
-    url: https://github.com/vlang/v/releases/download/weekly.{name}/v_linux.zip
+    dir: v-{{name}}
+    url: https://github.com/vlang/v/releases/download/weekly.{{name}}/v_linux.zip
     folder: v
     check_exe: v --version
     check_env:

--- a/bin/yaml/vyper.yaml
+++ b/bin/yaml/vyper.yaml
@@ -3,10 +3,10 @@ compilers:
     depends:
       - compilers/python 3.13.0
     type: pip
-    dir: vyper/v{name}
+    dir: vyper/v{{name}}
     python: '%DEP0%/bin/python3'
     package:
-    - vyper=={name}
+    - vyper=={{name}}
     - cffi
     check_exe: bin/vyper --version
     targets:

--- a/bin/yaml/wasm.yaml
+++ b/bin/yaml/wasm.yaml
@@ -3,10 +3,10 @@ compilers:
     wasmtime:
       type: tarballs
       compression: xz
-      url: https://github.com/bytecodealliance/wasmtime/releases/download/v{name}/wasmtime-v{name}-x86_64-linux.tar.xz
+      url: https://github.com/bytecodealliance/wasmtime/releases/download/v{{name}}/wasmtime-v{{name}}-x86_64-linux.tar.xz
       check_exe: wasmtime --version
-      dir: wasmtime-{name}
-      untar_dir: wasmtime-v{name}-x86_64-linux
+      dir: wasmtime-{{name}}
+      untar_dir: wasmtime-v{{name}}-x86_64-linux
       targets:
         - 22.0.0
         - 21.0.1

--- a/bin/yaml/windows.yaml
+++ b/bin/yaml/windows.yaml
@@ -4,37 +4,37 @@ windows:
     x86:
       mingw-w64:
         type: ziparchive
-        dir: "mingw-w64-{name}"
+        dir: "mingw-w64-{{name}}"
         folder: "mingw64"
         check_file: "bin/g++.exe"
         # check_exe: "bin/g++.exe --version"
         targets:
           - name: "13.1.0-16.0.2-11.0.0-ucrt-r1"
-            url: https://github.com/brechtsanders/winlibs_mingw/releases/download/{name}/winlibs-x86_64-mcf-seh-gcc-13.1.0-llvm-16.0.2-mingw-w64ucrt-11.0.0-r1.zip
+            url: https://github.com/brechtsanders/winlibs_mingw/releases/download/{{name}}/winlibs-x86_64-mcf-seh-gcc-13.1.0-llvm-16.0.2-mingw-w64ucrt-11.0.0-r1.zip
           - name: "12.2.0-16.0.0-10.0.0-ucrt-r5"
-            url: https://github.com/brechtsanders/winlibs_mingw/releases/download/{name}/winlibs-x86_64-posix-seh-gcc-12.2.0-llvm-16.0.0-mingw-w64ucrt-10.0.0-r5.zip
+            url: https://github.com/brechtsanders/winlibs_mingw/releases/download/{{name}}/winlibs-x86_64-posix-seh-gcc-12.2.0-llvm-16.0.0-mingw-w64ucrt-10.0.0-r5.zip
           - name: "12.2.0-15.0.7-10.0.0-ucrt-r4"
-            url: https://github.com/brechtsanders/winlibs_mingw/releases/download/{name}/winlibs-x86_64-posix-seh-gcc-12.2.0-llvm-15.0.7-mingw-w64ucrt-10.0.0-r4.zip
+            url: https://github.com/brechtsanders/winlibs_mingw/releases/download/{{name}}/winlibs-x86_64-posix-seh-gcc-12.2.0-llvm-15.0.7-mingw-w64ucrt-10.0.0-r4.zip
           - name: "12.1.0-14.0.6-10.0.0-ucrt-r3"
-            url: https://github.com/brechtsanders/winlibs_mingw/releases/download/{name}/winlibs-x86_64-posix-seh-gcc-12.1.0-llvm-14.0.6-mingw-w64ucrt-10.0.0-r3.zip
+            url: https://github.com/brechtsanders/winlibs_mingw/releases/download/{{name}}/winlibs-x86_64-posix-seh-gcc-12.1.0-llvm-14.0.6-mingw-w64ucrt-10.0.0-r3.zip
           - name: "11.3.0-14.0.3-10.0.0-ucrt-r3"
-            url: https://github.com/brechtsanders/winlibs_mingw/releases/download/{name}/winlibs-x86_64-posix-seh-gcc-11.3.0-llvm-14.0.3-mingw-w64ucrt-10.0.0-r3.zip
+            url: https://github.com/brechtsanders/winlibs_mingw/releases/download/{{name}}/winlibs-x86_64-posix-seh-gcc-11.3.0-llvm-14.0.3-mingw-w64ucrt-10.0.0-r3.zip
       clang-cl:
         type: tarballs
         compression: xz
-        dir: clang-cl-{name}
-        untar_dir: clang+llvm-{name}-x86_64-pc-windows-msvc
+        dir: clang-cl-{{name}}
+        untar_dir: clang+llvm-{{name}}-x86_64-pc-windows-msvc
         check_file: bin/clang-cl.exe
-        url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{name}/clang+llvm-{name}-x86_64-pc-windows-msvc.tar.xz
+        url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{{name}}/clang+llvm-{{name}}-x86_64-pc-windows-msvc.tar.xz
         targets:
           - 18.1.0
   tools:
     cmake:
       type: ziparchive
-      url: https://github.com/Kitware/CMake/releases/download/v{name}/cmake-{name}-windows-x86_64.zip
-      dir: cmake-v{name}
+      url: https://github.com/Kitware/CMake/releases/download/v{{name}}/cmake-{{name}}-windows-x86_64.zip
+      dir: cmake-v{{name}}
       check_file: "bin/cmake.exe"
-      folder: "cmake-{name}-windows-x86_64"
+      folder: "cmake-{{name}}-windows-x86_64"
       targets:
         - 3.27.6
         - 3.27.9
@@ -44,8 +44,8 @@ windows:
         - 3.31.5
     ninja:
       type: ziparchive
-      url: https://github.com/compiler-explorer/ninja/releases/download/v{name}/ninja-win.zip
-      dir: ninja-v{name}
+      url: https://github.com/compiler-explorer/ninja/releases/download/v{{name}}/ninja-win.zip
+      dir: ninja-v{{name}}
       folder: "bin"
       extract_into_folder: true
       check_file: "ninja.exe"

--- a/bin/yaml/zig.yaml
+++ b/bin/yaml/zig.yaml
@@ -2,9 +2,9 @@ compilers:
   zig:
     type: tarballs
     compression: xz
-    url: https://ziglang.org/download/{name}/zig-linux-x86_64-{name}.tar.xz
+    url: https://ziglang.org/download/{{name}}/zig-linux-x86_64-{{name}}.tar.xz
     check_exe: zig version
-    dir: zig-{name}
+    dir: zig-{{name}}
     strip_components: 1
     create_untar_dir: true
     strip: true


### PR DESCRIPTION
There are several changes in this PR which you can look at individually:
1. Work to add a `ce_install config-dump` command which dumps a sequence of JSON lines of the entire expanded configuration of everything.
2. A change where (carefully) all the `{` were turned into jinja `{{` and `}}` etc. At various stages of this change, and most importantly at the end, the output of `ce_install config-dump` was compared and no actual config changes occurred.
3. The ability to use single `{` was removed from the config loader, and tests updated and added.

This should allow single quotes to be used as normal, and in some cases `{% raw %}` type things (though this is not perfect for that, we may need more work, I have ideas on how to fix that but let me know if this is enough to start with @partouf.

Some junky editor config (both from intellij and vscode) made it into the change too, I can extract if it's annoying.

Example of the first few lines of the config dump output:
```json
{"name": "compilers/ada/gnat/arm 10.3.0-2", "type": "TarballInstallable(compilers/ada/gnat/arm 10.3.0-2, arm/gnat-arm-elf-linux64-10.3.0-2)", "config": {"check_file": "", "install_path": "arm/gnat-arm-elf-linux64-10.3.0-2", "language": "ada", "name": "compilers/ada/gnat/arm 10.3.0-2", "remove_older_pattern": "", "target_name": "10.3.0-2", "untar_path": "gnat-arm-elf-linux64-10.3.0-2", "untar_to": ".", "url": "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-10.3.0-2/gnat-arm-elf-linux64-10.3.0-2.tar.gz"}}
{"name": "compilers/ada/gnat/arm 11.2.0-3", "type": "TarballInstallable(compilers/ada/gnat/arm 11.2.0-3, arm/gnat-arm-elf-linux64-11.2.0-3)", "config": {"check_file": "", "install_path": "arm/gnat-arm-elf-linux64-11.2.0-3", "language": "ada", "name": "compilers/ada/gnat/arm 11.2.0-3", "remove_older_pattern": "", "target_name": "11.2.0-3", "untar_path": "gnat-arm-elf-linux64-11.2.0-3", "untar_to": ".", "url": "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-11.2.0-3/gnat-arm-elf-linux64-11.2.0-3.tar.gz"}}
{"name": "compilers/ada/gnat/riscv64 10.3.0-2", "type": "TarballInstallable(compilers/ada/gnat/riscv64 10.3.0-2, riscv64/gnat-riscv64-elf-linux64-10.3.0-2)", "config": {"check_file": "", "install_path": "riscv64/gnat-riscv64-elf-linux64-10.3.0-2", "language": "ada", "name": "compilers/ada/gnat/riscv64 10.3.0-2", "remove_older_pattern": "", "target_name": "10.3.0-2", "untar_path": "gnat-riscv64-elf-linux64-10.3.0-2", "untar_to": ".", "url": "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-10.3.0-2/gnat-riscv64-elf-linux64-10.3.0-2.tar.gz"}}
{"name": "compilers/ada/gnat/riscv64 11.2.0-3", "type": "TarballInstallable(compilers/ada/gnat/riscv64 11.2.0-3, riscv64/gnat-riscv64-elf-linux64-11.2.0-3)", "config": {"check_file": "", "install_path": "riscv64/gnat-riscv64-elf-linux64-11.2.0-3", "language": "ada", "name": "compilers/ada/gnat/riscv64 11.2.0-3", "remove_older_pattern": "", "target_name": "11.2.0-3", "untar_path": "gnat-riscv64-elf-linux64-11.2.0-3", "untar_to": ".", "url": "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-11.2.0-3/gnat-riscv64-elf-linux64-11.2.0-3.tar.gz"}}
{"name": "compilers/nightly/dex2oat dex2oat-latest", "type": "ScriptInstallable(compilers/nightly/dex2oat dex2oat-latest, dex2oat-latest)", "config": {"check_file": "x86_64/bin/dex2oat64", "install_path": "dex2oat-latest", "language": "nightly", "name": "compilers/nightly/dex2oat dex2oat-latest", "script": "mkdir dex2oat-latest\ncd dex2oat-latest\n/home/matthew/dev/ce/infra/bin/yaml/android-java/fetch_art_release_from_head.sh\nunzip art_release.zip\nrm art_release.zip\n/home/matthew/dev/ce/infra/bin/yaml/android-java/create_boot_images.sh", "target_name": "dex2oat-latest"}}
{"name": "compilers/android-d8 8.1.56", "type": "SingleFileInstallable(compilers/android-d8 8.1.56, r8-8.1.56)", "config": {"check_file": "", "filename": "r8-8.1.56.jar", "install_path": "r8-8.1.56", "language": "android-d8", "name": "compilers/android-d8 8.1.56", "target_name": "8.1.56", "url": "https://dl.google.com/android/maven2/com/android/tools/r8/8.1.56/r8-8.1.56.jar"}}
{"name": "compilers/android-d8 8.1.72", "type": "SingleFileInstallable(compilers/android-d8 8.1.72, r8-8.1.72)", "config": {"check_file": "", "filename": "r8-8.1.72.jar", "install_path": "r8-8.1.72", "language": "android-d8", "name": "compilers/android-d8 8.1.72", "target_name": "8.1.72", "url": "https://dl.google.com/android/maven2/com/android/tools/r8/8.1.72/r8-8.1.72.jar"}}
{"name": "compilers/android-d8 8.2.33", "type": "SingleFileInstallable(compilers/android-d8 8.2.33, r8-8.2.33)", "config": {"check_file": "", "filename": "r8-8.2.33.jar", "install_path": "r8-8.2.33", "language": "android-d8", "name": "compilers/android-d8 8.2.33", "target_name": "8.2.33", "url": "https://dl.google.com/android/maven2/com/android/tools/r8/8.2.33/r8-8.2.33.jar"}}
{"name": "compilers/android-d8 8.2.42", "type": "SingleFileInstallable(compilers/android-d8 8.2.42, r8-8.2.42)", "config": {"check_file": "", "filename": "r8-8.2.42.jar", "install_path": "r8-8.2.42", "language": "android-d8", "name": "compilers/android-d8 8.2.42", "target_name": "8.2.42", "url": "https://dl.google.com/android/maven2/com/android/tools/r8/8.2.42/r8-8.2.42.jar"}}
{"name": "compilers/android-d8 8.2.47", "type": "SingleFileInstallable(compilers/android-d8 8.2.47, r8-8.2.47)", "config": {"check_file": "", "filename": "r8-8.2.47.jar", "install_path": "r8-8.2.47", "language": "android-d8", "name": "compilers/android-d8 8.2.47", "target_name": "8.2.47", "url": "https://dl.google.com/android/maven2/com/android/tools/r8/8.2.47/r8-8.2.47.jar"}}
```

To repro you can:
```sh
$ git checkout be49fae707c516553b108a72f2859ac3070a7927
$ ce_install config-dump /tmp/before
$ git checkout 50e3cc1b9fd8b7f02b73d0e50248de20d18a3a7e
$ ce_install config-dump /tmp/after
$ diff /tmp/before /tmp/after
$
```