### PR TITLE
[swift]: update dev-snapshot to 6.2 compiler

### DIFF
--- a/bin/yaml/swift.yaml
+++ b/bin/yaml/swift.yaml
@@ -63,4 +63,4 @@ compilers:
         dir: swift-dev-snapshot
         toolchain: swift-{{name}}-branch
         targets:
-          - '6.1'
+          - '6.2'


### PR DESCRIPTION
the Swift compiler now has its most recent 'development snapshot' builds producing artifacts for the 6.2 compiler release. update the infra config to match.