### PR TITLE
feat: add spdlog v1.{13-15}.* to libraries.yaml

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -2248,6 +2248,9 @@ libraries:
       - 1.10.0
       - 1.11.0
       - 1.12.0
+      - 1.13.0
+      - 1.14.1
+      - 1.15.2
       type: github
     spy:
       check_file: README.md


### PR DESCRIPTION
This PR adds three new minor versions of `spdlog` (each at latest patch release), https://github.com/gabime/spdlog. I'll file a corresponding PR in the main repo.