### PR TITLE
Add C++ library doctest v2.4.12

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -544,6 +544,7 @@ libraries:
       - 2.3.6
       - 2.3.7
       - 2.3.8
+      - 2.4.12
       type: github
     eastl:
       build_type: none


### PR DESCRIPTION
This PR adds the C++ library **doctest** version 2.4.12 to Compiler Explorer.

- GitHub URL: https://github.com/doctest/doctest
- Library Type: Unknown