### PR TITLE
Add C++ library json v3.12.0

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -2098,6 +2098,7 @@ libraries:
       - 3.10.5
       - 3.11.1
       - 3.11.3
+      - 3.12.0
       type: github
     nsimd:
       check_file: x86_64/include/nsimd/nsimd.h


### PR DESCRIPTION
This PR adds the C++ library **json** version 3.12.0 to Compiler Explorer.

- GitHub URL: https://github.com/nlohmann/json
- Library Type: Unknown