### PR TITLE
Add solx, new Solidity LLVM-based compiler, add solc to 0.8.29

### DIFF
--- a/bin/yaml/solidity.yaml
+++ b/bin/yaml/solidity.yaml
@@ -12,6 +12,7 @@ compilers:
       - 0.7.6
       - 0.8.25
       - 0.8.26
+      - 0.8.29
   solidity_zksync:
     type: singleFile
     dir: zksync-solc-{{name}}
@@ -25,6 +26,7 @@ compilers:
       - 0.7.6-1.0.1
       - 0.8.25-1.0.1
       - 0.8.26-1.0.1
+      - 0.8.29-1.0.1
   zksolc:
     type: singleFile
     dir: zksolc-{{name}}
@@ -35,9 +37,19 @@ compilers:
       - compilers/solidity_zksync 0.7.6-1.0.1
       - compilers/solidity_zksync 0.8.25-1.0.1
       - compilers/solidity_zksync 0.8.26-1.0.1
+      - compilers/solidity_zksync 0.8.29-1.0.1
     url: https://github.com/matter-labs/era-compiler-solidity/releases/download/{{name}}/zksolc-linux-amd64-musl-v{{name}}
     filename: zksolc
     check_exe: zksolc --version
     targets:
       - 1.4.1
       - 1.5.0
+      - 1.5.13
+  solx:
+    type: singleFile
+    dir: solx-{{name}}
+    url: https://github.com/matter-labs/solx/releases/download/{{name}}/solx-linux-amd64-gnu-v{{name}}
+    filename: solx
+    check_exe: solx --version
+    targets:
+      - 0.1.0-alpha.2


### PR DESCRIPTION
## What?

* [x] Add new LLVM-based Solidity `solx` compiler
* [x] Update `solc` with 0.8.29
* [x] Update `zksolc` with 1.5.13

Related PR in compiler-explorer: https://github.com/compiler-explorer/compiler-explorer/pull/7633