### PR TITLE
Fix Crystal 1.14.1 build number

### DIFF
--- a/bin/yaml/crystal.yaml
+++ b/bin/yaml/crystal.yaml
@@ -1,7 +1,8 @@
 compilers:
   crystal:
     type: tarballs
-    url: https://github.com/crystal-lang/crystal/releases/download/{{name}}/crystal-{{name}}-1-linux-x86_64.tar.gz
+    build: 1
+    url: https://github.com/crystal-lang/crystal/releases/download/{{name}}/crystal-{{name}}-{{build}}-linux-x86_64.tar.gz
     compression: gz
     create_untar_dir: true
     strip_components: 1
@@ -19,7 +20,8 @@ compilers:
       - fi
     targets:
       - 1.15.0
-      # - 1.14.1 - failed see https://github.com/compiler-explorer/infra/pull/1512
+      - name: 1.14.1
+        build: 3
       - 1.13.3
       - 1.12.2
       - 1.11.1


### PR DESCRIPTION
This should pick the URL with the correct build number: https://github.com/crystal-lang/crystal/releases/download/1.14.1/crystal-1.14.1-3-linux-x86_64.tar.gz