### PR TITLE
Migrate to ruff for formatting, linting and isorting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,10 +12,12 @@ repos:
       - id: mixed-line-ending
       - id: check-toml
       - id: detect-private-key
-  - repo: https://github.com/psf/black
-    rev: 22.6.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.7
     hooks:
-      - id: black
+      - id: ruff
+        args: [ --fix ]
+      - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.971
     hooks:
@@ -32,10 +34,6 @@ repos:
     rev: 3.0.0
     hooks:
       - id: shellcheck
-  - repo: https://github.com/PyCQA/autoflake
-    rev: v2.2.1
-    hooks:
-      - id: autoflake
   # - repo: https://github.com/antonbabenko/pre-commit-terraform
   #   rev: v1.92.0
   #   hooks:
@@ -43,11 +41,6 @@ repos:
   #     - id: terraform_validate
   - repo: local
     hooks:
-      - id: pylint
-        name: pylint
-        entry: .poetry/bin/poetry run pylint
-        language: system
-        types: [python]
       - id: test
         name: Run tests
         entry: make test

--- a/bin/lib/amazon.py
+++ b/bin/lib/amazon.py
@@ -1,11 +1,11 @@
+import json
+import logging
 from datetime import datetime
 from operator import attrgetter
 from typing import List, Optional
-import logging
-import json
 
 from lib.env import Config, Environment
-from lib.releases import Version, Release, Hash, VersionSource
+from lib.releases import Hash, Release, Version, VersionSource
 
 S3_STORAGE_BUCKET = "storage.godbolt.org"
 
@@ -29,7 +29,6 @@ class LazyObjectWrapper:
 # this is a free function to avoid potentially shadowing any underlying members
 # which could happen if this was itself placed as a member of LazyObjectWrapper
 def force_lazy_init(lazy):
-    # pylint: disable=W0212
     lazy._LazyObjectWrapper__ensure_setup()
 
 
@@ -49,7 +48,6 @@ boto3 = LazyObjectWrapper(_import_boto)
 def _create_anon_s3_client():
     # https://github.com/boto/botocore/issues/1395
     obj = boto3.client("s3", aws_access_key_id="", aws_secret_access_key="")
-    # pylint: disable=W0212
     obj._request_signer.sign = lambda *args, **kwargs: None
     return obj
 

--- a/bin/lib/amazon_properties.py
+++ b/bin/lib/amazon_properties.py
@@ -2,10 +2,11 @@ import os
 import re
 import urllib.parse
 from collections import defaultdict
-from typing import Dict, Any
-from lib.library_platform import LibraryPlatform
+from typing import Any, Dict
 
 import requests
+
+from lib.library_platform import LibraryPlatform
 
 
 def get_specific_library_version_details(libraries, libid, library_version):

--- a/bin/lib/binary_info.py
+++ b/bin/lib/binary_info.py
@@ -2,7 +2,8 @@ import re
 import subprocess
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, Any, Iterable
+from typing import Any, Dict, Iterable
+
 from lib.library_platform import LibraryPlatform
 
 SYMBOLLINE_RE = re.compile(
@@ -65,10 +66,9 @@ class BinaryInfo:
                 self.readelf_header_details = self._debug_check_output(["readelf", "-h", str(self.filepath)])
                 self.readelf_symbols_details = self._debug_check_output(["readelf", "-W", "-s", str(self.filepath)])
                 if ".so" in self.filepath.name:
-                    # pylint: disable=W0702
                     try:
                         self.ldd_details = self._debug_check_output(["ldd", str(self.filepath)])
-                    except:
+                    except:  # noqa: E722
                         # some C++ SO's are stubborn and ldd can't read them for some reason, readelf -d sort of gives us the same info
                         self.ldd_details = self._debug_check_output(["readelf", "-d", str(self.filepath)])
             elif self.platform == LibraryPlatform.Windows:

--- a/bin/lib/cdn.py
+++ b/bin/lib/cdn.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from tempfile import mkdtemp
 from zipfile import ZipFile
 
-from lib.amazon import botocore, s3_client, force_lazy_init
+from lib.amazon import botocore, force_lazy_init, s3_client
 
 logger = logging.getLogger("ce-cdn")
 
@@ -91,7 +91,6 @@ class DeploymentJob:
         with ZipFile(self.tar_file_path) as zipfile:
 
             def is_within_directory(directory, target):
-
                 abs_directory = os.path.abspath(directory)
                 abs_target = os.path.abspath(target)
 
@@ -100,7 +99,6 @@ class DeploymentJob:
                 return prefix == abs_directory
 
             def safe_extract(zipfile, path=".", members=None):
-
                 for member in zipfile.infolist():
                     member_path = os.path.join(path, member.filename)
                     if not is_within_directory(path, member_path):
@@ -122,7 +120,6 @@ class DeploymentJob:
         with tarfile.open(self.tar_file_path) as tar:
 
             def is_within_directory(directory, target):
-
                 abs_directory = os.path.abspath(directory)
                 abs_target = os.path.abspath(target)
 
@@ -131,7 +128,6 @@ class DeploymentJob:
                 return prefix == abs_directory
 
             def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
-
                 for member in tar.getmembers():
                     member_path = os.path.join(path, member.name)
                     if not is_within_directory(path, member_path):

--- a/bin/lib/ce.py
+++ b/bin/lib/ce.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 def main():
     try:
-        cli(prog_name="ce")  # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
+        cli(prog_name="ce")
     except KeyboardInterrupt:
         # print empty line so terminal prompt doesn't end up on the end of some
         # of our own program output

--- a/bin/lib/ce_install.py
+++ b/bin/lib/ce_install.py
@@ -4,25 +4,25 @@ import json
 import logging
 import logging.config
 import multiprocessing
-from multiprocessing.pool import ThreadPool
 import os
 import signal
 import sys
 import traceback
 from dataclasses import dataclass
 from functools import partial
+from multiprocessing.pool import ThreadPool
 from pathlib import Path
-from typing import List, Optional, Tuple, TextIO
+from typing import List, Optional, TextIO, Tuple
 
 import click
 import yaml
 
 from lib.amazon_properties import get_properties_compilers_and_libraries
-from lib.library_platform import LibraryPlatform
 from lib.config_safe_loader import ConfigSafeLoader
 from lib.installable.installable import Installable
 from lib.installation import installers_for
 from lib.installation_context import InstallationContext
+from lib.library_platform import LibraryPlatform
 from lib.library_yaml import LibraryYaml
 
 _LOGGER = logging.getLogger(__name__)
@@ -441,7 +441,7 @@ def install(context: CliContext, filter_: List[str], force: bool):
                     else:
                         _LOGGER.info("%s installed OK", installable.name)
                         num_installed += 1
-            except Exception as e:  # pylint: disable=broad-except
+            except Exception as e:
                 _LOGGER.info("%s failed to install: %s\n%s", installable.name, e, traceback.format_exc(5))
                 failed.append(installable.name)
         else:
@@ -449,7 +449,7 @@ def install(context: CliContext, filter_: List[str], force: bool):
             num_skipped += 1
     print(
         f"{num_installed} packages installed "
-        f'{"(apparently; this was a dry-run) " if context.installation_context.dry_run else ""}OK, '
+        f"{'(apparently; this was a dry-run) ' if context.installation_context.dry_run else ''}OK, "
         f"{num_skipped} skipped, and {len(failed)} failed installation"
     )
     if len(failed):
@@ -466,8 +466,7 @@ def install(context: CliContext, filter_: List[str], force: bool):
     "--buildfor",
     default="",
     metavar="BUILDFOR",
-    help="Filter to only build for given compiler (should be a CE compiler identifier), "
-    "leave empty to build for all",
+    help="Filter to only build for given compiler (should be a CE compiler identifier), leave empty to build for all",
 )
 @click.option("--popular-compilers-only", is_flag=True, help="Only build with popular (enough) compilers")
 @click.option("--temp-install", is_flag=True, help="Temporary install target if it's not installed yet")
@@ -632,7 +631,7 @@ def config_dump(context: CliContext, output: TextIO):
 
 
 def main():
-    cli(prog_name="ce_install")  # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
+    cli(prog_name="ce_install")
 
 
 if __name__ == "__main__":

--- a/bin/lib/ce_utils.py
+++ b/bin/lib/ce_utils.py
@@ -2,11 +2,11 @@ import itertools
 import json
 import logging
 import time
-from typing import Optional, Union, Set, List
+from typing import List, Optional, Set, Union
 
 import click
 
-from lib.amazon import get_current_key, release_for, get_releases, get_events_file, save_event_file
+from lib.amazon import get_current_key, get_events_file, get_releases, release_for, save_event_file
 from lib.env import Config
 from lib.instance import Instance
 from lib.releases import Hash, Release

--- a/bin/lib/cli/__init__.py
+++ b/bin/lib/cli/__init__.py
@@ -1,7 +1,7 @@
 import importlib
 from pathlib import Path
 
-from .cli import cli
+from .cli import cli  # noqa: F401
 
 THIS_FILE = Path(__file__)
 for file in THIS_FILE.parent.glob("*.py"):

