### PR TITLE
Add more instance types

### DIFF
--- a/terraform/asg-amd64.tf
+++ b/terraform/asg-amd64.tf
@@ -60,6 +60,24 @@ resource "aws_autoscaling_group" "prod-mixed" {
       override {
         instance_type = "m6in.large"
       }
+      override {
+        instance_type = "m7i-flex.large"
+      }
+      override {
+        instance_type = "m7i.large"
+      }
+      override {
+        instance_type = "m5dn.large"
+      }
+      override {
+        instance_type = "r6a.large"
+      }
+      override {
+        instance_type = "i3.large"
+      }
+      override {
+        instance_type = "i4i.large"
+      }
     }
   }
 


### PR DESCRIPTION
From what I can gather these extra ones are rather cheap for spot and equal in specs compared to some of the ones that we already got.
More like saving pennies probably, but it probably can't hurt.

The r6a.large, i3.large and i4i.large also have 16GB of ram instead of just 8.