### PR TITLE
Add Numba

### DIFF
--- a/bin/yaml/numba.yaml
+++ b/bin/yaml/numba.yaml
@@ -1,0 +1,13 @@
+compilers:
+  numba:
+    depends:
+      - compilers/python 3.13.0
+    type: pip
+    dir: numba/v{{name}}
+    python: "%DEP0%/bin/python3"
+    package:
+      - numba=={{name}}
+      - scipy>=0.16 # numba requires scipy 0.16+ for `numpy.linalg` functions
+    check_exe: bin/python -c "import numba; print(numba.__version__)"
+    targets:
+      - 0.61.0

--- a/bin/yaml/numba.yaml
+++ b/bin/yaml/numba.yaml
@@ -8,6 +8,6 @@ compilers:
     package:
       - numba=={{name}}
       - scipy>=0.16 # numba requires scipy 0.16+ for `numpy.linalg` functions
-    check_exe: bin/python -c "import numba; print(numba.__version__)"
+    check_exe: bin/python3 -m numba -h
     targets:
       - 0.61.0

--- a/bin/yaml/numba.yaml
+++ b/bin/yaml/numba.yaml
@@ -4,10 +4,10 @@ compilers:
       - compilers/python 3.13.0
     type: pip
     dir: numba/v{{name}}
-    python: "%DEP0%/bin/python3"
+    python: "%DEP0%/bin/python3.13"
     package:
       - numba=={{name}}
       - scipy>=0.16 # numba requires scipy 0.16+ for `numpy.linalg` functions
-    check_exe: bin/python3 -m numba --help
+    check_exe: bin/python3.13 -m numba --help
     targets:
       - 0.61.0

--- a/bin/yaml/numba.yaml
+++ b/bin/yaml/numba.yaml
@@ -8,6 +8,6 @@ compilers:
     package:
       - numba=={{name}}
       - scipy>=0.16 # numba requires scipy 0.16+ for `numpy.linalg` functions
-    check_exe: bin/python3 -m numba -h
+    check_exe: bin/python3 -m numba --help
     targets:
       - 0.61.0


### PR DESCRIPTION
- Build a python environment for https://github.com/compiler-explorer/compiler-explorer/pull/5592

~This sadly requires a globally installed `libffi.so.7`, which I managed to acquire with instructions from https://askubuntu.com/a/1300763~

---

```console
$ /opt/compiler-explorer/numba/v0.61.0/bin/python3 -c "import numba; print(numba.__version__)"
0.61.0
```

(I didn't find how to escape the quotes for this command under `check_exe`, so instead invoked the module's help.)