--- a/bin/lib/cli/admin.py
+++ b/bin/lib/cli/admin.py
@@ -5,7 +5,7 @@ import click
 from lib.amazon import ec2_client
 from lib.cli import cli
 from lib.instance import AdminInstance
-from lib.ssh import run_remote_shell, exec_remote_to_stdout
+from lib.ssh import exec_remote_to_stdout, run_remote_shell
 
 
 @cli.group()

--- a/bin/lib/cli/ads.py
+++ b/bin/lib/cli/ads.py
@@ -1,11 +1,11 @@
 import json
-from typing import Sequence, Optional, Tuple
+from typing import Optional, Sequence, Tuple
 
 import click
 import dateutil.parser
 
 from lib.amazon import save_event_file
-from lib.ce_utils import get_events, are_you_sure
+from lib.ce_utils import are_you_sure, get_events
 from lib.cli import cli
 from lib.env import Config
 

--- a/bin/lib/cli/builder.py
+++ b/bin/lib/cli/builder.py
@@ -4,7 +4,8 @@ from typing import Sequence
 import click
 
 from lib.instance import BuilderInstance
-from lib.ssh import run_remote_shell, exec_remote, exec_remote_to_stdout
+from lib.ssh import exec_remote, exec_remote_to_stdout, run_remote_shell
+
 from .cli import cli
 
 
@@ -46,7 +47,7 @@ def builder_start():
             r = exec_remote(instance, ["echo", "hello"])
             if r.strip() == "hello":
                 break
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as e:
             print("Still waiting for SSH: got: {}".format(e))
         time.sleep(5)
     else:

--- a/bin/lib/cli/builds.py
+++ b/bin/lib/cli/builds.py
@@ -5,37 +5,37 @@ import subprocess
 import sys
 import tempfile
 from collections import defaultdict
-from typing import Optional, Dict, Sequence
+from typing import Dict, Optional, Sequence
 
 import click
 import requests
 
 from lib.amazon import (
+    delete_bouncelock_file,
     download_release_file,
     download_release_fileobj,
     find_latest_release,
     find_release,
-    get_all_releases,
-    get_key_counterpart,
-    log_new_build,
-    set_current_key,
-    get_ssm_param,
     get_all_current,
-    get_releases,
-    remove_release,
+    get_all_releases,
     get_current_key,
+    get_key_counterpart,
+    get_releases,
+    get_ssm_param,
+    has_bouncelock_file,
     list_all_build_logs,
     list_period_build_logs,
+    log_new_build,
     put_bouncelock_file,
-    delete_bouncelock_file,
-    has_bouncelock_file,
+    remove_release,
+    set_current_key,
 )
 from lib.cdn import DeploymentJob
-from lib.ce_utils import describe_current_release, are_you_sure, display_releases, confirm_branch, confirm_action
+from lib.ce_utils import are_you_sure, confirm_action, confirm_branch, describe_current_release, display_releases
 from lib.cli import cli
 from lib.cli.runner import runner_discoveryexists
 from lib.env import Config, Environment
-from lib.releases import Version, Release, VersionSource
+from lib.releases import Release, Version, VersionSource
 
 
 @cli.group()

--- a/bin/lib/cli/cli.py
+++ b/bin/lib/cli/cli.py
@@ -2,7 +2,7 @@ import logging
 
 import click
 
-from lib.env import Environment, Config
+from lib.env import Config, Environment
 
 
 @click.group()

--- a/bin/lib/cli/compiler_stats.py
+++ b/bin/lib/cli/compiler_stats.py
@@ -1,5 +1,6 @@
-import boto3
 import os
+
+import boto3
 
 from lib.cli import cli
 

--- a/bin/lib/cli/conan.py
+++ b/bin/lib/cli/conan.py
@@ -4,7 +4,7 @@ import click
 
 from lib.cli import cli
 from lib.instance import ConanInstance
-from lib.ssh import run_remote_shell, exec_remote_to_stdout, exec_remote
+from lib.ssh import exec_remote, exec_remote_to_stdout, run_remote_shell
 
 
 @cli.group()

--- a/bin/lib/cli/decorations.py
+++ b/bin/lib/cli/decorations.py
@@ -5,7 +5,7 @@ from typing import Sequence
 import click
 
 from lib.amazon import save_event_file
-from lib.ce_utils import get_events, are_you_sure
+from lib.ce_utils import are_you_sure, get_events
 from lib.cli import cli
 from lib.env import Config
 

--- a/bin/lib/cli/environment.py
+++ b/bin/lib/cli/environment.py
@@ -2,7 +2,7 @@ import time
 
 import click
 
-from lib.amazon import get_autoscaling_groups_for, as_client
+from lib.amazon import as_client, get_autoscaling_groups_for
 from lib.ce_utils import are_you_sure, describe_current_release, set_update_message
 from lib.cli import cli
 from lib.env import Config, Environment

--- a/bin/lib/cli/instances.py
+++ b/bin/lib/cli/instances.py
@@ -4,18 +4,18 @@ import shlex
 import subprocess
 import sys
 import time
-from typing import Sequence, Dict
+from typing import Dict, Sequence
 
 import click
 
-from lib.amazon import as_client, target_group_arn_for, get_autoscaling_group
-from lib.ce_utils import describe_current_release, are_you_sure, logger, wait_for_autoscale_state, set_update_message
+from lib.amazon import as_client, get_autoscaling_group, target_group_arn_for
+from lib.ce_utils import are_you_sure, describe_current_release, set_update_message, wait_for_autoscale_state
 from lib.cli import cli
 from lib.env import Config, Environment
-from lib.instance import print_instances, Instance
-from lib.ssh import exec_remote_all, run_remote_shell, exec_remote
+from lib.instance import Instance, print_instances
+from lib.ssh import exec_remote, exec_remote_all, run_remote_shell
 
-logger = logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 
 @cli.group()
@@ -51,14 +51,14 @@ def instances_restart_one(cfg: Config):
     instance = pick_instance(cfg)
     as_instance_status = instance.describe_autoscale()
     if not as_instance_status:
-        logger.error("Failed restarting %s - was not in ASG", instance)
+        LOGGER.error("Failed restarting %s - was not in ASG", instance)
         return
     as_group_name = as_instance_status["AutoScalingGroupName"]
     modified_groups: Dict[str, int] = {}
     try:
         restart_one_instance(as_group_name, instance, modified_groups)
     except RuntimeError as e:
-        logger.error("Failed restarting %s - skipping: %s", instance, e)
+        LOGGER.error("Failed restarting %s - skipping: %s", instance, e)
 
 
 @instances.command(name="start")
@@ -101,25 +101,25 @@ def instances_restart(cfg: Config, motd: str):
     to_restart = pick_instances(cfg)
 
     for index, instance in enumerate(to_restart):
-        logger.info("Restarting %s (%d of %d)...", instance, index + 1, len(to_restart))
+        LOGGER.info("Restarting %s (%d of %d)...", instance, index + 1, len(to_restart))
         as_instance_status = instance.describe_autoscale()
         if not as_instance_status:
-            logger.warning("Skipping %s as it is no longer in the ASG", instance)
+            LOGGER.warning("Skipping %s as it is no longer in the ASG", instance)
             continue
         as_group_name = as_instance_status["AutoScalingGroupName"]
         if as_instance_status["LifecycleState"] != "InService":
-            logger.warning("Skipping %s as it is not InService (%s)", instance, as_instance_status)
+            LOGGER.warning("Skipping %s as it is not InService (%s)", instance, as_instance_status)
             continue
 
         try:
             restart_one_instance(as_group_name, instance, modified_groups)
         except RuntimeError as e:
-            logger.error("Failed restarting %s - skipping: %s", instance, e)
+            LOGGER.error("Failed restarting %s - skipping: %s", instance, e)
             failed = True
             # TODO, what here?
 
     for group, desired in iter(modified_groups.items()):
-        logger.info("Putting desired instances for %s back to %d", group, desired)
+        LOGGER.info("Putting desired instances for %s back to %d", group, desired)
         as_client.update_auto_scaling_group(AutoScalingGroupName=group, DesiredCapacity=desired)
     set_update_message(cfg, "")
     end_time = datetime.datetime.now()
@@ -154,48 +154,48 @@ def pick_instances(cfg: Config):
 
 def restart_one_instance(as_group_name: str, instance: Instance, modified_groups: Dict[str, int]):
     instance_id = instance.instance.instance_id
-    logger.info("Enabling instance protection for %s", instance)
+    LOGGER.info("Enabling instance protection for %s", instance)
     as_client.set_instance_protection(
         AutoScalingGroupName=as_group_name, InstanceIds=[instance_id], ProtectedFromScaleIn=True
     )
     as_group = get_autoscaling_group(as_group_name)
     adjustment_required = as_group["DesiredCapacity"] == as_group["MinSize"]
     if adjustment_required:
-        logger.info("Group '%s' needs to be adjusted to keep enough nodes", as_group_name)
+        LOGGER.info("Group '%s' needs to be adjusted to keep enough nodes", as_group_name)
         modified_groups[as_group["AutoScalingGroupName"]] = as_group["DesiredCapacity"]
