### PR TITLE
Added new versions of Intel OneAPI  C++ compiler

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1231,10 +1231,30 @@ compilers:
           fetch:
             - https://registrationcenter-download.intel.com/akdlm/IRC_NAS/6780ac84-6256-4b59-a647-330eb65f32b6/l_dpcpp-cpp-compiler_p_{{name}}_offline.sh install.sh
           script: *intel-one-install-script
+        - name: 2024.2.1.79
+          check_exe: compiler/latest/bin/icx -V
+          fetch:
+            - https://registrationcenter-download.intel.com/akdlm/IRC_NAS/74587994-3c83-48fd-b963-b707521a63f4/l_dpcpp-cpp-compiler_p_{{name}}_offline.sh install.sh
+          script: *intel-one-install-script
         - name: 2025.0.0.740
           check_exe: compiler/latest/bin/icx -V
           fetch:
             - https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ac92f2bb-4818-4e53-a432-f8b34d502f23/intel-dpcpp-cpp-compiler-{{name}}_offline.sh install.sh
+          script: *intel-one-install-script
+        - name: 2025.0.1.46
+          check_exe: compiler/latest/bin/icx -V
+          fetch:
+            - https://registrationcenter-download.intel.com/akdlm/IRC_NAS/4fd7c6b0-853f-458a-a8ec-421ab50a80a6/intel-dpcpp-cpp-compiler-{{name}}_offline.sh install.sh
+          script: *intel-one-install-script
+        - name: 2025.0.3.9
+          check_exe: compiler/latest/bin/icx -V
+          fetch:
+            - https://registrationcenter-download.intel.com/akdlm/IRC_NAS/1cac4f39-2032-4aa9-86d7-e4f3e40e4277/intel-dpcpp-cpp-compiler-{{name}}_offline.sh install.sh
+          script: *intel-one-install-script
+        - name: 2025.0.4.20
+          check_exe: compiler/latest/bin/icx -V
+          fetch:
+            - https://registrationcenter-download.intel.com/akdlm/IRC_NAS/84c039b6-2b7d-4544-a745-3fcf8afd643f/intel-dpcpp-cpp-compiler-{{name}}_offline.sh install.sh
           script: *intel-one-install-script
 
     nvhpc-sdk:


### PR DESCRIPTION
Added new versions (and one old one) of the Intel OneAPI C++ compiler:
 - 2024.2.1
 - 2025.0.1
 - 2025.0.3
 - 2025.0.4

Unfortunately I was not able to find anywhere the link to download the 2025.0.2.

A PR on Compiler Explorer will follow to add these compilers.

Edit: the PR is [this one](https://github.com/compiler-explorer/compiler-explorer/pull/7474).