### PR TITLE
Add beman.net library trunk version

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1182,6 +1182,14 @@ libraries:
         targets:
         - main
         type: github
+      beman_net:
+        build_type: none
+        check_file: README.md
+        method: nightlyclone
+        repo: bemanproject/net
+        targets:
+        - main
+        type: github
       beman_optional:
         build_type: none
         check_file: README.md


### PR DESCRIPTION
* Issue: #1591 

* compiler-explorer
    *  library request issue - https://github.com/compiler-explorer/compiler-explorer/issues/7622
     * PR - https://github.com/compiler-explorer/compiler-explorer/pull/7623

* beman_net:
     * Issue -https://github.com/bemanproject/net/issues/23
      

Tested these changes on my local VM, Ubuntu 22.04:

```bash
radu@work:~/work/beman/infra$ tree -L 2 /opt/compiler-explorer/libs/beman_net
/opt/compiler-explorer/libs/beman_net
└── main
    ├── bin
    ├── cmake
    ├── CMakeLists.txt
    ├── docs
    ├── etc
    ├── examples
    ├── include
    ├── LICENSE.txt
    ├── Makefile
    ├── README.md
    ├── src
    └── tests
```