### PR TITLE
Add list-paths command to ce_install

### DIFF
--- a/bin/lib/ce_install.py
+++ b/bin/lib/ce_install.py
@@ -288,6 +288,33 @@ def verify(context: CliContext, filter_: List[str]):
         sys.exit(1)
 
 
+@cli.command(name="list-paths")
+@click.pass_obj
+@click.option("--json", "as_json", is_flag=True, help="Output in JSON format")
+@click.option("--absolute", is_flag=True, help="Show absolute paths")
+@click.argument("filter_", metavar="FILTER", nargs=-1)
+def list_paths(context: CliContext, filter_: List[str], as_json: bool, absolute: bool):
+    """List installation paths for targets matching FILTER without installing."""
+    paths = {}
+    for installable in context.get_installables(filter_):
+        if absolute:
+            # Combine with destination to get absolute path
+            path = str(context.installation_context.destination / installable.install_path)
+        else:
+            # Relative path within the installation directory
+            path = installable.install_path
+
+        if as_json:
+            paths[installable.name] = path
+        else:
+            print(f"{installable.name}: {path}")
+
+    if as_json:
+        import json
+
+        print(json.dumps(paths, indent=2))
+
+
 @cli.command()
 @click.pass_obj
 @click.argument("filter_", metavar="FILTER", nargs=-1)

--- a/docs/installing_compilers.md
+++ b/docs/installing_compilers.md
@@ -14,6 +14,17 @@ The directory `/opt/compiler-explorer` is required, otherwise you'll have to sup
 
 `ce_install list` or `ce_install --enable nightly list`
 
+### Listing installation paths
+
+To see where compilers/tools would be installed without actually installing them:
+
+`ce_install list-paths <filter>`
+
+Examples:
+- `ce_install list-paths 'libraries/c++/fmt'` - Show all fmt library version paths
+- `ce_install list-paths --absolute 'libraries/c++/fmt 10.2.1'` - Show absolute path for specific version
+- `ce_install list-paths --json 'compilers/c++'` - Output all C++ compiler paths in JSON format
+
 ### For versioned compilers/tools
 
 `ce_install install <name>`


### PR DESCRIPTION
This new command allows users to see where compilers/tools/libraries would be installed without actually installing them. This is useful for scripting and understanding the installation layout.

Features:
- Lists installation paths for targets matching a filter
- --json option for JSON formatted output
- --absolute option to show absolute paths with destination prefix
- Works exactly like install command but only shows paths

Examples:
  ce_install list-paths 'libraries/c++/fmt' ce_install list-paths --absolute 'libraries/c++/fmt 10.2.1' ce_install list-paths --json 'compilers/c++'

🤖 Generated with [Claude Code](https://claude.ai/code)