### PR TITLE
Add c2rust to C configuration

### DIFF
--- a/bin/yaml/c.yaml
+++ b/bin/yaml/c.yaml
@@ -12,6 +12,12 @@ compilers:
       check_exe: lc3-compile --version
       targets:
         - trunk
+    c2rust:
+      if: nightly
+      type: nightly
+      check_exe: bin/c2rust --version
+      targets:
+        - master
     ppci:
       type: tarballs
       compression: gz


### PR DESCRIPTION
Adds infra configuration for c2rust. See https://github.com/compiler-explorer/compiler-explorer/pull/7475 for the PR adding c2rust to the main compiler explorer and https://github.com/compiler-explorer/misc-builder/pull/105 for the PR adding the build script for c2rust.

I'm not sure if this is the right thing to do. I'm basing this off the setup for LC3 which is another Rust application. Let me know if there's a different way that I should be going about this.