### PR TITLE
Add C++ library jsoncons v0.177.0

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -839,6 +839,7 @@ libraries:
       target_prefix: v
       targets:
       - 0.168.3
+      - 0.177.0
       type: github
     jsoncpp:
       build_type: cmake


### PR DESCRIPTION
This PR adds the C++ library **jsoncons** version 0.177.0 to Compiler Explorer.

- GitHub URL: https://github.com/danielaparker/jsoncons
- Library Type: Unknown