-    logger.info("Putting %s into standby", instance)
+    LOGGER.info("Putting %s into standby", instance)
     as_client.enter_standby(
         InstanceIds=[instance_id],
         AutoScalingGroupName=as_group_name,
         ShouldDecrementDesiredCapacity=not adjustment_required,
     )
     wait_for_autoscale_state(instance, "Standby")
-    logger.info("Restarting service on %s", instance)
+    LOGGER.info("Restarting service on %s", instance)
     restart_response = exec_remote(instance, ["sudo", "systemctl", "restart", "compiler-explorer"])
     if restart_response:
-        logger.warning("Restart gave some output: %s", restart_response)
+        LOGGER.warning("Restart gave some output: %s", restart_response)
     wait_for_healthok(instance)
-    logger.info("Moving %s out of standby", instance)
+    LOGGER.info("Moving %s out of standby", instance)
     as_client.exit_standby(InstanceIds=[instance_id], AutoScalingGroupName=as_group_name)
     wait_for_autoscale_state(instance, "InService")
     wait_for_elb_state(instance, "healthy")
-    logger.info("Disabling instance protection for %s", instance)
+    LOGGER.info("Disabling instance protection for %s", instance)
     as_client.set_instance_protection(
         AutoScalingGroupName=as_group_name, InstanceIds=[instance_id], ProtectedFromScaleIn=False
     )
-    logger.info("Instance restarted ok")
+    LOGGER.info("Instance restarted ok")
 
 
 def wait_for_elb_state(instance, state):
-    logger.info("Waiting for %s to reach ELB state '%s'...", instance, state)
+    LOGGER.info("Waiting for %s to reach ELB state '%s'...", instance, state)
     while True:
         instance.update()
         instance_state = instance.instance.state["Name"]
         if instance_state != "running":
             raise RuntimeError("Instance no longer running (state {})".format(instance_state))
-        logger.debug("State is %s", instance.elb_health)
+        LOGGER.debug("State is %s", instance.elb_health)
         if instance.elb_health == state:
-            logger.info("...done")
+            LOGGER.info("...done")
             return
         time.sleep(5)
 
@@ -209,7 +209,7 @@ def is_everything_awesome(instance):
 
 
 def wait_for_healthok(instance):
-    logger.info("Waiting for instance to be Online %s", instance)
+    LOGGER.info("Waiting for instance to be Online %s", instance)
     sys.stdout.write("Waiting")
     while not is_everything_awesome(instance):
         sys.stdout.write(".")

--- a/bin/lib/cli/library_stats.py
+++ b/bin/lib/cli/library_stats.py
@@ -1,5 +1,6 @@
-import boto3
 import os
+
+import boto3
 
 from lib.cli import cli
 

--- a/bin/lib/cli/links.py
+++ b/bin/lib/cli/links.py
@@ -4,12 +4,12 @@ from pprint import pformat
 import click
 
 from lib.amazon import (
-    get_short_link,
-    expand_short_link,
-    put_short_link,
-    list_short_links,
-    delete_short_link,
     delete_s3_links,
+    delete_short_link,
+    expand_short_link,
+    get_short_link,
+    list_short_links,
+    put_short_link,
 )
 from lib.ce_utils import are_you_sure
 from lib.cli import cli

--- a/bin/lib/cli/motd.py
+++ b/bin/lib/cli/motd.py
@@ -3,7 +3,7 @@ import json
 import click
 
 from lib.amazon import save_event_file
-from lib.ce_utils import get_events, are_you_sure, save_events
+from lib.ce_utils import are_you_sure, get_events, save_events
 from lib.cli import cli
 from lib.env import Config
 

--- a/bin/lib/cli/runner.py
+++ b/bin/lib/cli/runner.py
@@ -2,13 +2,14 @@ import time
 from tempfile import NamedTemporaryFile
 from typing import Sequence, TextIO
 
-import click
 import boto3
 import botocore.exceptions
-from lib.env import Environment
+import click
 
+from lib.env import Environment
 from lib.instance import RunnerInstance
-from lib.ssh import get_remote_file, run_remote_shell, exec_remote, exec_remote_to_stdout
+from lib.ssh import exec_remote, exec_remote_to_stdout, get_remote_file, run_remote_shell
+
 from .cli import cli
 
 EXPECTED_REMOTE_COMPILERS = {"gpu", "winprod"}
@@ -152,7 +153,7 @@ def runner_start():
             r = exec_remote(instance, ["echo", "hello"])
             if r.strip() == "hello":
                 break
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as e:
             print("Still waiting for SSH: got: {}".format(e))
         time.sleep(5)
     else:
@@ -166,7 +167,7 @@ def runner_start():
                 or "compiler-explorer.service: Succeeded." in r  # 20.04
             ):
                 break
-        except:  # pylint: disable=bare-except
+        except:  # noqa: E722
             print("Waiting for startup to complete")
         time.sleep(5)
     else:

--- a/bin/lib/cli/smb.py
+++ b/bin/lib/cli/smb.py
@@ -4,7 +4,7 @@ import click
 
 from lib.cli import cli
 from lib.instance import SMBInstance, SMBTestInstance
-from lib.ssh import run_remote_shell, exec_remote_to_stdout
+from lib.ssh import exec_remote_to_stdout, run_remote_shell
 
 
 @cli.group()

--- a/bin/lib/cli/tools.py
+++ b/bin/lib/cli/tools.py
@@ -5,8 +5,8 @@ from typing import List
 
 import click
 
-from lib.amazon import get_tools_releases, download_release_file
-from lib.ce_utils import display_releases, are_you_sure
+from lib.amazon import download_release_file, get_tools_releases
+from lib.ce_utils import are_you_sure, display_releases
 from lib.cli import cli
 from lib.releases import Hash, Version, VersionSource
 

--- a/bin/lib/config_safe_loader.py
+++ b/bin/lib/config_safe_loader.py
@@ -1,6 +1,5 @@
 import yaml
 
-
 # With thanks to:
 # https://stackoverflow.com/questions/34667108/ignore-dates-and-times-while-parsing-yaml
 

--- a/bin/lib/fortran_library_builder.py
+++ b/bin/lib/fortran_library_builder.py
@@ -9,19 +9,19 @@ import re
 import shutil
 import subprocess
 import tempfile
+import time
 from collections import defaultdict
 from enum import Enum, unique
 from pathlib import Path
-import time
-from typing import Dict, Any, List, Optional, Generator, TextIO
-from urllib3.exceptions import ProtocolError
+from typing import Any, Dict, Generator, List, Optional, TextIO
 
 import requests
+from urllib3.exceptions import ProtocolError
 
 from lib.amazon import get_ssm_param
-from lib.amazon_properties import get_specific_library_version_details, get_properties_compilers_and_libraries
-from lib.library_platform import LibraryPlatform
+from lib.amazon_properties import get_properties_compilers_and_libraries, get_specific_library_version_details
 from lib.library_build_config import LibraryBuildConfig
+from lib.library_platform import LibraryPlatform
 from lib.staging import StagingDir
 
 _TIMEOUT = 600
@@ -251,7 +251,7 @@ class FortranLibraryBuilder:
         last_error = ""
         while retries > 0:
             try:
