### PR TITLE
Add beman.inplace_vector library

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1153,6 +1153,14 @@ libraries:
         targets:
         - main
         type: github
+      beman_inplace_vector:
+        build_type: none
+        check_file: README.md
+        method: nightlyclone
+        repo: bemanproject/inplace_vector
+        targets:
+        - main
+        type: github
       beman_optional:
         build_type: none
         check_file: README.md


### PR DESCRIPTION
Issue: https://github.com/compiler-explorer/infra/issues/1573

* compiler-explorer 
    * library request issue - https://github.com/compiler-explorer/compiler-explorer/issues/7567 -
    *  PR https://github.com/compiler-explorer/compiler-explorer/pull/7568
* beman_inplace_vector:
    * issue - https://github.com/bemanproject/inplace_vector/issues/70

Tested these changes on my local VM, Ubuntu 22.04.

```bash
radu@work:~/work/beman/infra$ tree -L 2 /opt/compiler-explorer/libs/beman_inplace_vector/
/opt/compiler-explorer/libs/beman_inplace_vector/
└── main
    ├── cmake
    ├── CMakeLists.txt
    ├── CMakePresets.json
    ├── examples
    ├── include
    ├── LICENSE.txt
    ├── pre-commit.yml
    ├── README.md
    └── tests
```