### PR TITLE
Add ORCA/C and Golden Gate

### DIFF
--- a/bin/yaml/c.yaml
+++ b/bin/yaml/c.yaml
@@ -70,6 +70,19 @@ compilers:
       check_exe: bin/zcc -h
       targets:
         - '2.2'
+    orca-c:
+      if: non-free
+      type: non-free-s3tarballs
+      compression: gz
+      dir: orca-c-{{name}}
+      check_file: Languages/cc
+      extract_xattrs: True
+      depends:
+        - tools/goldengate 2.0.9
+      targets:
+        - 2.1.0
+        - 2.2.0
+        - 2.2.1
     nightly:
       if: nightly
       cc65:

--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -207,3 +207,11 @@ tools:
     check_exe: bin/bloaty --help
     targets:
       - "1.1"
+  goldengate:
+    if: non-free
+    type: non-free-s3tarballs
+    compression: gz
+    dir: goldengate-{{name}}
+    check_exe: bin/iix --version
+    targets:
+      - 2.0.9

--- a/update_compilers/install_nonfree_compilers.sh
+++ b/update_compilers/install_nonfree_compilers.sh
@@ -26,6 +26,11 @@ ce_install qnx
 ce_squash qnx
 
 ##################################
+# ORCA/C compilers
+ce_install orca-c
+ce_squash orca-c
+
+##################################
 # Intel compilers
 for compiler in \
     intel.tar.gz; do


### PR DESCRIPTION
This adds the ORCA/C compiler and the Golden Gate emulation tool used to run it. These are not Free Software, but their rights holders have given permission for them to be used on Compiler Explorer.

Tarballs for ORCA/C and Golden Gate can be supplied privately. They should go in your private S3 for non-free software. I think this PR should be suitable to install them from there, but you should check to be sure it works, since I don't have access to your private systems for testing.

ORCA/C and Golden Gate rely on extended attributes (xattrs) to store file type information, so an option was added to preserve xattrs when extracting the tarballs.