### PR TITLE
Add nix evaluators

### DIFF
--- a/bin/yaml/nix.yaml
+++ b/bin/yaml/nix.yaml
@@ -1,0 +1,16 @@
+compilers:
+  nix:
+    type: tarballs
+    compression: gz
+    dir: nix-{{name}}
+    create_untar_dir: true
+    check_exe: nix --version
+    targets:
+      - name: 2.29.0
+        url: https://github.com/Rucadi/unofficial_nix_static_releases/releases/download/0.0.1/nix_2.29.0-x86_64-linux.tar.gz
+      - name: 2.28.3
+        url: https://github.com/Rucadi/unofficial_nix_static_releases/releases/download/0.0.1/nix_2.28.3-x86_64-linux.tar.gz
+      - name: 2.27.1
+        url: https://github.com/Rucadi/unofficial_nix_static_releases/releases/download/0.0.1/nix_2.27.1-x86_64-linux.tar.gz
+      - name: 2.26.3
+        url: https://github.com/Rucadi/unofficial_nix_static_releases/releases/download/0.0.1/nix_2.26.3-x86_64-linux.tar.gz


### PR DESCRIPTION
Following https://github.com/compiler-explorer/compiler-explorer/pull/6198 I introduce the installation of the evaluators for nix, to avoid the current status where compiler-explorer returns:
```
Internal Compiler Explorer error: Error: No executable provided
    at Module.execute (file:///infra/.deploy/lib/exec.js:552:15)
    at NixCompiler.exec (file:///infra/.deploy/lib/base-compiler.js:317:27)
    at NixCompiler.runCompiler (file:///infra/.deploy/lib/base-compiler.js:446:35)
    at NixCompiler.runCompiler (file:///infra/.deploy/lib/compilers/nix.js:40:48)
    at NixCompiler.doCompilation (file:///infra/.deploy/lib/base-compiler.js:1784:18)
    at async file:///infra/.deploy/lib/base-compiler.js:2233:63
    at async env.enqueue.abandonIfStale (file:///infra/.deploy/lib/base-compiler.js:2215:25)
    at async file:///infra/.deploy/node_modules/p-queue/dist/index.js:230:36
Compiler returned: -1
```

and to fix issue https://github.com/compiler-explorer/compiler-explorer/issues/7811

I tested the "ce" command and it installed correctly, the statically-linked binaries however are taken from my own repo, created for this specific purpose since statically-linked versions are not officially distributed.


I have tested these binaries output but I have not tested the integration within compiler-explorer. 