### PR TITLE
Extract version file during r8-latest install

### DIFF
--- a/bin/lib/installable/installable.py
+++ b/bin/lib/installable/installable.py
@@ -320,6 +320,7 @@ class SingleFileInstallable(Installable):
         with out_file_path.open("wb") as f:
             self.install_context.fetch_to(self.url, f)
         out_file_path.chmod(0o755)
+        self.install_context.run_script(staging, staging.path, self.after_stage_script)
 
     def verify(self) -> bool:
         if not super().verify():

--- a/bin/yaml/android-java.yaml
+++ b/bin/yaml/android-java.yaml
@@ -30,6 +30,9 @@ compilers:
       url: https://storage.googleapis.com/r8-releases/raw/latest-dev/r8lib.jar
       targets:
         - latest
+      after_stage_script:
+        - cd r8-{{name}}
+        - unzip r8-{{name}}.jar r8-version.properties
   dex2oat:
     dir: dex2oat-{{name}}
     check_file: "x86_64/bin/dex2oat64"


### PR DESCRIPTION
This change also updates SingleFileInstallable targets to run after_stage_script. This is a no-op for existing targets.