### PR TITLE
Populate the golang std library build cache

### DIFF
--- a/bin/yaml/go.yaml
+++ b/bin/yaml/go.yaml
@@ -10,6 +10,10 @@ compilers:
       dir: golang-{{name}}
       create_untar_dir: true
       strip: true
+      after_stage_script:
+        - "export GOROOT=$(pwd)/go"
+        - "[[ $(go/bin/go version) =~ go([0-9]+)\\.([0-9]+) ]] && (( BASH_REMATCH[1] < 1 || ( BASH_REMATCH[1] == 1 && BASH_REMATCH[2] < 20 ) )) && exit 0"
+        - "go/bin/go tool dist list | while IFS=/ read -r goos goarch; do echo \"Populating build cache for ${goos}/${goarch}\"; GOOS=${goos} GOARCH=${goarch} go/bin/go build std; done"
       targets:
         - "1.4.1"
         - "1.7.2"
@@ -53,3 +57,7 @@ compilers:
           - compiler_name: go-trunk
             name: trunk
             symlink: go-tip
+        after_stage_script:
+          - "export GOROOT=$(pwd)/go"
+          - "[[ $(go/bin/go version) =~ go([0-9]+)\\.([0-9]+) ]] && (( BASH_REMATCH[1] < 1 || ( BASH_REMATCH[1] == 1 && BASH_REMATCH[2] < 20 ) )) && exit 0"
+          - "go/bin/go tool dist list | while IFS=/ read -r goos goarch; do echo \"Populating build cache for ${goos}/${goarch}\"; GOOS=${goos} GOARCH=${goarch} go/bin/go build std; done"


### PR DESCRIPTION
See https://github.com/compiler-explorer/compiler-explorer/issues/5538

Note: I only tested the ~individual commands locally, I am not familiar with how to test the integration with the installation scripts.~ non-nightly versions.