### PR TITLE
[rust]: install `rust-src` component

### DIFF
--- a/bin/lib/installable/rust.py
+++ b/bin/lib/installable/rust.py
@@ -69,6 +69,8 @@ class RustInstallable(Installable):
         self.do_rust_install(staging, self.base_package, base_path)
         for architecture in architectures:
             self.do_rust_install(staging, f"rust-std-{self.target_name}-{architecture}", base_path)
+        if self.nightly_like:
+            self.do_rust_install(staging, f"rust-src-{self.target_name}", base_path)
         for binary in (base_path / "bin").glob("*"):
             self.maybe_set_rpath(binary, "$ORIGIN/../lib")
         for shared_object in (base_path / "lib").glob("*.so"):


### PR DESCRIPTION
Building a Miri sysroot needs the standard library sources.

Needed for https://github.com/compiler-explorer/misc-builder/pull/112.

See https://github.com/compiler-explorer/compiler-explorer/issues/2563.