-                if headers != None:
+                if headers is not None:
                     request = requests.post(url, data=json_data, headers=headers, timeout=_TIMEOUT)
                 else:
                     request = requests.post(
@@ -264,7 +264,7 @@ class FortranLibraryBuilder:
                 retries = retries - 1
                 time.sleep(1)
 
-        if request == None:
+        if request is None:
             request = {"ok": False, "text": last_error}
 
         return request
@@ -708,7 +708,7 @@ class FortranLibraryBuilder:
             self.logger.debug("downloading compiler popularity csv")
             self.download_compiler_usage_csv()
 
-        if not compiler in popular_compilers:
+        if compiler not in popular_compilers:
             return False
 
         if popular_compilers[compiler] < compiler_popularity_treshhold:

--- a/bin/lib/installable/archives.py
+++ b/bin/lib/installable/archives.py
@@ -3,23 +3,22 @@ from __future__ import annotations
 import functools
 import logging
 import os
+import re
+import shlex
+import socket
 import subprocess
 import tempfile
-import socket
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
-import shlex
-from typing import Dict, Any
+from typing import Any, Dict
 
 from lib import amazon
 from lib.amazon import list_compilers
 from lib.installable.installable import Installable, command_config
 from lib.installation_context import InstallationContext, is_windows
-from lib.staging import StagingDir
 from lib.nightly_versions import NightlyVersions
-
-import re
+from lib.staging import StagingDir
 
 VERSIONED_RE = re.compile(r"^(.*)-([0-9.]+)$")
 
@@ -209,7 +208,7 @@ class TarballInstallable(Installable):
         elif self.config_get("compression") == "tar":
             decompress_flag = ""
         else:
-            raise RuntimeError(f'Unknown compression {self.config_get("compression")}')
+            raise RuntimeError(f"Unknown compression {self.config_get('compression')}")
         self.configure_command = command_config(self.config_get("configure_command", []))
         if is_windows() and decompress_flag == "J":
             self.tar_cmd = ["7z", "x"]
@@ -365,7 +364,6 @@ class RestQueryTarballInstallable(TarballInstallable):
         document = self.install_context.fetch_rest_query(self.config_get("url"))
         query = self.config_get("query")
         try:
-            # pylint: disable-next=eval-used
             self.url = eval(query, {}, dict(document=document))
         except Exception:
             self._logger.exception("Exception evaluating query '%s' for %s", query, self)

--- a/bin/lib/installable/edg.py
+++ b/bin/lib/installable/edg.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
-from dataclasses import dataclass
-import logging
-import tempfile
-from typing import Dict, Any, Callable
 
+import logging
 import shlex
 import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict
+
 from lib import amazon
 from lib.installable.archives import NonFreeS3TarballInstallable
 from lib.installation_context import InstallationContext
 from lib.staging import StagingDir
-from pathlib import Path
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -114,7 +115,7 @@ class EdgCompilerInstallable(NonFreeS3TarballInstallable):
             return backend_path / "bin" / "gcc"
         else:
             # Currently only GCC emulation is supported on Compiler Explorer.
-            assert False, f"Emulation of the {self._compiler_type} C compiler family is not supported"
+            raise AssertionError(f"Emulation of the {self._compiler_type} C compiler family is not supported")
 
     def _resolve_emulated_cpp_compiler(self) -> Path:
         """The EDG front end generates C files and thus uses a backing C
@@ -127,7 +128,7 @@ class EdgCompilerInstallable(NonFreeS3TarballInstallable):
             return backend_path / "bin" / "g++"
         else:
             # Currently only GCC emulation is supported on Compiler Explorer.
-            assert False, f"Emulation of the {self._compiler_type} C++ compiler family is not supported"
+            raise AssertionError(f"Emulation of the {self._compiler_type} C++ compiler family is not supported")
 
     def _scrape_backend_compiler(self, staging: StagingDir, backend_compiler_path: Path) -> EdgBackendCompilerScrape:
         """The EDG front end when emulating a compiler needs to know that
@@ -185,12 +186,12 @@ class EdgCompilerInstallable(NonFreeS3TarballInstallable):
             if self._compiler_type == "gcc":
                 command_args = ["--g++", str(emulated_cpp_compiler_path), "--gcc", str(emulated_c_compiler_path)]
             elif self._compiler_type == "clang":
-                assert (
-                    emulated_c_compiler_path == emulated_cpp_compiler_path
-                ), "The emulate clang C and C++ compiler should be the same binary"
+                assert emulated_c_compiler_path == emulated_cpp_compiler_path, (
+                    "The emulate clang C and C++ compiler should be the same binary"
+                )
                 command_args = ["--clang", str(emulated_cpp_compiler_path)]
             else:
-                assert False, f"Cannot generate macros for {self._compiler_type}"
+                raise AssertionError(f"Cannot generate macros for {self._compiler_type}")
 
             command = ["bash", temp_file.name, *command_args]
             _LOGGER.info("Running %s", shlex.join(command))

--- a/bin/lib/installable/git.py
+++ b/bin/lib/installable/git.py
@@ -6,7 +6,7 @@ import re
 import shlex
 import subprocess
 from pathlib import Path
-from typing import Union, Optional
+from typing import Optional, Union
 
 from lib.installable.installable import Installable
 from lib.staging import StagingDir

--- a/bin/lib/installable/installable.py
+++ b/bin/lib/installable/installable.py
@@ -9,15 +9,15 @@ import socket
 import subprocess
 from functools import partial
 from pathlib import Path
-from typing import Optional, Callable, Dict, List, Any, Union
-from lib.nightly_versions import NightlyVersions
+from typing import Any, Callable, Dict, List, Optional, Union
 
-from lib.library_platform import LibraryPlatform
+from lib.fortran_library_builder import FortranLibraryBuilder
 from lib.installation_context import InstallationContext, is_windows
 from lib.library_build_config import LibraryBuildConfig
 from lib.library_builder import LibraryBuilder
+from lib.library_platform import LibraryPlatform
+from lib.nightly_versions import NightlyVersions
 from lib.rust_library_builder import RustLibraryBuilder
-from lib.fortran_library_builder import FortranLibraryBuilder
 from lib.staging import StagingDir
 
 _LOGGER = logging.getLogger(__name__)
@@ -41,7 +41,7 @@ class Installable:
         self.config = config
         self.target_name = str(self.config.get("name", "(unnamed)"))
         self.context = self.config_get("context", [])
-        self.name = f'{"/".join(self.context)} {self.target_name}'
+        self.name = f"{'/'.join(self.context)} {self.target_name}"
         self.is_library = False
         self.language = ""
         if len(self.context) > 0:
@@ -112,7 +112,7 @@ class Installable:
     def resolve(installables: list[Installable]) -> None:
         installables_by_name = {installable.name: installable for installable in installables}
         for installable in installables:
-            installable._resolve(installables_by_name)  # pylint: disable=protected-access
+            installable._resolve(installables_by_name)
 
     def find_dependee(self, name: str) -> Installable:
         for i in self.depends:

--- a/bin/lib/installable/python.py
+++ b/bin/lib/installable/python.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, Any, Callable
+from typing import Any, Callable, Dict
 
 from lib.installable.installable import Installable
 from lib.installation_context import InstallationContext

--- a/bin/lib/installable/rust.py
+++ b/bin/lib/installable/rust.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
 import functools
+import logging
 import os
 import subprocess
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any, Dict
 
 from lib.amazon import list_s3_artifacts
 from lib.installable.installable import Installable
 from lib.installation_context import InstallationContext
 from lib.staging import StagingDir
-
-import logging
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/bin/lib/installable/script.py
+++ b/bin/lib/installable/script.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any, Dict
 
 from lib.installable.installable import Installable
 from lib.installation_context import InstallationContext

--- a/bin/lib/installable/solidity.py
+++ b/bin/lib/installable/solidity.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import functools
-from typing import Dict, Any
+from typing import Any, Dict
 
 from lib.installable.installable import SingleFileInstallable
 from lib.installation_context import InstallationContext

--- a/bin/lib/installation.py
+++ b/bin/lib/installation.py
@@ -3,21 +3,21 @@ from __future__ import annotations
 from collections import ChainMap
 from datetime import datetime
 
-from lib.config_expand import is_value_type, expand_target
+from lib.config_expand import expand_target, is_value_type
 from lib.installable.archives import (
-    S3TarballInstallable,
     NightlyInstallable,
-    TarballInstallable,
     NightlyTarballInstallable,
-    ZipArchiveInstallable,
-    RestQueryTarballInstallable,
     NonFreeS3TarballInstallable,
+    RestQueryTarballInstallable,
+    S3TarballInstallable,
+    TarballInstallable,
+    ZipArchiveInstallable,
 )
 from lib.installable.edg import EdgCompilerInstallable
-from lib.installable.git import GitHubInstallable, GitLabInstallable, BitbucketInstallable
+from lib.installable.git import BitbucketInstallable, GitHubInstallable, GitLabInstallable
 from lib.installable.installable import SingleFileInstallable
 from lib.installable.python import PipInstallable
-from lib.installable.rust import RustInstallable, CratesIOInstallable
+from lib.installable.rust import CratesIOInstallable, RustInstallable
 from lib.installable.script import ScriptInstallable
 from lib.installable.solidity import SolidityInstallable
 

--- a/bin/lib/installation_context.py
+++ b/bin/lib/installation_context.py
@@ -11,15 +11,15 @@ import tempfile
 import time
 import uuid
 from pathlib import Path
-from typing import Optional, Iterator, Dict, IO, Sequence, Union, Collection, List
+from typing import IO, Collection, Dict, Iterator, List, Optional, Sequence, Union
 
 import requests
 import requests.adapters
-import yaml
 import requests_cache
+import yaml
 
-from lib.library_platform import LibraryPlatform
 from lib.config_safe_loader import ConfigSafeLoader
+from lib.library_platform import LibraryPlatform
 from lib.staging import StagingDir
 
 _LOGGER = logging.getLogger(__name__)
@@ -319,9 +319,9 @@ class InstallationContext:
             )
 
         fulloutput = ""
-        if output.stdout != None:
+        if output.stdout is not None:
             fulloutput += output.stdout.decode("utf-8")
-        if output.stderr != None:
+        if output.stderr is not None:
             fulloutput += output.stderr.decode("utf-8")
 
         return fulloutput

--- a/bin/lib/instance.py
+++ b/bin/lib/instance.py
@@ -3,8 +3,8 @@ import logging
 from multiprocessing.pool import ThreadPool
 from typing import Dict, Optional
 
-from lib.amazon import ec2, ec2_client, as_client, elb_client, get_all_releases, release_for
-from lib.ssh import exec_remote, can_ssh_to
+from lib.amazon import as_client, ec2, ec2_client, elb_client, get_all_releases, release_for
+from lib.ssh import can_ssh_to, exec_remote
 
 STATUS_FORMAT = "{: <16} {: <20} {: <10} {: <12} {: <11} {: <11} {: <14}"
 logger = logging.getLogger("instance")

