### PR TITLE
add C++ library beman.execution (issue #1585)

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1174,6 +1174,14 @@ libraries:
         targets:
         - main
         type: github
+      beman_execution:
+        build_type: none
+        check_file: README.md
+        method: nightlyclone
+        repo: bemanproject/execution
+        targets:
+        - main
+        type: github
       beman_inplace_vector:
         build_type: none
         check_file: README.md


### PR DESCRIPTION
Add [beman.execution library](https://github.com/bemanproject/execution) trunk version - [issue #1585](https://github.com/compiler-explorer/infra/issues/1585).

[beman.execution](https://github.com/bemanproject/execution) is an implementation of the C++ standard library ["std::execution"](https://wg21.link/p2300) implemented as part of the [Beman Project](https://github.com/bemanproject). It provides some infrastructure and algorithms to use asynchronous operations.

I have tested this change locally on MacOS together with a change to the [compiler explorer](https://github.com/compiler-explorer/compiler-explorer) repository (for which I'll create a separate issue and PR shortly).