### PR TITLE
Update infra for `proxy`

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1774,7 +1774,7 @@ libraries:
         - trunk
         type: github
       proxy:
-        build_type: none
+        build_type: cmake
         check_file: README.md
         method: nightlyclone
         repo: microsoft/proxy
@@ -2143,14 +2143,15 @@ libraries:
         - ./configure
       type: github
     proxy:
+      build_type: cmake
       check_file: README.md
-      method: clone_branch
       repo: microsoft/proxy
       targets:
       - 3.0.0
       - 3.1.0
       - 3.2.0
       - 3.2.1
+      - 3.3.0
       type: github
     pugixml:
       build_type: cmake

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1775,7 +1775,7 @@ libraries:
         type: github
       proxy:
         build_type: none
-        check_file: proxy.h
+        check_file: README.md
         method: nightlyclone
         repo: microsoft/proxy
         targets:
@@ -2143,7 +2143,7 @@ libraries:
         - ./configure
       type: github
     proxy:
-      check_file: proxy.h
+      check_file: README.md
       method: clone_branch
       repo: microsoft/proxy
       targets:


### PR DESCRIPTION
With changes in https://github.com/microsoft/proxy/pull/293, the Proxy library will require installation with CMake. This PR updates the infra.