### PR TITLE
Add beman.task library trunk version

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1190,6 +1190,14 @@ libraries:
         targets:
         - main
         type: github
+      beman_task:
+        build_type: none
+        check_file: README.md
+        method: nightlyclone
+        repo: bemanproject/task
+        targets:
+        - main
+        type: github
       benchmark:
         build_type: cmake
         check_file: README.md


### PR DESCRIPTION
* Issue: #1588

* compiler-explorer
    *  library request issue - https://github.com/compiler-explorer/compiler-explorer/issues/7619
     * PR - https://github.com/compiler-explorer/compiler-explorer/pull/7621

* beman_task:
     * Issue - https://github.com/bemanproject/task/issues/18
      

Tested these changes on my local VM, Ubuntu 22.04:

```bash
radu@work:~/work/beman/infra$ tree -L 2 /opt/compiler-explorer/libs/beman_task/
/opt/compiler-explorer/libs/beman_task/
└── main
    ├── cmake
    ├── CMakeLists.txt
    ├── CMakePresets.json
    ├── docs
    ├── examples
    ├── include
    ├── LICENSE
    ├── Makefile
    ├── README.md
    ├── src
    └── tests
```