### PR TITLE
Add beman.exemplar library trunk version

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1174,6 +1174,14 @@ libraries:
         targets:
         - main
         type: github
+      beman_exemplar:
+        build_type: none
+        check_file: README.md
+        method: nightlyclone
+        repo: bemanproject/exemplar
+        targets:
+        - main
+        type: github
       beman_inplace_vector:
         build_type: none
         check_file: README.md


### PR DESCRIPTION
* Issue: #1593

* compiler-explorer
    *  library request issue - https://github.com/compiler-explorer/compiler-explorer/issues/7624
     * PR - https://github.com/compiler-explorer/compiler-explorer/pull/7625

* beman_net:
     * Issue - https://github.com/bemanproject/exemplar/issues/155
      

Tested these changes on my local VM, Ubuntu 22.04:

```bash
radu@work:~/work/beman/infra$ tree -L 2 /opt/compiler-explorer/libs/beman_exemplar/
/opt/compiler-explorer/libs/beman_exemplar/
└── main
    ├── cmake
    ├── CMakeLists.txt
    ├── CMakePresets.json
    ├── docs
    ├── examples
    ├── include
    ├── LICENSE
    ├── lockfile.json
    ├── README.md
    ├── src
    └── tests

7 directories, 5 files
```