--- a/bin/lib/library_build_config.py
+++ b/bin/lib/library_build_config.py
@@ -1,4 +1,5 @@
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
+
 from lib.installation_context import is_windows
 
 valid_lib_types = ["static", "shared", "cshared", "headeronly"]
@@ -11,7 +12,7 @@ class LibraryBuildConfig:
         self.build_fixed_arch = self.config_get("build_fixed_arch", "")
         self.build_fixed_stdlib = self.config_get("build_fixed_stdlib", "")
         self.lib_type = self.config_get("lib_type", "headeronly")
-        if not self.lib_type in valid_lib_types:
+        if self.lib_type not in valid_lib_types:
             raise RuntimeError(f"{self.lib_type} not a valid lib_type")
         self.staticliblink = self.config_get("staticliblink", [])
         self.sharedliblink = self.config_get("sharedliblink", [])

--- a/bin/lib/library_build_history.py
+++ b/bin/lib/library_build_history.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict
 
 import botocore
+
 from lib.amazon import dynamodb_client
 
 

--- a/bin/lib/library_yaml.py
+++ b/bin/lib/library_yaml.py
@@ -1,14 +1,13 @@
 import os
-import yaml
-
 from pathlib import Path
 from typing import List
 
-from lib.library_platform import LibraryPlatform
-from lib.amazon_properties import get_properties_compilers_and_libraries, get_specific_library_version_details
-from lib.rust_crates import TopRustCrates
+import yaml
 
+from lib.amazon_properties import get_properties_compilers_and_libraries, get_specific_library_version_details
 from lib.config_safe_loader import ConfigSafeLoader
+from lib.library_platform import LibraryPlatform
+from lib.rust_crates import TopRustCrates
 
 
 class LibraryYaml:
@@ -29,12 +28,12 @@ class LibraryYaml:
         self.save()
 
     def add_rust_crate(self, libid, libversion):
-        if not "rust" in self.yaml_doc["libraries"]:
+        if "rust" not in self.yaml_doc["libraries"]:
             self.yaml_doc["libraries"]["rust"] = dict()
 
         libraries_for_language = self.yaml_doc["libraries"]["rust"]
         if libid in libraries_for_language:
-            if not libversion in libraries_for_language[libid]["targets"]:
+            if libversion not in libraries_for_language[libid]["targets"]:
                 libraries_for_language[libid]["targets"].append(libversion)
         else:
             libraries_for_language[libid] = dict(type="cratesio", build_type="cargo", targets=[libversion])
@@ -136,7 +135,8 @@ class LibraryYaml:
             lookupname = libid
             if linux_libid not in linux_libraries:
                 if linux_libid == "catch2v2":
-                    # hardcoded, we renamed this manually in the yaml file to distinguish catch2 versions that were header-only from the ones that are built
+                    # hardcoded, we renamed this manually in the yaml file to distinguish catch2 versions that were
+                    # header-only from the ones that are built
                     lookupname = "catch2"
                 else:
                     lookupname = self.get_possible_lookupname(linux_libraries, linux_libid)

--- a/bin/lib/nightly_versions.py
+++ b/bin/lib/nightly_versions.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from typing import Any, Dict, Set
+
 from lib.amazon import dynamodb_client
 from lib.amazon_properties import get_properties_compilers_and_libraries
 from lib.library_platform import LibraryPlatform

--- a/bin/lib/rust_crates.py
+++ b/bin/lib/rust_crates.py
@@ -1,5 +1,5 @@
-import urllib
 import json
+import urllib
 
 
 def get_builder_user_agent_id():

--- a/bin/lib/rust_library_builder.py
+++ b/bin/lib/rust_library_builder.py
@@ -11,19 +11,18 @@ import tempfile
 from collections import defaultdict
 from enum import Enum, unique
 from pathlib import Path
-from typing import Dict, Any, List, Optional, Generator, TextIO
-from urllib3.exceptions import ProtocolError
+from typing import Any, Dict, Generator, List, Optional, TextIO
 
 import requests
-from lib.staging import StagingDir
-from lib.installation_context import InstallationContext
-from lib.library_platform import LibraryPlatform
-
-from lib.rust_crates import RustCrate, get_builder_user_agent_id
+from urllib3.exceptions import ProtocolError
 
 from lib.amazon import get_ssm_param
 from lib.amazon_properties import get_properties_compilers_and_libraries
+from lib.installation_context import InstallationContext
 from lib.library_build_config import LibraryBuildConfig
+from lib.library_platform import LibraryPlatform
+from lib.rust_crates import RustCrate, get_builder_user_agent_id
+from lib.staging import StagingDir
 
 _TIMEOUT = 600
 skip_compilers = ["nightly", "beta", "gccrs-snapshot", "mrustc-master", "rustccggcc-master"]
@@ -105,7 +104,6 @@ class RustLibraryBuilder:
         if "url" in self.libraryprops[self.libid]:
             self.buildconfig.url = self.libraryprops[self.libid]["url"]
 
