### PR TITLE
Add Environment Status Page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,11 @@ upload-events-lambda: events-lambda-package  ## Uploads events-lambda to S3
 
 .PHONY: terraform-apply
 terraform-apply:  ## Applies terraform
-	cd terraform && terraform apply
+	terraform -chdir=terraform apply
+
+.PHONY: terraform-plan
+terraform-plan:  ## Plans terraform changes
+	terraform -chdir=terraform plan
 
 .PHONY: pre-commit
 pre-commit: ce  ## Runs all pre-commit hooks

--- a/README.md
+++ b/README.md
@@ -33,3 +33,10 @@ $ npx aws-amicleaner --region 'us-east-1' \
     --exclude-newest=2 --exclude-days 7 \
     --include-name 'compiler-explorer*'
 ```
+
+# Deploying the admin site and associated lambda
+
+- If you had to change the lambda code:
+  - `make upload-lambda` - uploads the lambda code to S3 (NOT idempotent unfortunately so only do this if you change the code)
+  - `make terraform-apply` - updates the endpoints/balancer config to point at the new lambda zip
+- `make deploy-admin` - deploys the admin site HTML and CSS etc

--- a/admin/knockout.simpleGrid.3.0.js
+++ b/admin/knockout.simpleGrid.3.0.js
@@ -52,7 +52,7 @@
                            <tr data-bind=\"foreach: $parent.columns\">\
                                <td data-bind=\"html: typeof rowText === 'function' ? rowText($parent) : $parent[rowText],\
                                 style: typeof style === 'function' ? style($parent) : {},\
-                                click: typeof click === 'function' ? function () { click($parent) } : {}\"></td>\
+                                click: typeof click === 'function' ? function () { click($parent) } : undefined\"></td>\
                             </tr>\
                         </tbody>\
                     </table>");

--- a/admin/status.css
+++ b/admin/status.css
@@ -1,0 +1,159 @@
+html, body {
+    background-color: #EEEEEE;
+    padding: 20px;
+}
+
+.ko-grid {
+    width: 100%;
+    margin-top: 20px;
+}
+
+.ko-grid thead th {
+    border-bottom: 1px solid black;
+    user-select: none;
+    padding: 8px;
+    font-weight: bold;
+}
+
+.ko-grid tbody tr:nth-child(odd),
+.ko-grid thead th:nth-child(odd) {
+    background-color: #EEEEEE;
+}
+
+.ko-grid tbody tr:nth-child(even),
+.ko-grid thead th:nth-child(even) {
+    background-color: #DDDDDD;
+}
+
+.ko-grid tbody td:nth-child(odd),
+.ko-grid thead th:nth-child(odd) {
+    background-color: rgba(220, 220, 220, 0.5);
+}
+
+.ko-grid tbody td:nth-child(even),
+.ko-grid thead th:nth-child(even) {
+    background-color: rgba(200, 200, 200, 0.5);
+}
+
+.ko-grid tbody td {
+    text-align: center;
+    padding: 8px;
+}
+
+/* Style for links in the table */
+.ko-grid tbody td a {
+    color: #0366d6;
+    text-decoration: none;
+}
+
+.ko-grid tbody td a:hover {
+    text-decoration: underline;
+}
+
+.ko-grid-pageLinks {
+    background-color: #EEEEAA;
+    border-top: 1px solid #f3f3f3;
+    padding: 8px;
+    margin-top: 10px;
+}
+
+.badge {
+    display: inline-block;
+    padding: 0.25em 0.6em;
+    font-size: 0.85em;
+    font-weight: 700;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: baseline;
+    border-radius: 0.375rem;
+}
+
+.badge-success {
+    color: #fff;
+    background-color: #28a745;
+}
+
+.badge-warning {
+    color: #212529;
+    background-color: #ffc107;
+}
+
+.badge-danger {
+    color: #fff;
+    background-color: #dc3545;
+}
+
+.badge-info {
+    color: #fff;
+    background-color: #17a2b8;
+}
+
+.badge-secondary {
+    color: #fff;
+    background-color: #6c757d;
+}
+
+.loading {
+    text-align: center;
+    margin: 20px 0;
+    font-size: 1.2em;
+}
+
+.error {
+    color: #dc3545;
+    margin: 20px 0;
+    text-align: center;
+}
+
+.header {
+    text-align: center;
+    margin: 20px 0;
+}
+
+.controls {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 20px;
+}
+
+.refresh-container {
+    display: flex;
+    align-items: center;
+}
+
+.refresh-button {
+    padding: 8px 16px;
+    background-color: #6c757d;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 14px;
+    margin-right: 15px;
+}
+
+.refresh-button:hover {
+    background-color: #5a6268;
+}
+
+.auto-refresh-label {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    user-select: none;
+}
+
+.auto-refresh-label input[type="checkbox"] {
+    margin-right: 5px;
+}
+
+/* Style for version links */
+.version-link {
+    color: #0366d6;
+    cursor: pointer;
+    text-decoration: none;
+}
+
+.version-link:hover {
+    text-decoration: underline;
+}

--- a/admin/status.html
+++ b/admin/status.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Compiler Explorer - Environment Status</title>
+    <script src="knockout-3.4.2.js"></script>
+    <script src="knockout.simpleGrid.3.0.js"></script>
+    <link rel="icon" type="image/png"
+          href="https://github.com/compiler-explorer/infra/blob/main/logo/favicon.png?raw=true"/>
+    <link rel="stylesheet" href="status.css">
+</head>
+<body>
+    <div class="header">
+        <h1>Compiler Explorer Environment Status</h1>
+        <p>Last updated: <span data-bind="text: lastUpdated"></span></p>
+    </div>
+
+    <div class="controls">
+        <div class="refresh-container">
+            <button class="refresh-button" data-bind="click: refreshData">Refresh Data</button>
+            <label class="auto-refresh-label">
+                <input type="checkbox" data-bind="checked: autoRefreshEnabled">
+                Auto-refresh (15s)
+            </label>
+        </div>
+    </div>
+
+    <div class="loading" data-bind="visible: isLoading">
+        Loading environment status...
+    </div>
+
+    <div class="error" data-bind="visible: hasError, text: errorMessage"></div>
+
+    <div data-bind="visible: !isLoading() && !hasError()">
+        <div data-bind="simpleGrid: gridViewModel"></div>
+    </div>
+
+    <script src="status.js"></script>
+    <script>
+        // Initialize and bind the view model
+        const statusViewModel = new StatusViewModel();
+        ko.applyBindings(statusViewModel);
+    </script>
+</body>
+</html>

--- a/admin/status.js
+++ b/admin/status.js
@@ -1,0 +1,152 @@
+class StatusViewModel {
+    constructor() {
+        this.isLoading = ko.observable(true);
+        this.hasError = ko.observable(false);
+        this.errorMessage = ko.observable('');
+        this.lastUpdated = ko.observable('');
+        this.items = ko.observableArray([]);
+        this.autoRefreshEnabled = ko.observable(this.loadAutoRefreshSetting());
+
+        // Subscribe to changes of autoRefreshEnabled to save to localStorage
+        this.autoRefreshEnabled.subscribe((newValue) => {
+            this.saveAutoRefreshSetting(newValue);
+            this.setupAutoRefresh(newValue);
+        });
+
+        this.gridViewModel = new ko.simpleGrid.viewModel({
+            data: this.items,
+            columns: [
+                {
+                    headerText: "Environment",
+                    rowText: "description"
+                },
+                {
+                    headerText: "Status",
+                    rowText: "statusBadge"
+                },
+                {
+                    headerText: "Version",
+                    rowText: "versionDisplay"
+                },
+                {
+                    headerText: "Instances",
+                    rowText: "instances"
+                },
+                {
+                    headerText: "URL",
+                    rowText: "url"
+                }
+            ],
+            pageSize: 20
+        });
+
+        this.refreshData();
+
+        // Setup initial auto-refresh if enabled
+        this.setupAutoRefresh(this.autoRefreshEnabled());
+    }
+
+    refreshData() {
+        this.isLoading(true);
+        this.hasError(false);
+
+        // Using the ALB endpoint
+        fetch('https://compiler-explorer.com/api/status')
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error(`HTTP error! Status: ${response.status}`);
+                }
+                return response.json();
+            })
+            .then(data => {
+                this.lastUpdated(new Date(data.timestamp).toLocaleString());
+                this.items.removeAll();
+
+                data.environments.forEach(env => {
+                    const versionInfo = env.version_info || {
+                        type: 'Unknown',
+                        version: env.version || 'Unknown',
+                        version_num: 'unknown',
+                        hash_short: 'unknown',
+                        hash_url: null
+                    };
+
+                    // Create a formatted version display with commit link
+                    let versionDisplay;
+
+                    if (versionInfo.hash_url) {
+                        // Make entire version text a clickable link to the GitHub commit
+                        versionDisplay = `<a href="${versionInfo.hash_url}" target="_blank" title="View commit ${versionInfo.hash}" class="version-link">${versionInfo.version} (${versionInfo.hash_short})</a>`;
+                    } else {
+                        versionDisplay = versionInfo.version || 'Unknown';
+                    }
+
+                    this.items.push({
+                        name: env.name,
+                        description: env.description,
+                        version: env.version || 'Unknown',
+                        versionInfo: versionInfo,
+                        versionDisplay: versionDisplay,
+                        status: env.health ? env.health.status : 'Unknown',
+                        statusBadge: this.getStatusBadge(env.health ? env.health.status : 'Unknown'),
+                        instances: env.health ?
+                            `${env.health.healthy_targets}/${env.health.total_targets}` :
+                            'N/A',
+                        url: `<a href="https://${env.url}" target="_blank">${env.url}</a>`,
+                    });
+                });
+
+                this.isLoading(false);
+            })
+            .catch(error => {
+                console.error('Error fetching status:', error);
+                this.errorMessage(`Error loading status data: ${error.message}`);
+                this.hasError(true);
+                this.isLoading(false);
+            });
+    }
+
+    getStatusBadge(status) {
+        let badgeClass = '';
+        switch (status) {
+            case 'Online':
+                badgeClass = 'badge-success';
+                break;
+            case 'Offline':
+                badgeClass = 'badge-danger';
+                break;
+            default:
+                badgeClass = 'badge-secondary';
+        }
+        return `<span class="badge ${badgeClass}">${status}</span>`;
+    }
+
+    toggleAutoRefresh() {
+        this.autoRefreshEnabled(!this.autoRefreshEnabled());
+    }
+
+    // Load auto-refresh setting from localStorage
+    loadAutoRefreshSetting() {
+        const savedSetting = localStorage.getItem('ce_status_autorefresh');
+        return savedSetting === null ? true : savedSetting === 'true';
+    }
+
+    // Save auto-refresh setting to localStorage
+    saveAutoRefreshSetting(value) {
+        localStorage.setItem('ce_status_autorefresh', value.toString());
+    }
+
+    // Setup or clear the auto-refresh interval
+    setupAutoRefresh(enabled) {
+        // Clear any existing interval
+        if (this.autoRefreshInterval) {
+            clearInterval(this.autoRefreshInterval);
+            this.autoRefreshInterval = null;
+        }
+
+        // Setup new interval if enabled
+        if (enabled) {
+            this.autoRefreshInterval = setInterval(() => this.refreshData(), 15000);
+        }
+    }
+}

--- a/lambda/status.py
+++ b/lambda/status.py
@@ -1,0 +1,311 @@
+import boto3
+import json
+from datetime import datetime
+import os
+import re
+
+# Configure AWS resources
+s3_client = boto3.client("s3")
+lb_client = boto3.client("elbv2")
+ec2_client = boto3.client("ec2")
+
+# Environment configuration
+ENVIRONMENTS = [
+    {
+        "name": "prod",
+        "description": "Production",
+        "branch": "release",
+        "url": "godbolt.org",
+        "load_balancer": os.environ.get("PROD_LB_ARN"),
+    },
+    {
+        "name": "staging",
+        "description": "Staging",
+        "branch": "staging",
+        "url": "godbolt.org/staging",
+        "load_balancer": os.environ.get("STAGING_LB_ARN"),
+    },
+    {
+        "name": "beta",
+        "description": "Beta",
+        "branch": "staging",
+        "url": "godbolt.org/beta",
+        "load_balancer": os.environ.get("BETA_LB_ARN"),
+    },
+    {
+        "name": "gpu",
+        "description": "GPU",
+        "branch": "release",
+        "url": "godbolt.org/gpu",
+        "load_balancer": os.environ.get("GPU_LB_ARN"),
+    },
+    {
+        "name": "aarch64prod",
+        "description": "ARM64 Production",
+        "branch": "release",
+        "url": "godbolt.org/aarch64prod",
+        "load_balancer": os.environ.get("ARM_PROD_LB_ARN"),
+    },
+    {
+        "name": "aarch64staging",
+        "description": "ARM64 Staging",
+        "branch": "staging",
+        "url": "godbolt.org/aarch64staging",
+        "load_balancer": os.environ.get("ARM_STAGING_LB_ARN"),
+    },
+]
+
+
+def lambda_handler(event, _context):
+    """Handle Lambda invocation from API Gateway"""
+    try:
+        # CORS headers for browser access
+        headers = {
+            "Access-Control-Allow-Origin": "*",  # More permissive for testing
+            "Access-Control-Allow-Methods": "GET, OPTIONS",
+            "Access-Control-Allow-Headers": "Content-Type,X-Amz-Date,Authorization,X-Api-Key",
+            "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+            "Pragma": "no-cache",
+            "Expires": "0",
+        }
+
+        # Handle preflight OPTIONS request
+        if event.get("httpMethod") == "OPTIONS":
+            return {"statusCode": 200, "headers": headers, "body": ""}
+
+        # Collect status for all environments
+        environments_status = []
+
+        for env in ENVIRONMENTS:
+            status = get_environment_status(env)
+            environments_status.append(status)
+
+        # Return JSON response
+        return {
+            "statusCode": 200,
+            "headers": {**headers, "Content-Type": "application/json"},
+            "body": json.dumps({"environments": environments_status, "timestamp": datetime.utcnow().isoformat()}),
+        }
+    except (ValueError, TypeError, KeyError, boto3.exceptions.Boto3Error) as e:
+        print(f"Error: {str(e)}")
+        return {
+            "statusCode": 500,
+            "headers": {**headers, "Content-Type": "application/json"},
+            "body": json.dumps({"error": str(e)}),
+        }
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        # Handle unexpected errors while still returning a proper response
+        print(f"Unexpected error: {str(e)}")
+        return {
+            "statusCode": 500,
+            "headers": {**headers, "Content-Type": "application/json"},
+            "body": json.dumps({"error": "Internal server error"}),
+        }
+
+
+def extract_version_from_key(key_str):
+    """Extract clean version number from an S3 key"""
+    # Try to extract a version number from a path like 'dist/gh/main/14618.tar.xz'
+    # or directly from 'gh-14618.tar.xz'
+
+    # First, check for a gh-XXXX format
+    gh_match = re.search(r"gh-(\d+)", key_str)
+    if gh_match:
+        return f"gh-{gh_match.group(1)}"
+
+    # Then look for a version number in a path like dist/gh/main/14618.tar.xz
+    path_match = re.search(r"dist/gh/[^/]+/(\d+)[.][^/]+$", key_str)
+    if path_match:
+        return f"gh-{path_match.group(1)}"
+
+    # Generic pattern for version number at the end of a path
+    generic_path_match = re.search(r"/(\d+)[.][^/]+$", key_str)
+    if generic_path_match:
+        return f"gh-{generic_path_match.group(1)}"
+
+    # For other formats, just use the filename without extension
+    filename = key_str.split("/")[-1]
+    if "." in filename:
+        return filename.split(".")[0]
+
+    return key_str
+
+
+def parse_version_info(version_str):
+    """Parse version information to extract branch, version number, and commit hash"""
+    try:
+        # Get the full release info from S3
+        version_info = {}
+
+        # Set the clean version number - removing any paths and extensions
+        cleaned_version = extract_version_from_key(version_str)
+        version_info["version"] = cleaned_version
+
+        # Extract basic version string
+        if "gh-" in cleaned_version:
+            version_info["type"] = "GitHub"
+            version_num = cleaned_version.split("-")[1] if "-" in cleaned_version else "unknown"
+            version_info["version_num"] = version_num
+        else:
+            # Even if the cleaned version doesn't have 'gh-', the original might still be a GitHub build
+            # Set default type based on the raw version string pattern
+            if "dist/gh/" in version_str:
+                version_info["type"] = "GitHub"
+                # Try to extract the build number from the path
+                build_match = re.search(r"/(\d+)[.][^/]+$", version_str)
+                if build_match:
+                    version_info["version_num"] = build_match.group(1)
+                else:
+                    version_info["version_num"] = "unknown"
+            else:
+                version_info["type"] = "Unknown"
+                version_info["version_num"] = "unknown"
+
+        # Try to determine the correct info file path
+        info_key = None
+
+        # Parse the S3 path pattern which looks like: dist/gh/main/14618.tar.xz
+        path_match = re.match(r"dist/gh/([^/]+)/(\d+)[.][^/]+$", version_str)
+        if path_match:
+            branch = path_match.group(1)
+            build_num = path_match.group(2)
+            info_key = f"dist/gh/{branch}/{build_num}.txt"
+            print(f"Determined info key from path: {info_key}")
+
+            # Also update the version info to accurately reflect this is a GitHub build
+            version_info["type"] = "GitHub"
+            version_info["version"] = f"gh-{build_num}"
+            version_info["version_num"] = build_num
+        elif "gh-" in version_str:
+            # Extract GitHub version if it's embedded in the path
+            match = re.search(r"(gh-\d+)", version_str)
+            if match:
+                info_key = f"dist/gh/{match.group(1)}.txt"
+
+        if info_key:
+            try:
+                print(f"Looking for info file at: {info_key}")
+                release_info = s3_client.get_object(Bucket="compiler-explorer", Key=info_key)
+                commit_hash = release_info["Body"].read().decode("utf-8").strip()
+
+                # Validate that this looks like a git hash (40 hex chars)
+                if re.match(r"^[0-9a-f]{40}$", commit_hash):
+                    version_info["hash"] = commit_hash
+                    version_info["hash_short"] = commit_hash[:7]
+                    version_info[
+                        "hash_url"
+                    ] = f"https://github.com/compiler-explorer/compiler-explorer/tree/{commit_hash}"
+                else:
+                    version_info["hash"] = "unknown"
+                    version_info["hash_short"] = "unknown"
+                    version_info["hash_url"] = None
+            except (boto3.exceptions.Boto3Error, KeyError, ValueError) as e:
+                print(f"Error fetching hash from {info_key}: {str(e)}")
+                version_info["hash"] = "unknown"
+                version_info["hash_short"] = "unknown"
+                version_info["hash_url"] = None
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                print(f"Unexpected error fetching hash from {info_key}: {str(e)}")
+                version_info["hash"] = "unknown"
+                version_info["hash_short"] = "unknown"
+                version_info["hash_url"] = None
+        else:
+            version_info["hash"] = "unknown"
+            version_info["hash_short"] = "unknown"
+            version_info["hash_url"] = None
+
+        return version_info
+    except (ValueError, TypeError, KeyError, AttributeError, IndexError) as e:
+        print(f"Error parsing version '{version_str}': {str(e)}")
+        return {
+            "type": "GitHub",
+            "version": extract_version_from_key(version_str),
+            "version_num": version_str.split("/")[-1].split(".")[0] if "/" in version_str else "unknown",
+            "hash": "unknown",
+            "hash_short": "unknown",
+            "hash_url": None,
+        }
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        # Fall back to safe defaults for unexpected errors
+        print(f"Unexpected error parsing version '{version_str}': {str(e)}")
+        return {
+            "type": "Unknown",
+            "version": "Unknown",
+            "version_num": "unknown",
+            "hash": "unknown",
+            "hash_short": "unknown",
+            "hash_url": None,
+        }
+
+
+def get_environment_status(env):
+    """Get status information for a given environment"""
+    status = {
+        "name": env["name"],
+        "description": env["description"],
+        "url": env["url"],
+        "branch": env["branch"],
+    }
+
+    # Get version from S3
+    try:
+        version_key = f"version/{env['branch']}"
+        version_obj = s3_client.get_object(Bucket="compiler-explorer", Key=version_key)
+        raw_version = version_obj["Body"].read().decode("utf-8").strip()
+        status["raw_version"] = raw_version  # Store the raw version for debugging
+        version_info = parse_version_info(raw_version)
+        status["version"] = version_info["version"]  # Use the cleaned up version
+        status["version_info"] = version_info
+    except (boto3.exceptions.Boto3Error, KeyError, ValueError) as e:
+        print(f"Error fetching version for {env['name']}: {str(e)}")
+        status["version"] = "Unknown"
+        status["raw_version"] = "Error"
+        status["version_info"] = {
+            "type": "Unknown",
+            "version": "Unknown",
+            "version_num": "unknown",
+            "hash": "unknown",
+            "hash_short": "unknown",
+            "hash_url": None,
+        }
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        print(f"Unexpected error fetching version for {env['name']}: {str(e)}")
+        status["version"] = "Unknown"
+        status["raw_version"] = "Error"
+        status["version_info"] = {
+            "type": "Unknown",
+            "version": "Unknown",
+            "version_num": "unknown",
+            "hash": "unknown",
+            "hash_short": "unknown",
+            "hash_url": None,
+        }
+
+    # Check load balancer status if ARN is provided
+    if env.get("load_balancer"):
+        try:
+            lb_status = lb_client.describe_target_health(TargetGroupArn=env["load_balancer"])
+
+            healthy_targets = 0
+            total_targets = 0
+
+            for target in lb_status.get("TargetHealthDescriptions", []):
+                total_targets += 1
+                if target.get("TargetHealth", {}).get("State") == "healthy":
+                    healthy_targets += 1
+
+            status["health"] = {
+                "healthy_targets": healthy_targets,
+                "total_targets": total_targets,
+                "status": "Online" if healthy_targets > 0 else "Offline",
+            }
+        except (boto3.exceptions.Boto3Error, KeyError, ValueError) as e:
+            print(f"Error fetching load balancer status for {env['name']}: {str(e)}")
+            status["health"] = {"status": "Unknown", "error": str(e)}
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            print(f"Unexpected error fetching load balancer status for {env['name']}: {str(e)}")
+            status["health"] = {"status": "Unknown", "error": "Internal error"}
+    else:
+        status["health"] = {"status": "Unknown", "error": "No load balancer configured"}
+
+    return status

--- a/lambda/status_test.py
+++ b/lambda/status_test.py
@@ -1,0 +1,120 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+import json
+import status
+
+
+class TestStatusLambda(unittest.TestCase):
+    def setUp(self):
+        # Mock environment variables
+        os.environ["PROD_LB_ARN"] = "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/prod/abcdef"
+
+        # Create a minimal event
+        self.event = {
+            "httpMethod": "GET",
+        }
+
+    @patch("status.get_environment_status")
+    def test_lambda_handler_success(self, mock_get_status):
+        # Set up the mock
+        mock_get_status.return_value = {
+            "name": "prod",
+            "description": "Production",
+            "url": "godbolt.org",
+            "branch": "release",
+            "version": "abc123",
+            "health": {"healthy_targets": 2, "total_targets": 3, "status": "Online"},
+        }
+
+        # Call the lambda_handler
+        response = status.lambda_handler(self.event, None)
+
+        # Verify response
+        self.assertEqual(response["statusCode"], 200)
+        self.assertIn("application/json", response["headers"]["Content-Type"])
+
+        # Parse the body
+        body = json.loads(response["body"])
+        self.assertIn("environments", body)
+        self.assertIn("timestamp", body)
+
+        # Verify the mock was called for each environment
+        self.assertEqual(mock_get_status.call_count, len(status.ENVIRONMENTS))
+
+    @patch("status.get_environment_status")
+    def test_lambda_handler_options(self, mock_get_status):
+        # Set up an OPTIONS event
+        options_event = {
+            "httpMethod": "OPTIONS",
+        }
+
+        # Call the lambda_handler
+        response = status.lambda_handler(options_event, None)
+
+        # Verify CORS headers
+        self.assertEqual(response["statusCode"], 200)
+        self.assertIn("Access-Control-Allow-Origin", response["headers"])
+
+        # Verify the mock was not called
+        mock_get_status.assert_not_called()
+
+    @patch("status.s3_client")
+    @patch("status.lb_client")
+    def test_get_environment_status(self, mock_lb, mock_s3):
+        # Mock S3 response
+        mock_s3.get_object.return_value = {"Body": MagicMock(read=lambda: b"abc123")}
+
+        # Mock load balancer response
+        mock_lb.describe_target_health.return_value = {
+            "TargetHealthDescriptions": [
+                {"TargetHealth": {"State": "healthy"}},
+                {"TargetHealth": {"State": "healthy"}},
+                {"TargetHealth": {"State": "unhealthy"}},
+            ]
+        }
+
+        # Test environment
+        env = {
+            "name": "prod",
+            "description": "Production",
+            "branch": "release",
+            "url": "godbolt.org",
+            "load_balancer": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/prod/abcdef",
+        }
+
+        # Call the function
+        result = status.get_environment_status(env)
+
+        # Verify results
+        self.assertEqual(result["name"], "prod")
+        self.assertEqual(result["version"], "abc123")
+        self.assertEqual(result["health"]["healthy_targets"], 2)
+        self.assertEqual(result["health"]["total_targets"], 3)
+        self.assertEqual(result["health"]["status"], "Online")
+
+        # Verify S3 client was called
+        mock_s3.get_object.assert_called_once_with(Bucket="compiler-explorer", Key="version/release")
+
+        # Verify load balancer client was called
+        mock_lb.describe_target_health.assert_called_once_with(TargetGroupArn=env["load_balancer"])
+
+    @patch("status.s3_client")
+    def test_get_environment_status_no_lb(self, mock_s3):
+        # Mock S3 response
+        mock_s3.get_object.return_value = {"Body": MagicMock(read=lambda: b"def456")}
+
+        # Test environment without load balancer
+        env = {"name": "test", "description": "Test", "branch": "release", "url": "test.godbolt.org"}
+
+        # Call the function
+        result = status.get_environment_status(env)
+
+        # Verify results
+        self.assertEqual(result["version"], "def456")
+        self.assertEqual(result["health"]["status"], "Unknown")
+        self.assertIn("error", result["health"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -233,3 +233,20 @@ resource "aws_alb_listener_rule" "compiler-explorer-alb-listen-https-stats" {
   }
   listener_arn = aws_alb_listener.compiler-explorer-alb-listen-https.arn
 }
+
+# Status API ALB listener rule
+resource "aws_alb_listener_rule" "compiler-explorer-alb-listen-https-status" {
+  priority = 11
+  action {
+    type             = "forward"
+    target_group_arn = aws_alb_target_group.lambda_status.arn
+  }
+  condition {
+    path_pattern {
+      values = [
+        "/api/status"
+      ]
+    }
+  }
+  listener_arn = aws_alb_listener.compiler-explorer-alb-listen-https.arn
+}

--- a/terraform/tg.tf
+++ b/terraform/tg.tf
@@ -65,3 +65,16 @@ resource "aws_alb_target_group_attachment" "CEConanServerTargetInstance" {
   target_id        = aws_instance.ConanNode.id
   port             = 1080
 }
+
+# Target group for the status Lambda
+resource "aws_alb_target_group" "lambda_status" {
+  name        = "StatusApiTargetGroup"
+  target_type = "lambda"
+}
+
+# Attach the Lambda function to the target group
+resource "aws_alb_target_group_attachment" "lambda-status-endpoint" {
+  target_group_arn = aws_alb_target_group.lambda_status.arn
+  target_id        = aws_lambda_function.status.arn
+  depends_on       = [aws_lambda_permission.from_alb_status]
+}


### PR DESCRIPTION
## Summary
- Adds a status page for Compiler Explorer environments showing their online/offline status, version information, and health
- Provides an API endpoint that fetches status information from S3 and load balancers
- Includes HTML/JS frontend with auto-refresh functionality and GitHub version linking

## Test plan
1. Verify that the status page displays correctly at `/admin/status.html`
2. Check that the API endpoint works at `/api/status`
3. Confirm that version links correctly point to GitHub repository tree at the specific commit
4. Test auto-refresh functionality with the checkbox
5. Verify that responsive design works on different screen sizes

Fixes #1598

🤖 Generated with [Claude Code](https://claude.ai/code)