### PR TITLE
Update dex2oat latest script

### DIFF
--- a/bin/yaml/android-java/fetch_art_release_from_head.sh
+++ b/bin/yaml/android-java/fetch_art_release_from_head.sh
@@ -5,6 +5,12 @@
 
 set -euo pipefail
 
-URL=https://ci.android.com/builds/latest/branches/aosp-main/targets/aosp_arm64-trunk_staging-userdebug/view/BUILD_INFO
-RURL=$(curl -Ls -o /dev/null -w "%{url_effective}" "${URL}")
-curl "${RURL%/view/BUILD_INFO}/raw/art_release.zip" --location --output art_release.zip
+URL=https://ci.android.com/builds/latest/branches/aosp-android-latest-release/targets/aosp_cf_x86_64_only_phone-userdebug/view/BUILD_INFO
+PATTERN="(.*\/submitted\/([0-9]+)\/.*)/view/BUILD_INFO$"
+
+RURL=$(curl -Ls -o /dev/null -w %{url_effective} "${URL}")
+if ! [[ "$RURL" =~ $PATTERN ]]; then
+  echo "Got expected URL $RURL"
+  exit 1
+fi
+curl "${BASH_REMATCH[1]}/raw/art_release.zip" --location --output art_release.zip

--- a/bin/yaml/android-java/fetch_art_release_from_head.sh
+++ b/bin/yaml/android-java/fetch_art_release_from_head.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 URL=https://ci.android.com/builds/latest/branches/aosp-android-latest-release/targets/aosp_cf_x86_64_only_phone-userdebug/view/BUILD_INFO
 PATTERN="(.*\/submitted\/([0-9]+)\/.*)/view/BUILD_INFO$"
 
-RURL=$(curl -Ls -o /dev/null -w %{url_effective} "${URL}")
+RURL=$(curl -Ls -o /dev/null -w "%{url_effective}" "${URL}")
 if ! [[ "$RURL" =~ $PATTERN ]]; then
   echo "Got expected URL $RURL"
   exit 1


### PR DESCRIPTION
This updates the URL to point to the release branch that is now being used for AOSP (and also includes some other changes to bring it up-to-date with the internal script).