### PR TITLE
Add C++ library magic_enum v0.9.7

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1087,6 +1087,7 @@ libraries:
       target_prefix: v
       targets:
       - 0.7.3
+      - 0.9.7
       type: github
     mdspan:
       build_type: none


### PR DESCRIPTION
This PR adds the C++ library **magic_enum** version 0.9.7 to Compiler Explorer.

- GitHub URL: https://github.com/Neargye/magic_enum
- Library Type: Unknown