### PR TITLE
Bump hpx to v1.11.0

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -827,7 +827,7 @@ libraries:
       - hpx_wrap
       target_prefix: v
       targets:
-      - name: 1.10.0
+      - name: 1.11.0
       type: github
     jsoncons:
       check_file: README.md


### PR DESCRIPTION
Bumps hpx version to use latest tag release v1.11.0