### PR TITLE
Install mojo nightly

### DIFF
--- a/bin/yaml/mojo.yaml
+++ b/bin/yaml/mojo.yaml
@@ -10,3 +10,11 @@ compilers:
     check_exe: bin/mojo --version
     targets:
       - 25.3.0
+    nightly:
+      if: nightly
+      install_always: true
+      targets:
+        - name: nightly
+          package:
+            - --index-url=https://dl.modular.com/public/nightly/python/simple/
+            - max


### PR DESCRIPTION
Slightly hacky - but works :tada:

```
bollo:~/d/c/infra (main|✚1) 36.2s $ /opt/compiler-explorer/mojo-nightly/bin/mojo --version
mojo 25.4.0.dev2025052105 (217ba624)
bollo:~/d/c/infra (main|✚1) $ /opt/compiler-explorer/mojo-25.3.0/bin/mojo --version
mojo 25.3.0 (d430567f)
```

CC @rparolin  :) Not that elegant but "good enough :D