### PR TITLE
Add Rust crate ahash v0.8.12

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -2895,6 +2895,11 @@ libraries:
         - stdlib-fpm
         type: github
   rust:
+    ahash:
+      build_type: cargo
+      targets:
+      - 0.8.12
+      type: cratesio
     aho-corasick:
       build_type: cargo
       targets:


### PR DESCRIPTION
This PR adds the Rust crate **ahash** version 0.8.12 to Compiler Explorer.