### PR TITLE
Add beman.scope library trunk version

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1217,6 +1217,14 @@ libraries:
         targets:
         - main
         type: github
+      beman_scope:
+        build_type: none
+        check_file: README.md
+        method: nightlyclone
+        repo: bemanproject/scope
+        targets:
+        - main
+        type: github
       beman_task:
         build_type: none
         check_file: README.md


### PR DESCRIPTION
* Issue: #1608 

* compiler-explorer
    *  library request issue - https://github.com/compiler-explorer/compiler-explorer/issues/7624
     * PR - https://github.com/compiler-explorer/compiler-explorer/pull/7666
     
* beman_scope:
     * Issue - https://github.com/bemanproject/scope/issues/22
      
Tested these changes on my local VM, Ubuntu 22.04:

```bash
radu@work:~/work/beman/infra$ tree -L 2 /opt/compiler-explorer/libs/beman_scope/
/opt/compiler-explorer/libs/beman_scope/
└── main
    ├── cmake
    ├── CMakeLists.txt
    ├── CMakePresets.json
    ├── examples
    ├── include
    ├── LICENSE
    ├── paper
    ├── README.md
    ├── src
    └── tests
```