-    # pylint: disable=unused-argument
     def writebuildscript(
         self,
         buildfolder,
@@ -271,7 +269,7 @@ class RustLibraryBuilder:
         last_error = ""
         while retries > 0:
             try:
-                if headers != None:
+                if headers is not None:
                     request = requests.post(url, data=json_data, headers=headers, timeout=_TIMEOUT)
                 else:
                     request = requests.post(
@@ -283,7 +281,7 @@ class RustLibraryBuilder:
                 last_error = e
                 retries = retries - 1
 
-        if request == None:
+        if request is None:
             request = {"ok": False, "text": last_error}
 
         return request
@@ -432,7 +430,7 @@ class RustLibraryBuilder:
 
     def get_source_folder(self, source_staging: StagingDir):
         source_folder = os.path.join(source_staging.path, f"crate_{self.libname}_{self.target_name}")
-        if not source_folder in self.cached_source_folders:
+        if source_folder not in self.cached_source_folders:
             if not os.path.exists(source_folder):
                 os.mkdir(source_folder)
             self.cached_source_folders.append(source_folder)

--- a/bin/lib/ssh.py
+++ b/bin/lib/ssh.py
@@ -105,4 +105,4 @@ def ssh_client_for(instance) -> paramiko.SSHClient:
 def exec_remote_all(instances, command):
     for instance in instances:
         result = exec_remote(instance, command)
-        print(f'{instance}: {result or "(no output)"}')
+        print(f"{instance}: {result or '(no output)'}")

--- a/bin/test/amazon_properties_test.py
+++ b/bin/test/amazon_properties_test.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 import requests
 from lib.amazon_properties import get_properties_compilers_and_libraries, get_specific_library_version_details
@@ -33,10 +34,10 @@ def test_googletest_should_have_versions():
         assert _libraries["googletest"]["versionprops"]["110"]["version"] == "1.10.0"
 
         details = get_specific_library_version_details(_libraries, "googletest", "1.10.0")
-        assert details != False
+        assert details
 
         details = get_specific_library_version_details(_libraries, "googletest", "release-1.10.0")
-        assert details != False
+        assert details
     except requests.exceptions.ConnectionError:
         pytest.skip("Connection error in test_googletest_should_have_versions, which needs internet access")
 

--- a/bin/test/ce_install_test.py
+++ b/bin/test/ce_install_test.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock
 
-from lib.ce_install import filter_match, filter_aggregate
+from lib.ce_install import filter_aggregate, filter_match
 
 
 def fake(context, target_name):

--- a/bin/test/installable/git_test.py
+++ b/bin/test/installable/git_test.py
@@ -1,14 +1,13 @@
+import logging
+import os
 import subprocess
 from pathlib import Path
 from unittest import mock
 
 import pytest
-import logging
-
 from lib.installable.git import GitHubInstallable
 from lib.installation_context import InstallationContext
 from lib.staging import StagingDir
-import os
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/bin/test/installable/installable_test.py
+++ b/bin/test/installable/installable_test.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from lib.installable.installable import Installable
 from lib.installation_context import InstallationContext
 

--- a/bin/test/installation_test.py
+++ b/bin/test/installation_test.py
@@ -1,14 +1,13 @@
 import re
 from pathlib import Path
+from unittest import mock
 
 import pytest
 import yaml
-
 from lib.config_safe_loader import ConfigSafeLoader
 from lib.installable.installable import Installable
 from lib.installation import targets_from
 from lib.installation_context import InstallationContext
-from unittest import mock
 
 
 def parse_targets(string_config, enabled=None):
@@ -20,23 +19,19 @@ def test_targets_from_simple_cases():
     assert list(targets_from({}, set())) == []
     assert parse_targets("") == []
 
-    assert (
-        parse_targets(
-            """
+    assert parse_targets(
+        """
 weasel:
     type: foo
     targets:
     - moo
     """
-        )
-        == [{"type": "foo", "name": "moo", "underscore_name": "moo", "context": ["weasel"]}]
-    )
+    ) == [{"type": "foo", "name": "moo", "underscore_name": "moo", "context": ["weasel"]}]
 
 
 def test_targets_from_carries_hierarchy_config():
-    assert (
-        parse_targets(
-            """
+    assert parse_targets(
+        """
 weasel:
     base_config: "weasel"
     weasel_config: "weasel"
@@ -46,18 +41,16 @@ weasel:
         targets:
         - ook
     """
-        )
-        == [
-            {
-                "type": "foo",
-                "base_config": "baboon",
-                "weasel_config": "weasel",
-                "context": ["weasel", "baboon"],
-                "name": "ook",
-                "underscore_name": "ook",
-            }
-        ]
-    )
+    ) == [
+        {
+            "type": "foo",
+            "base_config": "baboon",
+            "weasel_config": "weasel",
+            "context": ["weasel", "baboon"],
+            "name": "ook",
+            "underscore_name": "ook",
+        }
+    ]
 
 
 def test_codependent_configs():

--- a/bin/test/library_builder_test.py
+++ b/bin/test/library_builder_test.py
@@ -1,13 +1,12 @@
+import ast
+import io
 from logging import Logger
+from unittest import mock
 
 from lib.installation_context import InstallationContext
 from lib.library_build_config import LibraryBuildConfig
 from lib.library_builder import LibraryBuilder
 from lib.library_platform import LibraryPlatform
-
-from unittest import mock
-import io
-import ast
 
 BASE = "https://raw.githubusercontent.com/compiler-explorer/compiler-explorer/main/etc/config/"
 

--- a/bin/test/runner_test.py
+++ b/bin/test/runner_test.py
@@ -1,5 +1,5 @@
-from lib.cli.runner import runner_check_discovery_json_contents
 import pytest
+from lib.cli.runner import runner_check_discovery_json_contents
 
 
 def test_should_find_remote_compilers():

--- a/lambda/alert_on_elb_instance.py
+++ b/lambda/alert_on_elb_instance.py
@@ -1,10 +1,10 @@
 import enum
 import json
-import boto3
-
 import logging
-from dataclasses import dataclass
 import os
+from dataclasses import dataclass
+
+import boto3
 
 BASE_CW_URL = "https://console.aws.amazon.com/cloudwatch/home"
 REGION = "us-east-1"

--- a/lambda/alert_on_elb_instance_test.py
+++ b/lambda/alert_on_elb_instance_test.py
@@ -1,4 +1,4 @@
-from alert_on_elb_instance import parse_sns_message, Reason
+from alert_on_elb_instance import Reason, parse_sns_message
 
 UNHEALTHY_EVENT = dict(
     Origin="AutoScalingGroup",
@@ -69,7 +69,11 @@ SCALING_EVENT = dict(
         ],
     },
     AutoScalingGroupName="prod",
-    Cause="At 2022-12-23T19:12:06Z a monitor alarm TargetTracking-prod-AlarmLow-a83afbd9-b74b-408b-b787-b01c939e9da1 in state ALARM triggered policy cpu-tracker changing the desired capacity from 7 to 6.  At 2022-12-23T19:12:09Z an instance was taken out of service in response to a difference between desired and actual capacity, shrinking the capacity from 7 to 6.  At 2022-12-23T19:12:10Z instance i-0d1835f80668172d7 was selected for termination.",
+    Cause="At 2022-12-23T19:12:06Z a monitor alarm TargetTracking-prod-AlarmLow-a83afbd9-b74b-408b-b787-b01c939e9da1 in "
+    "state ALARM triggered policy cpu-tracker changing the desired capacity from 7 to 6.  At 2022-12-23T19:12:09Z "
+    "an instance was taken out of service in response to a difference between desired and actual capacity, "
+    "shrinking the capacity from 7 to 6.  At 2022-12-23T19:12:10Z instance i-0d1835f80668172d7 was "
+    "selected for termination.",
     Event="autoscaling:EC2_INSTANCE_TERMINATE",
 )
 
@@ -91,7 +95,10 @@ ENVIRONMENT_SHUTDOWN_EVENT = dict(
     StatusMessage="",
     Details={"Subnet ID": "subnet-690ed81e", "Availability Zone": "us-east-1a"},
     AutoScalingGroupName="staging",
-    Cause="At 2022-12-23T20:48:54Z a user request update of AutoScalingGroup constraints to min: 0, max: 4, desired: 0 changing the desired capacity from 1 to 0.  At 2022-12-23T20:49:01Z an instance was taken out of service in response to a difference between desired and actual capacity, shrinking the capacity from 1 to 0.  At 2022-12-23T20:49:01Z instance i-0bff86408fbe11f7a was selected for termination.",
+    Cause="At 2022-12-23T20:48:54Z a user request update of AutoScalingGroup constraints to min: 0, max: 4, desired: 0"
+    " changing the desired capacity from 1 to 0.  At 2022-12-23T20:49:01Z an instance was taken out of service in "
+    "response to a difference between desired and actual capacity, shrinking the capacity from 1 to 0.  "
+    "At 2022-12-23T20:49:01Z instance i-0bff86408fbe11f7a was selected for termination.",
     Event="autoscaling:EC2_INSTANCE_TERMINATE",
 )
 
@@ -113,7 +120,8 @@ INSTANCE_REFRESH_EVENT = dict(
     StatusMessage="",
     Details={"Subnet ID": "subnet-1bed1d42", "Availability Zone": "us-east-1b"},
     AutoScalingGroupName="prod",
-    Cause="At 2022-12-24T22:03:59Z an instance was taken out of service in response to an instance refresh.  At 2022-12-24T22:03:59Z instance i-0002075bea40ce1c8 was selected for termination.",
+    Cause="At 2022-12-24T22:03:59Z an instance was taken out of service in response to an instance refresh.  "
+    "At 2022-12-24T22:03:59Z instance i-0002075bea40ce1c8 was selected for termination.",
     Event="autoscaling:EC2_INSTANCE_TERMINATE",
 )
 

--- a/lambda/cloudwatch_to_discord.py
+++ b/lambda/cloudwatch_to_discord.py
@@ -1,7 +1,8 @@
 import json
-import requests
-import os
 import logging
+import os
+
+import requests
 
 BASE_CW_URL = "https://console.aws.amazon.com/cloudwatch/home"
 REGION = "us-east-1"

--- a/lambda/get_deployed_exe_version.py
+++ b/lambda/get_deployed_exe_version.py
@@ -1,6 +1,7 @@
-import boto3
 import json
 from typing import Dict
+
+import boto3
 
 versionTablename = "nightly-version"
 nightlyExeTablename = "nightly-exe"
@@ -8,7 +9,7 @@ db_client = boto3.client("dynamodb")
 
 
 def lambda_handler(event, _context):
-    if not ("queryStringParameters" in event):
+    if "queryStringParameters" not in event:
         return default_error("No event.queryStringParameters")
 
     jsonp = ""
@@ -18,18 +19,18 @@ def lambda_handler(event, _context):
     item = False
     if "id" in event["queryStringParameters"]:
         exeItem = get_exe_path_by_compiler_id(event["queryStringParameters"]["id"])
-        if not exeItem or not "Item" in exeItem:
+        if not exeItem or "Item" not in exeItem:
             return default_error("No exe found based on id " + event["queryStringParameters"]["id"])
         else:
             exe = exeItem["Item"]["exe"]["S"]
             item = get_exe_version(exe)
-            if not item or not "Item" in item:
+            if not item or "Item" not in item:
                 return default_error("No exe found based on path " + exe)
 
     if "exe" in event["queryStringParameters"]:
         exe = event["queryStringParameters"]["exe"]
         item = get_exe_version(exe)
-        if not item or not "Item" in item:
+        if not item or "Item" not in item:
             return default_error("No exe found based on path " + exe)
 
     return respond_with_version(item["Item"], jsonp)

--- a/lambda/get_remote_execution_archs.py
+++ b/lambda/get_remote_execution_archs.py
@@ -1,5 +1,6 @@
-import boto3
 import json
+
+import boto3
 
 remote_archs_table = "remote-exec-archs"
 db_client = boto3.client("dynamodb")

--- a/lambda/stats.py
+++ b/lambda/stats.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 import urllib.parse
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
 import aws_embedded_metrics
 import boto3

--- a/lambda/stats_test.py
+++ b/lambda/stats_test.py
@@ -1,4 +1,3 @@
-# pylint: disable=redefined-outer-name
 import datetime
 import json
 import os
@@ -10,9 +9,8 @@ import botocore.client
 import botocore.session
 import pytest as pytest
 from aws_embedded_metrics.logger.metrics_logger import MetricsLogger
-from botocore.stub import Stubber, ANY
-
-from stats import handle_sqs, handle_pageload, handle_compiler_stats
+from botocore.stub import ANY, Stubber
+from stats import handle_compiler_stats, handle_pageload, handle_sqs
 
 SOME_DATE = datetime.datetime(2020, 1, 2, 3, 4, 5, 12312)
 

--- a/lambda/status.py
+++ b/lambda/status.py
@@ -1,9 +1,11 @@
-import boto3
 import functools
 import json
-from datetime import datetime, timezone
 import os
 import re
+from datetime import datetime, timezone
+
+import boto3
+
 
 # AWS clients are initialized on demand with caching to make testing easier
 @functools.cache
@@ -163,7 +165,7 @@ def lambda_handler(event, _context):
         )
     except (ValueError, TypeError, KeyError, boto3.exceptions.Boto3Error) as e:
         return handle_error(e)
