### PR TITLE
Add zig 0.14.1

### DIFF
--- a/bin/yaml/zig.yaml
+++ b/bin/yaml/zig.yaml
@@ -24,6 +24,10 @@ compilers:
       - 0.12.1
       - 0.13.0
       - 0.14.0
+    new_naming:
+      url: https://ziglang.org/download/{{name}}/zig-x86_64-linux-{{name}}.tar.xz
+      targets:
+        - 0.14.1
     nightly:
       if: nightly
       type: restQueryTarballs


### PR DESCRIPTION
In the `0.14.1` release cycle, the release tarball naming scheme changed from `[os]-[arch]` to `[arch]-[os]`. Older tarballs are unaffected. The new naming scheme is expected to be carried forward for future releases.