### PR TITLE
Add C3 0.7.0 to 0.7.2

### DIFF
--- a/bin/yaml/c3.yaml
+++ b/bin/yaml/c3.yaml
@@ -32,3 +32,9 @@ compilers:
         url: https://github.com/c3lang/c3c/releases/download/v0.6.7/c3-ubuntu-20.tar.gz
       - name: 0.6.8
         url: https://github.com/c3lang/c3c/releases/download/v0.6.8/c3-ubuntu-20.tar.gz
+      - name: 0.7.0
+        url: https://github.com/c3lang/c3c/releases/download/v0.7.0/c3-ubuntu-20.tar.gz
+      - name: 0.7.1
+        url: https://github.com/c3lang/c3c/releases/download/v0.7.1/c3-ubuntu-22.tar.gz
+      - name: 0.7.2
+        url: https://github.com/c3lang/c3c/releases/download/v0.7.2/c3-ubuntu-22.tar.gz


### PR DESCRIPTION
This adds C3 0.7.0 to 0.7.2. One question is whether there are additional changes needed as 0.7.1 and 0.7.2 are built for Ubuntu 22 instead?