-    except Exception as e:  # pylint: disable=broad-exception-caught
+    except Exception as e:
         # Handle unexpected errors while still returning a proper response
         return handle_error(e, is_internal=True)
 
@@ -263,7 +265,7 @@ def parse_version_info(version_str):
             version_info["version"] = extract_version_from_key(version_str)
 
         return version_info
-    except Exception as e:  # pylint: disable=broad-exception-caught
+    except Exception as e:
         # Fall back to safe defaults for unexpected errors
         return handle_version_parse_error(version_str, e, is_internal=True)
 
@@ -290,7 +292,7 @@ def fetch_commit_hash(info_key):
                 "hash_url": f"https://github.com/compiler-explorer/compiler-explorer/tree/{commit_hash}",
             }
         return None
-    except Exception as e:  # pylint: disable=broad-exception-caught
+    except Exception as e:
         # Log error and return
         print(f"Error fetching hash from {info_key}: {str(e)}")
         return None
@@ -345,7 +347,7 @@ def get_asg_status(env_name):
             "max_size": asg["MaxSize"],
             "is_deliberate_shutdown": asg["DesiredCapacity"] == 0 and asg["MinSize"] == 0,
         }
-    except Exception as e:  # pylint: disable=broad-exception-caught
+    except Exception as e:
         print(f"Error fetching ASG status for {env_name}: {str(e)}")
         return {"is_deliberate_shutdown": False}
 
@@ -370,7 +372,7 @@ def get_environment_status(env):
         status["version_info"] = version_info
     except (boto3.exceptions.Boto3Error, KeyError, ValueError) as e:
         status.update(handle_environment_error(env["name"], e))
-    except Exception as e:  # pylint: disable=broad-exception-caught
+    except Exception as e:
         status.update(handle_environment_error(env["name"], e, is_internal=True))
 
     # Check load balancer status if ARN is provided
@@ -410,7 +412,7 @@ def get_environment_status(env):
             }
         except (boto3.exceptions.Boto3Error, KeyError, ValueError) as e:
             status["health"] = handle_lb_error(env["name"], e)
-        except Exception as e:  # pylint: disable=broad-exception-caught
+        except Exception as e:
             status["health"] = handle_lb_error(env["name"], e, is_internal=True)
     else:
         status["health"] = {"status": "Unknown", "status_type": "secondary", "error": "No load balancer configured"}

--- a/lambda/status_test.py
+++ b/lambda/status_test.py
@@ -1,7 +1,8 @@
+import json
 import os
 import unittest
 from unittest.mock import MagicMock, patch
-import json
+
 import status
 
 

--- a/make_json.py
+++ b/make_json.py
@@ -1,6 +1,6 @@
-from configparser import ConfigParser
-import os
 import json
+import os
+from configparser import ConfigParser
 
 
 def main():

