### PR TITLE
add bmpi3 to libraries.yaml

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1279,19 +1279,19 @@ libraries:
         targets:
         - trunk
         type: bitbucket
-      bmulti:
-        build_type: none
-        check_file: include/multi/array.hpp
-        method: nightlyclone
-        repo: correaa/boost-multi
-        targets:
-        - trunk
-        type: gitlab
       bmpi3:
         build_type: none
         check_file: include/mpi3/communicator.hpp
         method: nightlyclone
         repo: correaa/boost-mpi3
+        targets:
+        - trunk
+        type: gitlab
+      bmulti:
+        build_type: none
+        check_file: include/multi/array.hpp
+        method: nightlyclone
+        repo: correaa/boost-multi
         targets:
         - trunk
         type: gitlab


### PR DESCRIPTION
Proposing to add the B-MPI3 library to the live site. https://gitlab.com/correaa/boost-mpi3

Followed the steps as best as I could in based on other gitlab type libraries (bmulti)

Feedback on improving the hooks and the organizations of files in the repository is welcome.
The goal is to include the library by doing #include<mpi3/communicator.hpp>.

There will be an accompanying PR in compiler-explorer repo

The library depends on the C MPI system library, since this is not likely to be available in Compiler Explorer one should expect to be able compile but not to link test programs