### PR TITLE
update OSACA version to newest release 0.7.0

### DIFF
--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -114,7 +114,7 @@ tools:
     package: osaca=={{name}}
     check_exe: bin/osaca --version
     targets:
-      - 0.6.1
+      - 0.7.0
   rustfmt:
     type: tarballs
     dir: rustfmt-{{name}}


### PR DESCRIPTION
Updated OSACA to version 0.7.0 that finally includes support for Intel syntax assembly.

See also the related PR in https://github.com/compiler-explorer/compiler-explorer/pull/7519