--- a/poetry.lock
+++ b/poetry.lock
@@ -132,28 +132,13 @@ files = [
 frozenlist = ">=1.1.0"
 
 [[package]]
-name = "astroid"
-version = "3.3.9"
-description = "An abstract syntax tree for Python with inference support."
-optional = false
-python-versions = ">=3.9.0"
-groups = ["dev"]
-files = [
-    {file = "astroid-3.3.9-py3-none-any.whl", hash = "sha256:d05bfd0acba96a7bd43e222828b7d9bc1e138aaeb0649707908d3702a9831248"},
-    {file = "astroid-3.3.9.tar.gz", hash = "sha256:622cc8e3048684aa42c820d9d218978021c3c3d174fb03a9f0d615921744f550"},
-]
-
-[package.dependencies]
-typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
-
-[[package]]
 name = "async-timeout"
 version = "5.0.1"
 description = "Timeout context manager for asyncio programs"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "python_version <= \"3.10\""
+markers = "python_version < \"3.11\""
 files = [
     {file = "async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c"},
     {file = "async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"},
@@ -258,53 +243,6 @@ files = [
 [package.extras]
 tests = ["pytest (>=3.2.1,!=3.3.0)"]
 typecheck = ["mypy"]
-
-[[package]]
-name = "black"
-version = "24.10.0"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "black-24.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6668650ea4b685440857138e5fe40cde4d652633b1bdffc62933d0db4ed9812"},
-    {file = "black-24.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1c536fcf674217e87b8cc3657b81809d3c085d7bf3ef262ead700da345bfa6ea"},
-    {file = "black-24.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:649fff99a20bd06c6f727d2a27f401331dc0cc861fb69cde910fe95b01b5928f"},
-    {file = "black-24.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:fe4d6476887de70546212c99ac9bd803d90b42fc4767f058a0baa895013fbb3e"},
-    {file = "black-24.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5a2221696a8224e335c28816a9d331a6c2ae15a2ee34ec857dcf3e45dbfa99ad"},
-    {file = "black-24.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f9da3333530dbcecc1be13e69c250ed8dfa67f43c4005fb537bb426e19200d50"},
-    {file = "black-24.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4007b1393d902b48b36958a216c20c4482f601569d19ed1df294a496eb366392"},
-    {file = "black-24.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:394d4ddc64782e51153eadcaaca95144ac4c35e27ef9b0a42e121ae7e57a9175"},
-    {file = "black-24.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e39e0fae001df40f95bd8cc36b9165c5e2ea88900167bddf258bacef9bbdc3"},
-    {file = "black-24.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d37d422772111794b26757c5b55a3eade028aa3fde43121ab7b673d050949d65"},
-    {file = "black-24.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f"},
-    {file = "black-24.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:30d2c30dc5139211dda799758559d1b049f7f14c580c409d6ad925b74a4208a8"},
-    {file = "black-24.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cbacacb19e922a1d75ef2b6ccaefcd6e93a2c05ede32f06a21386a04cedb981"},
-    {file = "black-24.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f93102e0c5bb3907451063e08b9876dbeac810e7da5a8bfb7aeb5a9ef89066b"},
-    {file = "black-24.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddacb691cdcdf77b96f549cf9591701d8db36b2f19519373d60d31746068dbf2"},
-    {file = "black-24.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:680359d932801c76d2e9c9068d05c6b107f2584b2a5b88831c83962eb9984c1b"},
-    {file = "black-24.10.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:17374989640fbca88b6a448129cd1745c5eb8d9547b464f281b251dd00155ccd"},
-    {file = "black-24.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:63f626344343083322233f175aaf372d326de8436f5928c042639a4afbbf1d3f"},
-    {file = "black-24.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfa1d0cb6200857f1923b602f978386a3a2758a65b52e0950299ea014be6800"},
-    {file = "black-24.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:2cd9c95431d94adc56600710f8813ee27eea544dd118d45896bb734e9d7a0dc7"},
-    {file = "black-24.10.0-py3-none-any.whl", hash = "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d"},
-    {file = "black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-packaging = ">=22.0"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.10)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
@@ -588,7 +526,7 @@ version = "8.1.8"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
     {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
@@ -608,7 +546,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\"", dev = "platform_system == \"Windows\" or sys_platform == \"win32\""}
+markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "cryptography"
@@ -721,22 +659,6 @@ test = ["certifi (>=2024)", "cryptography-vectors (==44.0.2)", "pretend (>=0.7)"
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
-name = "dill"
-version = "0.4.0"
-description = "serialize all of Python"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "dill-0.4.0-py3-none-any.whl", hash = "sha256:44f54bf6412c2c8464c14e8243eb163690a9800dbe2c367330883b19c7561049"},
-    {file = "dill-0.4.0.tar.gz", hash = "sha256:0633f1d2df477324f53a895b02c901fb961bdbf65a17122586ea7019292cbcf0"},
-]
-
-[package.extras]
-graph = ["objgraph (>=1.7.2)"]
-profile = ["gprof2dot (>=2022.7.29)"]
-
-[[package]]
 name = "distlib"
 version = "0.3.9"
 description = "Distribution utilities"
@@ -755,7 +677,7 @@ description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev"]
-markers = "python_version <= \"3.10\""
+markers = "python_version < \"3.11\""
 files = [
     {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
     {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
@@ -938,22 +860,6 @@ files = [
 ]
 
 [[package]]
-name = "isort"
-version = "6.0.1"
-description = "A Python utility / library to sort Python imports."
-optional = false
-python-versions = ">=3.9.0"
-groups = ["dev"]
-files = [
-    {file = "isort-6.0.1-py3-none-any.whl", hash = "sha256:2dc5d7f65c9678d94c88dfc29161a320eec67328bc97aad576874cb4be1e9615"},
-    {file = "isort-6.0.1.tar.gz", hash = "sha256:1cb5df28dfbc742e490c5e41bad6da41b805b0a8be7bc93cd0fb2a8a890ac450"},
-]
-
-[package.extras]
-colors = ["colorama"]
-plugins = ["setuptools"]
-
-[[package]]
 name = "jinja2"
 version = "3.1.6"
 description = "A very fast and expressive template engine."
@@ -1052,18 +958,6 @@ files = [
     {file = "MarkupSafe-3.0.2-cp39-cp39-win32.whl", hash = "sha256:8c4e8c3ce11e1f92f6536ff07154f9d49677ebaaafc32db9db4620bc11ed480f"},
     {file = "MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:6e296a513ca3d94054c2c881cc913116e90fd030ad1c656b3869762b754f5f8a"},
     {file = "markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0"},
-]
-
-[[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-optional = false
-python-versions = ">=3.6"
-groups = ["dev"]
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
 ]
 
 [[package]]
@@ -1184,18 +1078,6 @@ files = [
 typing-extensions = {version = ">=4.1.0", markers = "python_version < \"3.11\""}
 
 [[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-description = "Type system extensions for programs checked with the mypy type checker."
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
-    {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
-]
-
-[[package]]
 name = "nodeenv"
 version = "1.9.1"
 description = "Node.js virtual environment builder"
@@ -1240,18 +1122,6 @@ pynacl = ">=1.5"
 all = ["gssapi (>=1.4.1) ; platform_system != \"Windows\"", "invoke (>=2.0)", "pyasn1 (>=0.1.7)", "pywin32 (>=2.1.8) ; platform_system == \"Windows\""]
 gssapi = ["gssapi (>=1.4.1) ; platform_system != \"Windows\"", "pyasn1 (>=0.1.7)", "pywin32 (>=2.1.8) ; platform_system == \"Windows\""]
 invoke = ["invoke (>=2.0)"]
-
-[[package]]
-name = "pathspec"
-version = "0.12.1"
-description = "Utility library for gitignore style pattern matching of file paths."
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
-    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
-]
 
 [[package]]
 name = "platformdirs"
@@ -1424,37 +1294,6 @@ files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
     {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
 ]
-
-[[package]]
-name = "pylint"
-version = "3.3.6"
-description = "python code static checker"
-optional = false
-python-versions = ">=3.9.0"
-groups = ["dev"]
-files = [
-    {file = "pylint-3.3.6-py3-none-any.whl", hash = "sha256:8b7c2d3e86ae3f94fb27703d521dd0b9b6b378775991f504d7c3a6275aa0a6a6"},
-    {file = "pylint-3.3.6.tar.gz", hash = "sha256:b634a041aac33706d56a0d217e6587228c66427e20ec21a019bc4cdee48c040a"},
-]
-
-[package.dependencies]
-astroid = ">=3.3.8,<=3.4.0.dev0"
-colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
-dill = [
-    {version = ">=0.2", markers = "python_version < \"3.11\""},
-    {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
-    {version = ">=0.3.6", markers = "python_version == \"3.11\""},
-]
-isort = ">=4.2.5,<5.13 || >5.13,<7"
-mccabe = ">=0.6,<0.8"
-platformdirs = ">=2.2"
-tomli = {version = ">=1.1", markers = "python_version < \"3.11\""}
-tomlkit = ">=0.10.1"
-typing-extensions = {version = ">=3.10", markers = "python_version < \"3.10\""}
-
-[package.extras]
-spelling = ["pyenchant (>=3.2,<4.0)"]
-testutils = ["gitpython (>3)"]
 
 [[package]]
 name = "pynacl"
@@ -1656,6 +1495,34 @@ requests = ">=2.22,<3"
 fixture = ["fixtures"]
 
 [[package]]
+name = "ruff"
+version = "0.11.7"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "ruff-0.11.7-py3-none-linux_armv6l.whl", hash = "sha256:d29e909d9a8d02f928d72ab7837b5cbc450a5bdf578ab9ebee3263d0a525091c"},
+    {file = "ruff-0.11.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:dd1fb86b168ae349fb01dd497d83537b2c5541fe0626e70c786427dd8363aaee"},
+    {file = "ruff-0.11.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d3d7d2e140a6fbbc09033bce65bd7ea29d6a0adeb90b8430262fbacd58c38ada"},
+    {file = "ruff-0.11.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4809df77de390a1c2077d9b7945d82f44b95d19ceccf0c287c56e4dc9b91ca64"},
+    {file = "ruff-0.11.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f3a0c2e169e6b545f8e2dba185eabbd9db4f08880032e75aa0e285a6d3f48201"},
+    {file = "ruff-0.11.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:49b888200a320dd96a68e86736cf531d6afba03e4f6cf098401406a257fcf3d6"},
+    {file = "ruff-0.11.7-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:2b19cdb9cf7dae00d5ee2e7c013540cdc3b31c4f281f1dacb5a799d610e90db4"},
+    {file = "ruff-0.11.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:64e0ee994c9e326b43539d133a36a455dbaab477bc84fe7bfbd528abe2f05c1e"},
+    {file = "ruff-0.11.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bad82052311479a5865f52c76ecee5d468a58ba44fb23ee15079f17dd4c8fd63"},
+    {file = "ruff-0.11.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7940665e74e7b65d427b82bffc1e46710ec7f30d58b4b2d5016e3f0321436502"},
+    {file = "ruff-0.11.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:169027e31c52c0e36c44ae9a9c7db35e505fee0b39f8d9fca7274a6305295a92"},
+    {file = "ruff-0.11.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:305b93f9798aee582e91e34437810439acb28b5fc1fee6b8205c78c806845a94"},
+    {file = "ruff-0.11.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a681db041ef55550c371f9cd52a3cf17a0da4c75d6bd691092dfc38170ebc4b6"},
+    {file = "ruff-0.11.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:07f1496ad00a4a139f4de220b0c97da6d4c85e0e4aa9b2624167b7d4d44fd6b6"},
+    {file = "ruff-0.11.7-py3-none-win32.whl", hash = "sha256:f25dfb853ad217e6e5f1924ae8a5b3f6709051a13e9dad18690de6c8ff299e26"},
+    {file = "ruff-0.11.7-py3-none-win_amd64.whl", hash = "sha256:0a931d85959ceb77e92aea4bbedfded0a31534ce191252721128f77e5ae1f98a"},
+    {file = "ruff-0.11.7-py3-none-win_arm64.whl", hash = "sha256:778c1e5d6f9e91034142dfd06110534ca13220bfaad5c3735f6cb844654f6177"},
+    {file = "ruff-0.11.7.tar.gz", hash = "sha256:655089ad3224070736dc32844fde783454f8558e71f501cb207485fe4eee23d4"},
+]
+
+[[package]]
 name = "s3transfer"
 version = "0.12.0"
 description = "An Amazon S3 Transfer Manager"
@@ -1692,7 +1559,7 @@ description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
-markers = "python_version <= \"3.10\""
+markers = "python_version < \"3.11\""
 files = [
     {file = "tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249"},
     {file = "tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6"},
@@ -1729,25 +1596,13 @@ files = [
 ]
 
 [[package]]
-name = "tomlkit"
-version = "0.13.2"
-description = "Style preserving TOML library"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "tomlkit-0.13.2-py3-none-any.whl", hash = "sha256:7a974427f6e119197f670fbbbeae7bef749a6c14e793db934baefc1b5f03efde"},
-    {file = "tomlkit-0.13.2.tar.gz", hash = "sha256:fff5fe59a87295b278abd31bec92c15d9bc4a06885ab12bcea52c71119392e79"},
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.13.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
-markers = "python_version <= \"3.10\""
+groups = ["main"]
+markers = "python_version < \"3.11\""
 files = [
     {file = "typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c"},
     {file = "typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"},
@@ -1951,4 +1806,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4"
-content-hash = "bb146400bed27a93263b3ec179500bc10eb178e113f252a4dd7c1c382972e4a3"
+content-hash = "aacbdc813ea3af0e0e93e6996bfe4cfa539e7add971a0996cff9b03bca679e22"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
-[tool.black]
+[tool.ruff]
 line-length = 120
-target-version = ['py310']
+target-version = "py310"
 
 [tool.poetry]
 name = "compiler-explorer-infra"
@@ -24,5 +24,17 @@ requests-cache = "^1.2.1"
 pytest = "^8.2.2"
 pre-commit = "^3.7.1"
 requests-mock = "^1.10.0"
-black = "^24.3.0"
-pylint = "^3.2.3"
+ruff = "^0.11.7"
+
+[tool.ruff.lint]
+select = [
+    # https://docs.astral.sh/ruff/rules/
+    "E", # pycodestyle errors,
+    "W", # pycodestyle warnings
+    "F", # pyflake
+    "B", # flake8-bugbear
+    "I", # isort
+]
+ignore = [
+    "E501" # line length
+]

--- a/test/remote-test.py
+++ b/test/remote-test.py
@@ -2,13 +2,12 @@
 import glob
 import json
 import os
-import requests
+import re
+import sys
 from argparse import ArgumentParser
 from difflib import unified_diff
 
-import re
-
-import sys
+import requests
 
 _TIMEOUT = 10.0
 


### PR DESCRIPTION
Human-created! was sick of having a bunch of things to fight; `ruff` does all the things and is super quick (and supported `poetry run ruff check --watch` etc)