### PR TITLE
Experimental: try mounting serially but in parallel with startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,31 @@ check-lambda-changed: lambda-package
 		echo "LAMBDA_CHANGED=0" > $(LAMBDA_PACKAGE_SHA).status; \
 	fi
 
+.PHONY: check-compilation-lambda-changed
+check-compilation-lambda-changed: compilation-lambda-package
+	@mkdir -p $(dir $(COMPILATION_LAMBDA_PACKAGE))
+	@echo "Checking if compilation lambda package has changed..."
+	@aws s3 cp s3://compiler-explorer/lambdas/compilation-lambda-package.zip.sha256 $(COMPILATION_LAMBDA_PACKAGE_SHA).remote 2>/dev/null || (echo "Remote compilation lambda SHA doesn't exist yet" && touch $(COMPILATION_LAMBDA_PACKAGE_SHA).remote)
+	@if [ ! -f $(COMPILATION_LAMBDA_PACKAGE_SHA).remote ] || ! cmp -s $(COMPILATION_LAMBDA_PACKAGE_SHA) $(COMPILATION_LAMBDA_PACKAGE_SHA).remote; then \
+		echo "Compilation lambda package has changed"; \
+		echo "COMPILATION_LAMBDA_CHANGED=1" > $(COMPILATION_LAMBDA_PACKAGE_SHA).status; \
+	else \
+		echo "Compilation lambda package has not changed"; \
+		echo "COMPILATION_LAMBDA_CHANGED=0" > $(COMPILATION_LAMBDA_PACKAGE_SHA).status; \
+	fi
+
+.PHONY: upload-compilation-lambda
+upload-compilation-lambda: check-compilation-lambda-changed
+	@. $(COMPILATION_LAMBDA_PACKAGE_SHA).status && \
+	if [ "$$COMPILATION_LAMBDA_CHANGED" = "1" ]; then \
+		echo "Uploading new compilation lambda package to S3..."; \
+		aws s3 cp $(COMPILATION_LAMBDA_PACKAGE) s3://compiler-explorer/lambdas/compilation-lambda-package.zip; \
+		aws s3 cp --content-type text/sha256 $(COMPILATION_LAMBDA_PACKAGE_SHA) s3://compiler-explorer/lambdas/compilation-lambda-package.zip.sha256; \
+		echo "Compilation lambda package uploaded successfully!"; \
+	else \
+		echo "Compilation lambda package hasn't changed. No upload needed."; \
+	fi
+
 .PHONY: upload-lambda
 upload-lambda: check-lambda-changed
 	@. $(LAMBDA_PACKAGE_SHA).status && \
@@ -145,6 +170,18 @@ $(EVENTS_LAMBDA_PACKAGE_SHA): $(EVENTS_LAMBDA_PACKAGE)
 .PHONY: events-lambda-package  ## builds events lambda
 events-lambda-package: $(EVENTS_LAMBDA_PACKAGE) $(EVENTS_LAMBDA_PACKAGE_SHA)
 
+COMPILATION_LAMBDA_PACKAGE:=$(CURDIR)/.dist/compilation-lambda-package.zip
+COMPILATION_LAMBDA_PACKAGE_SHA:=$(CURDIR)/.dist/compilation-lambda-package.zip.sha256
+$(COMPILATION_LAMBDA_PACKAGE) $(COMPILATION_LAMBDA_PACKAGE_SHA): $(wildcard compilation-lambda/*.py) compilation-lambda/pyproject.toml Makefile scripts/build_lambda_deterministic.py
+	$(UV_BIN) run python scripts/build_lambda_deterministic.py $(CURDIR)/compilation-lambda $(COMPILATION_LAMBDA_PACKAGE)
+
+.PHONY: compilation-lambda-package  ## builds compilation lambda
+compilation-lambda-package: $(COMPILATION_LAMBDA_PACKAGE) $(COMPILATION_LAMBDA_PACKAGE_SHA)
+
+.PHONY: test-compilation-lambda  ## runs compilation lambda tests
+test-compilation-lambda: ce
+	cd compilation-lambda && $(UV_BIN) run --with websocket-client --with boto3 --with pytest python -m pytest test_lambda_function.py -v
+
 .PHONY: events-lambda-package  ## Builds events-lambda
 events-lambda-package: $(EVENTS_LAMBDA_PACKAGE) $(EVENTS_LAMBDA_PACKAGE_SHA)
 
@@ -154,11 +191,11 @@ upload-events-lambda: events-lambda-package  ## Uploads events-lambda to S3
 	aws s3 cp --content-type text/sha256 $(EVENTS_LAMBDA_PACKAGE_SHA) s3://compiler-explorer/lambdas/events-lambda-package.zip.sha256
 
 .PHONY: terraform-apply
-terraform-apply:  upload-lambda ## Applies terraform
+terraform-apply:  upload-lambda upload-compilation-lambda ## Applies terraform
 	terraform -chdir=terraform apply
 
 .PHONY: terraform-plan
-terraform-plan:  upload-lambda ## Plans terraform changes
+terraform-plan:  upload-lambda upload-compilation-lambda ## Plans terraform changes
 	terraform -chdir=terraform plan
 
 .PHONY: pre-commit

--- a/compilation-lambda/README.md
+++ b/compilation-lambda/README.md
@@ -1,0 +1,83 @@
+# Compilation Lambda
+
+This Lambda function handles compilation requests for Compiler Explorer by:
+
+1. Accepting POST requests to `/api/compiler/{compiler_id}/compile` and `/api/compiler/{compiler_id}/cmake`
+2. Extracting the compiler ID from the URL path
+3. Generating a unique GUID for request tracking
+4. Sending the request to an SQS queue for processing
+5. Waiting for compilation results via WebSocket
+6. Returning the compilation results to the client
+
+## Environment Variables
+
+- `RETRY_COUNT` (default: 1) - Number of WebSocket connection retry attempts
+- `TIMEOUT_SECONDS` (default: 60) - Timeout for WebSocket response in seconds
+- `SQS_QUEUE_URL` - URL of the SQS FIFO queue for compilation requests
+- `WEBSOCKET_URL` - URL of the WebSocket endpoint for receiving results
+
+## Logging
+
+The Lambda uses WARNING level logging by default for optimal performance. Only errors, warnings, and critical issues are logged to CloudWatch.
+
+## Request Flow
+
+1. ALB receives POST request to `/api/compiler/{compiler_id}/compile` or `/api/compiler/{compiler_id}/cmake`
+2. Lambda extracts `compiler_id` from URL path
+3. Lambda generates unique GUID for tracking
+4. Lambda connects to WebSocket and subscribes to messages for the GUID
+5. Lambda wraps request body with GUID, compiler ID, and cmake flag
+6. Lambda sends message to SQS queue
+7. Worker processes compilation and sends result to WebSocket
+8. Lambda receives result and returns it to client
+
+## Error Handling
+
+- **400 Bad Request**: Invalid path or missing compiler ID
+- **405 Method Not Allowed**: Non-POST requests
+- **408 Request Timeout**: No response received within timeout period
+- **500 Internal Server Error**: SQS failures, WebSocket errors, or other exceptions
+
+## Testing
+
+Run unit tests with:
+
+```bash
+python -m pytest test_lambda_function.py -v
+```
+
+## Message Format
+
+SQS message body:
+```json
+{
+  "guid": "uuid-string",
+  "compilerId": "gcc12",
+  "isCMake": false,
+  "headers": {"Content-Type": "application/json"},
+  "source": "int main() { return 0; }",
+  "options": ["-O2"],
+  "filters": {},
+  "libraries": [],
+  "backendOptions": {},
+  "tools": [],
+  "files": [],
+  "executeParameters": {}
+}
+```
+
+WebSocket subscription:
+```
+subscribe: uuid-string
+```
+
+WebSocket result:
+```json
+{
+  "guid": "uuid-string",
+  "code": 0,
+  "stdout": ["Hello World"],
+  "stderr": [],
+  "asm": []
+}
+```

--- a/compilation-lambda/lambda_function.py
+++ b/compilation-lambda/lambda_function.py
@@ -1,0 +1,438 @@
+import json
+import logging
+import os
+import time
+import uuid
+from typing import Any, Dict, Optional
+
+import boto3
+import websocket
+from botocore.exceptions import ClientError
+
+# Configure logging
+logger = logging.getLogger()
+logger.setLevel(logging.WARNING)
+
+# Environment variables with defaults
+RETRY_COUNT = int(os.environ.get("RETRY_COUNT", "1"))
+TIMEOUT_SECONDS = int(os.environ.get("TIMEOUT_SECONDS", "60"))
+SQS_QUEUE_URL = os.environ.get("SQS_QUEUE_URL", "")
+WEBSOCKET_URL = os.environ.get("WEBSOCKET_URL", "")
+
+# Initialize AWS clients
+sqs = boto3.client("sqs")
+
+
+class CompilationError(Exception):
+    """Base exception for compilation-related errors."""
+
+    pass
+
+
+class WebSocketTimeoutError(CompilationError):
+    """Raised when WebSocket response times out."""
+
+    pass
+
+
+class SQSError(CompilationError):
+    """Raised when SQS operations fail."""
+
+    pass
+
+
+def generate_guid() -> str:
+    """Generate a unique GUID for request tracking."""
+    return str(uuid.uuid4())
+
+
+def extract_compiler_id(path: str) -> Optional[str]:
+    """
+    Extract compiler ID from ALB request path.
+    Expected paths:
+    - Production: /api/compiler/{compiler_id}/compile or /api/compiler/{compiler_id}/cmake
+    - Other envs: /{env}/api/compiler/{compiler_id}/compile or /{env}/api/compiler/{compiler_id}/cmake
+    """
+    try:
+        path_parts = path.strip("/").split("/")
+
+        # Production format: /api/compiler/{compiler_id}/compile
+        if len(path_parts) >= 4 and path_parts[0] == "api" and path_parts[1] == "compiler":
+            return path_parts[2]
+
+        # Other environments format: /{env}/api/compiler/{compiler_id}/compile
+        if len(path_parts) >= 5 and path_parts[1] == "api" and path_parts[2] == "compiler":
+            return path_parts[3]
+
+    except (IndexError, AttributeError):
+        pass
+    return None
+
+
+def is_cmake_request(path: str) -> bool:
+    """Check if the request is for cmake compilation."""
+    return path.endswith("/cmake")
+
+
+def parse_request_body(body: str, content_type: str) -> Dict[str, Any]:
+    """
+    Parse request body based on content type.
+    Supports both JSON and plain text (for source code).
+    """
+    if not body:
+        return {}
+
+    # Check if content type indicates JSON
+    if content_type and "application/json" in content_type.lower():
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError:
+            logger.warning("Failed to parse JSON body, treating as plain text")
+            return {"source": body}
+    else:
+        # Plain text body - treat as source code
+        return {"source": body}
+
+
+def send_to_sqs(guid: str, compiler_id: str, body: str, is_cmake: bool, headers: Dict[str, str]) -> None:
+    """Send compilation request to SQS queue as RemoteCompilationRequest."""
+    if not SQS_QUEUE_URL:
+        raise SQSError("SQS_QUEUE_URL environment variable not set")
+
+    # Parse body based on content type
+    content_type = headers.get("content-type", headers.get("Content-Type", ""))
+    request_data = parse_request_body(body, content_type)
+
+    if not isinstance(request_data, dict):
+        logger.warning(f"Request data is not a dict: {str(request_data)[:100]}...")
+
+    # Start with Lambda-specific fields
+    message_body = {
+        "guid": guid,
+        "compilerId": compiler_id,
+        "isCMake": is_cmake,
+        "headers": headers,  # Preserve original headers for response formatting
+    }
+
+    # Merge all fields from the original request first (preserves original values)
+    message_body.update(request_data)
+
+    # Add defaults for fields that are required by the consumer but might be missing
+    if "source" not in message_body:
+        message_body["source"] = ""
+    if "options" not in message_body:
+        message_body["options"] = []
+    if "filters" not in message_body:
+        message_body["filters"] = {}
+    if "backendOptions" not in message_body:
+        message_body["backendOptions"] = {}
+    if "tools" not in message_body:
+        message_body["tools"] = []
+    if "libraries" not in message_body:
+        message_body["libraries"] = []
+    if "files" not in message_body:
+        message_body["files"] = []
+    if "executeParameters" not in message_body:
+        message_body["executeParameters"] = {}
+
+    try:
+        # Ensure we're sending a proper JSON string (not double-encoded)
+        if isinstance(message_body, str):
+            logger.warning("Message body is already a string - this might cause double encoding")
+            message_json = message_body
+        else:
+            message_json = json.dumps(message_body, separators=(",", ":"))
+
+        sqs.send_message(
+            QueueUrl=SQS_QUEUE_URL,
+            MessageBody=message_json,
+            MessageGroupId="default",
+            MessageDeduplicationId=guid,
+        )
+
+    except (TypeError, ValueError) as e:
+        logger.error(f"Failed to JSON encode message body: {e}")
+        raise SQSError(f"Failed to JSON encode message: {e}") from e
+    except ClientError as e:
+        logger.error(f"Failed to send message to SQS: {e}")
+        raise SQSError(f"Failed to send message to SQS: {e}") from e
+
+
+class WebSocketClient:
+    """WebSocket client for receiving compilation results."""
+
+    def __init__(self, url: str, guid: str):
+        self.url = url
+        self.guid = guid
+        self.ws = None
+        self.result = None
+        self.connected = False
+
+    def on_open(self, ws):
+        """Called when WebSocket connection opens."""
+        self.connected = True
+        # Subscribe to messages for this GUID
+        subscribe_msg = f"subscribe: {self.guid}"
+        ws.send(subscribe_msg)
+
+    def on_message(self, ws, message):
+        """Called when WebSocket receives a message."""
+        try:
+            data = json.loads(message)
+            message_guid = data.get("guid")
+
+            if message_guid == self.guid:
+                # The entire message IS the result
+                self.result = data
+                ws.close()
+        except json.JSONDecodeError as e:
+            logger.warning(f"Received invalid JSON message: {message[:100]}... Error: {e}")
+
+    def on_error(self, ws, error):
+        """Called when WebSocket encounters an error."""
+        logger.error(f"WebSocket error for {self.guid}: {error}")
+
+    def on_close(self, ws, close_status_code, close_msg):
+        """Called when WebSocket connection closes."""
+        pass
+
+    def connect_and_subscribe(self):
+        """Connect to WebSocket and subscribe to GUID (doesn't wait for result)."""
+        if not self.url:
+            raise CompilationError("WEBSOCKET_URL environment variable not set")
+
+        websocket.enableTrace(False)
+        self.ws = websocket.WebSocketApp(
+            self.url, on_open=self.on_open, on_message=self.on_message, on_error=self.on_error, on_close=self.on_close
+        )
+
+        if self.ws is None:
+            raise CompilationError("WebSocket client not initialized")
+
+    def wait_for_result(self, timeout: int) -> Dict[str, Any]:
+        """Wait for compilation result on already-connected WebSocket."""
+        start_time = time.time()
+
+        while time.time() - start_time < timeout:
+            if self.result is not None:
+                if self.ws:
+                    self.ws.close()
+                return self.result
+            time.sleep(0.1)
+
+        # Timeout reached
+        logger.error(f"WebSocket timeout for {self.guid} after {timeout}s")
+        if self.ws:
+            self.ws.close()
+        raise WebSocketTimeoutError(f"No response received within {timeout} seconds")
+
+    def connect_and_wait(self, timeout: int) -> Dict[str, Any]:
+        """Connect to WebSocket and wait for result."""
+        if not self.url:
+            raise CompilationError("WEBSOCKET_URL environment variable not set")
+
+        websocket.enableTrace(False)
+        self.ws = websocket.WebSocketApp(
+            self.url, on_open=self.on_open, on_message=self.on_message, on_error=self.on_error, on_close=self.on_close
+        )
+
+        # Start WebSocket in a separate thread and wait for result
+        import threading
+
+        if self.ws is not None:
+            ws_thread = threading.Thread(target=self.ws.run_forever)
+            ws_thread.daemon = True
+            ws_thread.start()
+        else:
+            raise CompilationError("WebSocket client not initialized")
+
+        # Wait for connection and result
+        start_time = time.time()
+
+        while time.time() - start_time < timeout:
+            if self.result is not None:
+                return self.result
+            time.sleep(0.1)
+
+        # Timeout reached
+        logger.error(f"WebSocket timeout for {self.guid} after {timeout}s")
+        if self.ws:
+            self.ws.close()
+        raise WebSocketTimeoutError(f"No response received within {timeout} seconds")
+
+
+def wait_for_compilation_result(guid: str, timeout: int) -> Dict[str, Any]:
+    """Wait for compilation result via WebSocket with retry logic."""
+    last_error = None
+
+    for attempt in range(RETRY_COUNT + 1):
+        try:
+            client = WebSocketClient(WEBSOCKET_URL, guid)
+            return client.connect_and_wait(timeout)
+        except Exception as e:
+            last_error = e
+            if attempt < RETRY_COUNT:
+                time.sleep(1)  # Brief delay before retry
+
+    raise last_error or CompilationError("All WebSocket attempts failed")
+
+
+def create_error_response(status_code: int, message: str) -> Dict[str, Any]:
+    """Create an ALB-compatible error response."""
+    return {
+        "statusCode": status_code,
+        "headers": {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "POST",
+            "Access-Control-Allow-Headers": "Content-Type",
+        },
+        "body": json.dumps({"error": message}),
+    }
+
+
+def create_success_response(result: Dict[str, Any], accept_header: str) -> Dict[str, Any]:
+    """
+    Create an ALB-compatible success response.
+    Response format depends on Accept header.
+    """
+    # Determine response format based on Accept header
+    if accept_header and "text/plain" in accept_header.lower():
+        # Plain text response - typically just the assembly output
+        body = ""
+        if "asm" in result:
+            # Join assembly lines
+            body = "\n".join(line.get("text", "") for line in result.get("asm", []))
+        elif "stdout" in result:
+            # Fallback to stdout if no asm
+            body = "\n".join(result.get("stdout", []))
+
+        return {
+            "statusCode": 200,
+            "headers": {
+                "Content-Type": "text/plain; charset=utf-8",
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Methods": "POST",
+                "Access-Control-Allow-Headers": "Content-Type, Accept",
+            },
+            "body": body,
+        }
+    else:
+        # Default to JSON response
+        return {
+            "statusCode": 200,
+            "headers": {
+                "Content-Type": "application/json; charset=utf-8",
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Methods": "POST",
+                "Access-Control-Allow-Headers": "Content-Type, Accept",
+            },
+            "body": json.dumps(result),
+        }
+
+
+def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """
+    Main Lambda handler for compilation requests.
+    Handles ALB requests for /api/compilers/{compiler_id}/compile and /api/compilers/{compiler_id}/cmake
+    """
+    try:
+        # Parse ALB request
+        path = event.get("path", "")
+        method = event.get("httpMethod", "")
+        body = event.get("body", "")
+        headers = event.get("headers", {})
+
+        # Validate request method
+        if method != "POST":
+            return create_error_response(405, "Method not allowed")
+
+        # Extract compiler ID from path
+        compiler_id = extract_compiler_id(path)
+        if not compiler_id:
+            return create_error_response(400, "Invalid path: compiler ID not found")
+
+        # Check if this is a cmake request
+        is_cmake = is_cmake_request(path)
+
+        # Generate unique GUID for this request
+        guid = generate_guid()
+
+        # First, establish WebSocket connection and subscribe to the GUID
+        # This ensures we're ready to receive the result before sending to SQS
+        try:
+            ws_client = WebSocketClient(WEBSOCKET_URL, guid)
+
+            # Initialize the WebSocket app
+            websocket.enableTrace(False)
+            ws_client.ws = websocket.WebSocketApp(
+                ws_client.url,
+                on_open=ws_client.on_open,
+                on_message=ws_client.on_message,
+                on_error=ws_client.on_error,
+                on_close=ws_client.on_close,
+            )
+
+            # Start the WebSocket connection in a separate thread using run_forever
+            import threading
+
+            if ws_client.ws is not None:
+                ws_thread = threading.Thread(target=ws_client.ws.run_forever)
+                ws_thread.daemon = True
+                ws_thread.start()
+            else:
+                raise CompilationError("WebSocket client not initialized")
+
+            # Wait a moment to ensure subscription is established
+            start_time = time.time()
+            while not ws_client.connected and time.time() - start_time < 5:
+                time.sleep(0.1)
+
+            if not ws_client.connected:
+                raise CompilationError("Failed to establish WebSocket connection within 5 seconds")
+
+        except Exception as e:
+            logger.error(f"Failed to setup WebSocket subscription: {e}")
+            return create_error_response(500, f"Failed to setup result subscription: {str(e)}")
+
+        # Now send request to SQS queue with headers
+        try:
+            send_to_sqs(guid, compiler_id, body, is_cmake, headers)
+        except SQSError as e:
+            logger.error(f"SQS error: {e}")
+            try:
+                if ws_client and ws_client.ws:
+                    ws_client.ws.close()
+            except Exception:
+                pass
+            return create_error_response(500, f"Failed to queue compilation request: {str(e)}")
+
+        # Wait for compilation result via the already-connected WebSocket
+        try:
+            result = ws_client.wait_for_result(TIMEOUT_SECONDS)
+
+            # Get Accept header for response formatting
+            accept_header = headers.get("accept", headers.get("Accept", ""))
+            return create_success_response(result, accept_header)
+
+        except WebSocketTimeoutError as e:
+            logger.error(f"Timeout waiting for compilation result: {e}")
+            try:
+                if ws_client and ws_client.ws:
+                    ws_client.ws.close()
+            except Exception:
+                pass
+            return create_error_response(408, f"Compilation timeout: {str(e)}")
+
+        except Exception as e:
+            logger.error(f"WebSocket error: {e}")
+            try:
+                if ws_client and ws_client.ws:
+                    ws_client.ws.close()
+            except Exception:
+                pass
+            return create_error_response(500, f"Failed to receive compilation result: {str(e)}")
+
+    except Exception as e:
+        logger.error(f"Unexpected error in lambda_handler: {e}")
+        return create_error_response(500, f"Internal server error: {str(e)}")

--- a/compilation-lambda/pyproject.toml
+++ b/compilation-lambda/pyproject.toml
@@ -1,0 +1,35 @@
+[project]
+name = "compilation-lambda"
+version = "0.0.1"
+description = "Compiler Explorer Compilation Lambda Function"
+authors = [
+    {name = "Matt Godbolt", email = "matt@godbolt.org"}
+]
+requires-python = ">=3.12"
+dependencies = [
+    "boto3>=1.26.0",
+    "websocket-client>=1.6.0"
+]
+
+# Copied from the parent project.
+[tool.ruff]
+line-length = 120
+target-version = "py312"
+
+[tool.ruff.lint]
+select = [
+    # https://docs.astral.sh/ruff/rules/
+    "E", # pycodestyle errors,
+    "W", # pycodestyle warnings
+    "F", # pyflake
+    "B", # flake8-bugbear
+    "I", # isort
+]
+ignore = [
+    "E501" # line length
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.4.1",
+]

--- a/compilation-lambda/test_lambda_function.py
+++ b/compilation-lambda/test_lambda_function.py
@@ -1,0 +1,499 @@
+import json
+import os
+import unittest
+import uuid
+from unittest.mock import Mock, patch
+
+import lambda_function
+
+
+class TestCompilationLambda(unittest.TestCase):
+    """Test cases for compilation Lambda function."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Mock environment variables
+        self.env_patcher = patch.dict(
+            os.environ,
+            {
+                "RETRY_COUNT": "2",
+                "TIMEOUT_SECONDS": "30",
+                "SQS_QUEUE_URL": "https://sqs.us-east-1.amazonaws.com/123456789/test-queue.fifo",
+                "WEBSOCKET_URL": "wss://events.test.com/environment",
+            },
+        )
+        self.env_patcher.start()
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        self.env_patcher.stop()
+
+    def test_generate_guid(self):
+        """Test GUID generation."""
+        guid1 = lambda_function.generate_guid()
+        guid2 = lambda_function.generate_guid()
+
+        # Should be valid UUIDs
+        uuid.UUID(guid1)
+        uuid.UUID(guid2)
+
+        # Should be unique
+        self.assertNotEqual(guid1, guid2)
+
+    def test_extract_compiler_id(self):
+        """Test compiler ID extraction from paths."""
+        test_cases = [
+            # Production format: /api/compiler/{id}/compile
+            ("/api/compiler/gcc12/compile", "gcc12"),
+            ("/api/compiler/clang15/cmake", "clang15"),
+            ("api/compiler/rust-nightly/compile", "rust-nightly"),
+            ("/api/compiler/g++12.2/compile", "g++12.2"),
+            ("/api/compiler/gcc12/invalid", "gcc12"),  # Still extracts valid compiler ID
+            # Environment-prefixed format: /{env}/api/compiler/{id}/compile
+            ("/beta/api/compiler/gcc12/compile", "gcc12"),
+            ("/staging/api/compiler/clang15/cmake", "clang15"),
+            ("beta/api/compiler/g++12.2/compile", "g++12.2"),
+            ("/beta/api/compiler/gcc12/invalid", "gcc12"),  # Still extracts valid compiler ID
+            # Invalid paths
+            ("/invalid/path", None),
+            ("/api/compilers/gcc12/compile", None),  # Legacy plural format no longer supported
+            ("/api/compilers/", None),
+            ("/api/compiler/", None),  # Missing compiler ID
+            ("/beta/api/compiler/", None),  # Missing compiler ID
+            ("/beta/api/compilers/gcc12/compile", None),  # Wrong plural form
+            ("", None),
+        ]
+
+        for path, expected in test_cases:
+            with self.subTest(path=path):
+                result = lambda_function.extract_compiler_id(path)
+                self.assertEqual(result, expected)
+
+    def test_is_cmake_request(self):
+        """Test cmake request detection."""
+        test_cases = [
+            # Production format
+            ("/api/compiler/gcc12/cmake", True),
+            ("/api/compiler/clang15/compile", False),
+            # Environment-prefixed format
+            ("/beta/api/compiler/gcc12/cmake", True),
+            ("/staging/api/compiler/clang15/compile", False),
+            # Invalid cases
+            ("/api/compilers/gcc12/cmake", True),  # Legacy plural format still detects /cmake ending
+            ("cmake", False),  # Must end with /cmake
+            ("", False),
+        ]
+
+        for path, expected in test_cases:
+            with self.subTest(path=path):
+                result = lambda_function.is_cmake_request(path)
+                self.assertEqual(result, expected)
+
+    @patch("lambda_function.sqs")
+    @patch("lambda_function.SQS_QUEUE_URL", "https://sqs.us-east-1.amazonaws.com/123456789/test-queue.fifo")
+    def test_send_to_sqs_success(self, mock_sqs):
+        """Test successful SQS message sending."""
+        mock_sqs.send_message.return_value = {"MessageId": "test-message-id"}
+
+        headers = {"Content-Type": "application/json"}
+        lambda_function.send_to_sqs("test-guid", "gcc12", '{"source": "test"}', False, headers)
+
+        mock_sqs.send_message.assert_called_once()
+        call_args = mock_sqs.send_message.call_args
+
+        self.assertEqual(call_args[1]["QueueUrl"], "https://sqs.us-east-1.amazonaws.com/123456789/test-queue.fifo")
+        self.assertEqual(call_args[1]["MessageGroupId"], "default")
+        self.assertEqual(call_args[1]["MessageDeduplicationId"], "test-guid")
+
+        # Check message body
+        message_body = json.loads(call_args[1]["MessageBody"])
+        self.assertEqual(message_body["guid"], "test-guid")
+        self.assertEqual(message_body["compilerId"], "gcc12")
+        self.assertEqual(message_body["isCMake"], False)
+        self.assertEqual(message_body["source"], "test")
+        self.assertEqual(message_body["options"], [])  # Default added since not in request
+        # Check that required defaults are added
+        self.assertEqual(message_body["backendOptions"], {})
+        self.assertEqual(message_body["filters"], {})
+        self.assertEqual(message_body["tools"], [])
+        self.assertEqual(message_body["executeParameters"], {})
+        self.assertEqual(message_body["libraries"], [])
+        self.assertEqual(message_body["files"], [])
+        # Optional fields not added if not in request
+        self.assertNotIn("bypassCache", message_body)
+        self.assertNotIn("lang", message_body)
+        self.assertNotIn("allowStoreCodeDebug", message_body)
+
+    @patch("lambda_function.sqs")
+    @patch("lambda_function.SQS_QUEUE_URL", "https://sqs.us-east-1.amazonaws.com/123456789/test-queue.fifo")
+    def test_send_to_sqs_plain_text(self, mock_sqs):
+        """Test SQS message sending with plain text body."""
+        mock_sqs.send_message.return_value = {"MessageId": "test-message-id"}
+
+        headers = {"Content-Type": "text/plain"}
+        plain_text_source = "int main() { return 0; }"
+        lambda_function.send_to_sqs("test-guid", "gcc12", plain_text_source, False, headers)
+
+        mock_sqs.send_message.assert_called_once()
+        call_args = mock_sqs.send_message.call_args
+
+        # Check message body contains plain text as source
+        message_body = json.loads(call_args[1]["MessageBody"])
+        self.assertEqual(message_body["source"], plain_text_source)
+        self.assertEqual(message_body["options"], [])
+        self.assertEqual(message_body["headers"]["Content-Type"], "text/plain")
+
+    @patch("lambda_function.sqs")
+    @patch("lambda_function.SQS_QUEUE_URL", "https://sqs.us-east-1.amazonaws.com/123456789/test-queue.fifo")
+    def test_send_to_sqs_complete_request(self, mock_sqs):
+        """Test SQS message sending with complete compilation request."""
+        mock_sqs.send_message.return_value = {"MessageId": "test-message-id"}
+
+        complete_request = {
+            "source": "int main() { return 0; }",
+            "options": ["-O2", "-std=c++17"],
+            "backendOptions": {"produceBinaryObject": True},
+            "filters": {"binary": True, "execute": False},
+            "bypassCache": True,
+            "tools": [{"id": "tool1", "args": ["--flag"]}],
+            "executeParameters": {"args": ["arg1"], "stdin": "input"},
+            "libraries": [{"id": "lib1", "version": "1.0"}],
+            "files": [{"name": "file.h", "contents": "#pragma once"}],
+            "lang": "c++",
+            "allowStoreCodeDebug": True,
+            "customField": "should be preserved",
+        }
+
+        headers = {"Content-Type": "application/json"}
+        lambda_function.send_to_sqs("test-guid", "gcc12", json.dumps(complete_request), False, headers)
+
+        mock_sqs.send_message.assert_called_once()
+        call_args = mock_sqs.send_message.call_args
+
+        # Check that all fields from the original request are preserved
+        message_body = json.loads(call_args[1]["MessageBody"])
+        self.assertEqual(message_body["guid"], "test-guid")
+        self.assertEqual(message_body["compilerId"], "gcc12")
+        self.assertEqual(message_body["isCMake"], False)
+
+        # Check that all original request fields are preserved
+        self.assertEqual(message_body["source"], "int main() { return 0; }")
+        self.assertEqual(message_body["options"], ["-O2", "-std=c++17"])
+        self.assertEqual(message_body["backendOptions"], {"produceBinaryObject": True})
+        self.assertEqual(message_body["filters"], {"binary": True, "execute": False})
+        self.assertEqual(message_body["bypassCache"], True)
+        self.assertEqual(message_body["tools"], [{"id": "tool1", "args": ["--flag"]}])
+        self.assertEqual(message_body["executeParameters"], {"args": ["arg1"], "stdin": "input"})
+        self.assertEqual(message_body["libraries"], [{"id": "lib1", "version": "1.0"}])
+        self.assertEqual(message_body["files"], [{"name": "file.h", "contents": "#pragma once"}])
+        self.assertEqual(message_body["lang"], "c++")
+        self.assertEqual(message_body["allowStoreCodeDebug"], True)
+        self.assertEqual(message_body["customField"], "should be preserved")
+
+    @patch("lambda_function.sqs")
+    @patch("lambda_function.SQS_QUEUE_URL", "https://sqs.us-east-1.amazonaws.com/123456789/test-queue.fifo")
+    def test_send_to_sqs_prevents_double_encoding(self, mock_sqs):
+        """Test that SQS message prevents double JSON encoding."""
+        mock_sqs.send_message.return_value = {"MessageId": "test-message-id"}
+
+        request_data = {"source": "test", "options": ["-O2"]}
+        headers = {"Content-Type": "application/json"}
+        lambda_function.send_to_sqs("test-guid", "gcc12", json.dumps(request_data), False, headers)
+
+        mock_sqs.send_message.assert_called_once()
+        call_args = mock_sqs.send_message.call_args
+
+        # The message body should be a valid JSON string, not double-encoded
+        message_body_str = call_args[1]["MessageBody"]
+        self.assertIsInstance(message_body_str, str)
+
+        # Should be able to parse as JSON (not indexed characters)
+        message_body = json.loads(message_body_str)
+        self.assertIsInstance(message_body, dict)
+        self.assertEqual(message_body["source"], "test")
+        self.assertEqual(message_body["options"], ["-O2"])
+
+        # Ensure it's not double-encoded (would cause indexed characters)
+        self.assertNotIn("0", message_body)  # Would exist if double-encoded
+        self.assertNotIn("1", message_body)  # Would exist if double-encoded
+
+    @patch("lambda_function.sqs")
+    @patch("lambda_function.SQS_QUEUE_URL", "")
+    def test_send_to_sqs_no_url(self, mock_sqs):
+        """Test SQS sending when URL is not set."""
+        with self.assertRaises(lambda_function.SQSError):
+            lambda_function.send_to_sqs("test-guid", "gcc12", "{}", False, {})
+
+    @patch("lambda_function.sqs")
+    def test_send_to_sqs_client_error(self, mock_sqs):
+        """Test SQS sending with client error."""
+        from botocore.exceptions import ClientError
+
+        mock_sqs.send_message.side_effect = ClientError(
+            {"Error": {"Code": "InvalidParameterValue", "Message": "Invalid parameter"}}, "SendMessage"
+        )
+
+        with self.assertRaises(lambda_function.SQSError):
+            lambda_function.send_to_sqs("test-guid", "gcc12", "{}", False, {})
+
+    def test_create_error_response(self):
+        """Test error response creation."""
+        response = lambda_function.create_error_response(400, "Bad request")
+
+        self.assertEqual(response["statusCode"], 400)
+        self.assertEqual(response["headers"]["Content-Type"], "application/json")
+        self.assertIn("Access-Control-Allow-Origin", response["headers"])
+
+        body = json.loads(response["body"])
+        self.assertEqual(body["error"], "Bad request")
+
+    def test_create_success_response_json(self):
+        """Test success response creation with JSON format."""
+        result = {"code": 0, "stdout": ["Hello World"]}
+        response = lambda_function.create_success_response(result, "application/json")
+
+        self.assertEqual(response["statusCode"], 200)
+        self.assertEqual(response["headers"]["Content-Type"], "application/json; charset=utf-8")
+
+        body = json.loads(response["body"])
+        self.assertEqual(body, result)
+
+    def test_create_success_response_plain_text(self):
+        """Test success response creation with plain text format."""
+        result = {"code": 0, "asm": [{"text": "main:"}, {"text": "    xor eax, eax"}, {"text": "    ret"}]}
+        response = lambda_function.create_success_response(result, "text/plain")
+
+        self.assertEqual(response["statusCode"], 200)
+        self.assertEqual(response["headers"]["Content-Type"], "text/plain; charset=utf-8")
+        self.assertEqual(response["body"], "main:\n    xor eax, eax\n    ret")
+
+    def test_parse_request_body_json(self):
+        """Test parsing JSON request body."""
+        body = '{"source": "int main() {}", "options": ["-O2"]}'
+        result = lambda_function.parse_request_body(body, "application/json")
+
+        self.assertEqual(result["source"], "int main() {}")
+        self.assertEqual(result["options"], ["-O2"])
+
+    def test_parse_request_body_plain_text(self):
+        """Test parsing plain text request body."""
+        body = "int main() { return 0; }"
+        result = lambda_function.parse_request_body(body, "text/plain")
+
+        self.assertEqual(result, {"source": body})
+
+    @patch("lambda_function.WebSocketClient")
+    @patch("lambda_function.send_to_sqs")
+    @patch("lambda_function.generate_guid")
+    def test_lambda_handler_success(self, mock_generate_guid, mock_send_to_sqs, mock_ws_client_class):
+        """Test successful lambda handler execution."""
+        mock_generate_guid.return_value = "test-guid-123"
+
+        # Mock WebSocket client
+        mock_ws_client = Mock()
+        mock_ws_client.connected = True
+        mock_ws_client.wait_for_result.return_value = {"guid": "test-guid-123", "code": 0, "stdout": ["Success"]}
+        mock_ws_client_class.return_value = mock_ws_client
+
+        event = {
+            "path": "/beta/api/compiler/gcc12/compile",
+            "httpMethod": "POST",
+            "body": '{"source": "int main() { return 0; }"}',
+            "headers": {"Content-Type": "application/json", "Accept": "application/json"},
+        }
+
+        response = lambda_function.lambda_handler(event, None)
+
+        self.assertEqual(response["statusCode"], 200)
+        mock_generate_guid.assert_called_once()
+        mock_send_to_sqs.assert_called_once_with(
+            "test-guid-123",
+            "gcc12",
+            '{"source": "int main() { return 0; }"}',
+            False,
+            {"Content-Type": "application/json", "Accept": "application/json"},
+        )
+        mock_ws_client.wait_for_result.assert_called_once_with(60)
+
+    @patch("lambda_function.wait_for_compilation_result")
+    @patch("lambda_function.send_to_sqs")
+    @patch("lambda_function.generate_guid")
+    def test_lambda_handler_production_path(self, mock_generate_guid, mock_send_to_sqs, mock_wait_for_result):
+        """Test successful lambda handler execution with production path format."""
+        mock_generate_guid.return_value = "test-guid-456"
+        mock_wait_for_result.return_value = {"code": 0, "stdout": ["Success"]}
+
+        event = {
+            "path": "/api/compiler/gcc12/compile",
+            "httpMethod": "POST",
+            "body": '{"source": "int main() { return 0; }"}',
+            "headers": {"Content-Type": "application/json", "Accept": "application/json"},
+        }
+
+        response = lambda_function.lambda_handler(event, None)
+
+        self.assertEqual(response["statusCode"], 200)
+        mock_generate_guid.assert_called_once()
+        mock_send_to_sqs.assert_called_once_with(
+            "test-guid-456",
+            "gcc12",
+            '{"source": "int main() { return 0; }"}',
+            False,
+            {"Content-Type": "application/json", "Accept": "application/json"},
+        )
+        mock_wait_for_result.assert_called_once_with("test-guid-456", 60)
+
+    def test_lambda_handler_invalid_method(self):
+        """Test lambda handler with invalid HTTP method."""
+        event = {"path": "/beta/api/compiler/gcc12/compile", "httpMethod": "GET", "body": ""}
+
+        response = lambda_function.lambda_handler(event, None)
+
+        self.assertEqual(response["statusCode"], 405)
+        body = json.loads(response["body"])
+        self.assertEqual(body["error"], "Method not allowed")
+
+    def test_lambda_handler_invalid_path(self):
+        """Test lambda handler with invalid path."""
+        event = {"path": "/invalid/path", "httpMethod": "POST", "body": "{}"}
+
+        response = lambda_function.lambda_handler(event, None)
+
+        self.assertEqual(response["statusCode"], 400)
+        body = json.loads(response["body"])
+        self.assertEqual(body["error"], "Invalid path: compiler ID not found")
+
+    @patch("lambda_function.wait_for_compilation_result")
+    @patch("lambda_function.send_to_sqs")
+    @patch("lambda_function.generate_guid")
+    def test_lambda_handler_sqs_error(self, mock_generate_guid, mock_send_to_sqs, mock_wait_for_result):
+        """Test lambda handler with SQS error."""
+        mock_generate_guid.return_value = "test-guid-123"
+        mock_send_to_sqs.side_effect = lambda_function.SQSError("Queue not found")
+
+        event = {"path": "/beta/api/compiler/gcc12/compile", "httpMethod": "POST", "body": "{}", "headers": {}}
+
+        response = lambda_function.lambda_handler(event, None)
+
+        self.assertEqual(response["statusCode"], 500)
+        body = json.loads(response["body"])
+        self.assertIn("Failed to queue compilation request", body["error"])
+
+    @patch("lambda_function.WebSocketClient")
+    @patch("lambda_function.send_to_sqs")
+    @patch("lambda_function.generate_guid")
+    def test_lambda_handler_timeout(self, mock_generate_guid, mock_send_to_sqs, mock_ws_client_class):
+        """Test lambda handler with WebSocket timeout."""
+        mock_generate_guid.return_value = "test-guid-123"
+
+        # Mock WebSocket client that times out
+        mock_ws_client = Mock()
+        mock_ws_client.connected = True
+        mock_ws_client.wait_for_result.side_effect = lambda_function.WebSocketTimeoutError(
+            "No response received within 30 seconds"
+        )
+        mock_ws_client_class.return_value = mock_ws_client
+
+        event = {"path": "/beta/api/compiler/gcc12/compile", "httpMethod": "POST", "body": "{}", "headers": {}}
+
+        response = lambda_function.lambda_handler(event, None)
+
+        self.assertEqual(response["statusCode"], 408)
+        body = json.loads(response["body"])
+        self.assertIn("Compilation timeout", body["error"])
+
+    def test_lambda_handler_cmake_request(self):
+        """Test lambda handler recognizes cmake requests."""
+        with (
+            patch("lambda_function.wait_for_compilation_result") as mock_wait,
+            patch("lambda_function.send_to_sqs") as mock_send,
+            patch("lambda_function.generate_guid") as mock_guid,
+        ):
+            mock_guid.return_value = "test-guid-123"
+            mock_wait.return_value = {"code": 0}
+
+            event = {"path": "/beta/api/compiler/gcc12/cmake", "httpMethod": "POST", "body": "{}", "headers": {}}
+
+            lambda_function.lambda_handler(event, None)
+
+            # Verify that isCMake is set to True
+            mock_send.assert_called_once_with("test-guid-123", "gcc12", "{}", True, {})
+
+    @patch("lambda_function.wait_for_compilation_result")
+    @patch("lambda_function.send_to_sqs")
+    @patch("lambda_function.generate_guid")
+    def test_lambda_handler_plain_text_request(self, mock_generate_guid, mock_send_to_sqs, mock_wait_for_result):
+        """Test lambda handler with plain text request and text/plain Accept header."""
+        mock_generate_guid.return_value = "test-guid-123"
+        mock_wait_for_result.return_value = {
+            "code": 0,
+            "asm": [{"text": "main:"}, {"text": "    xor eax, eax"}, {"text": "    ret"}],
+        }
+
+        event = {
+            "path": "/beta/api/compiler/gcc12/compile",
+            "httpMethod": "POST",
+            "body": "int main() { return 0; }",
+            "headers": {"Content-Type": "text/plain", "Accept": "text/plain"},
+        }
+
+        response = lambda_function.lambda_handler(event, None)
+
+        self.assertEqual(response["statusCode"], 200)
+        self.assertEqual(response["headers"]["Content-Type"], "text/plain; charset=utf-8")
+        self.assertEqual(response["body"], "main:\n    xor eax, eax\n    ret")
+
+        # Verify the request was sent with plain text body
+        mock_send_to_sqs.assert_called_once()
+        call_args = mock_send_to_sqs.call_args
+        self.assertEqual(call_args[0][2], "int main() { return 0; }")
+
+
+class TestWebSocketClient(unittest.TestCase):
+    """Test cases for WebSocket client."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.client = lambda_function.WebSocketClient("wss://test.com/ws", "test-guid")
+
+    def test_websocket_client_init(self):
+        """Test WebSocket client initialization."""
+        self.assertEqual(self.client.url, "wss://test.com/ws")
+        self.assertEqual(self.client.guid, "test-guid")
+        self.assertIsNone(self.client.result)
+        self.assertFalse(self.client.connected)
+
+    def test_on_message_correct_guid(self):
+        """Test WebSocket message handling with correct GUID."""
+        mock_ws = Mock()
+        message_data = {"guid": "test-guid", "code": 0, "stdout": ["Success"], "stderr": []}
+        message = json.dumps(message_data)
+
+        self.client.on_message(mock_ws, message)
+
+        self.assertEqual(self.client.result, message_data)
+        mock_ws.close.assert_called_once()
+
+    def test_on_message_wrong_guid(self):
+        """Test WebSocket message handling with wrong GUID."""
+        mock_ws = Mock()
+        message = json.dumps({"guid": "different-guid", "result": {"code": 0, "stdout": ["Success"]}})
+
+        self.client.on_message(mock_ws, message)
+
+        self.assertIsNone(self.client.result)
+        mock_ws.close.assert_not_called()
+
+    def test_on_message_invalid_json(self):
+        """Test WebSocket message handling with invalid JSON."""
+        mock_ws = Mock()
+
+        # Should not raise exception
+        self.client.on_message(mock_ws, "invalid json")
+
+        self.assertIsNone(self.client.result)
+        mock_ws.close.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/compilation-lambda/uv.lock
+++ b/compilation-lambda/uv.lock
@@ -1,0 +1,175 @@
+version = 1
+revision = 2
+requires-python = ">=3.12"
+
+[[package]]
+name = "boto3"
+version = "1.38.43"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/96/c99c9dac902faae3896558809d130b1bf02df8abb6e4553ad87d018910f9/boto3-1.38.43.tar.gz", hash = "sha256:9b0ff0b34c9cf7328546c532c20b081f09055ff485f4d57c19146c36877048c5", size = 111845, upload-time = "2025-06-24T19:29:02.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/67/42355b452a5aa622205c321217cba61a85746f0d93984788116a43120821/boto3-1.38.43-py3-none-any.whl", hash = "sha256:2e3411bb43285caad1c8e1a3186d025ba65a6342e26bad493f6b8feb3d1a1680", size = 139922, upload-time = "2025-06-24T19:29:01.545Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.38.43"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/ff/8ace3f46fa1a32c09ee994b5401c7853613a283e134449fdc136bb753b40/botocore-1.38.43.tar.gz", hash = "sha256:c453c5c16c157c5427058bb3cc2c5ad35ee2e43336f0ccbfcc6092c5635505c6", size = 14044468, upload-time = "2025-06-24T19:28:52.803Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/12/0ebcfb91738d0cf9560220ee4e0db351acab14026fac74bbce9ab3881fd9/botocore-1.38.43-py3-none-any.whl", hash = "sha256:2ee60ac0b08e80e9be2aa2841d42e438d5bc4f82549560a682837655097a3db7", size = 13706448, upload-time = "2025-06-24T19:28:47.877Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "compilation-lambda"
+version = "0.0.1"
+source = { virtual = "." }
+dependencies = [
+    { name = "boto3" },
+    { name = "websocket-client" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "boto3", specifier = ">=1.26.0" },
+    { name = "websocket-client", specifier = ">=1.6.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.4.1" }]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/5d/9dcc100abc6711e8247af5aa561fc07c4a046f72f659c3adea9a449e191a/s3transfer-0.13.0.tar.gz", hash = "sha256:f5e6db74eb7776a37208001113ea7aa97695368242b364d73e91c981ac522177", size = 150232, upload-time = "2025-05-22T19:24:50.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/17/22bf8155aa0ea2305eefa3a6402e040df7ebe512d1310165eda1e233c3f8/s3transfer-0.13.0-py3-none-any.whl", hash = "sha256:0148ef34d6dd964d0d8cf4311b2b21c474693e57c2e069ec708ce043d2b527be", size = 85152, upload-time = "2025-05-22T19:24:48.703Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/30/fba0d96b4b5fbf5948ed3f4681f7da2f9f64512e1d303f94b4cc174c24a5/websocket_client-1.8.0.tar.gz", hash = "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da", size = 54648, upload-time = "2024-04-23T22:16:16.976Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl", hash = "sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526", size = 58826, upload-time = "2024-04-23T22:16:14.422Z" },
+]

--- a/docs/lambda_compilation_workflow.md
+++ b/docs/lambda_compilation_workflow.md
@@ -1,0 +1,660 @@
+# Lambda-Based Compilation Workflow and Architecture
+
+## Overview
+
+Compiler Explorer has implemented a **Lambda-based compilation endpoint system** that intercepts compilation requests and routes them through an asynchronous queue-based workflow. This new architecture replaces direct ALB-to-instance routing for compilation endpoints, enabling better scalability, reliability, and workload distribution.
+
+Unlike the traditional model where compilation requests hit instances directly, the Lambda system creates a **buffer layer** that queues compilation requests and waits for results via WebSocket connections, providing more resilient request handling.
+
+This document describes the complete workflow, architecture, and operational model for Lambda-based compilation in Compiler Explorer.
+
+## Simplified Use-Case Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant ALB as Application Load Balancer
+    participant Lambda as Compilation Lambda
+    participant SQS as SQS FIFO Queue<br/>compilation-queue
+    participant WS as WebSocket API<br/>Events System
+    participant Instance as Compiler Instance<br/>(Backend Worker)
+
+    User->>ALB: 1. POST /api/compiler/gcc/compile
+    ALB->>Lambda: 2. Route to compilation endpoint
+    Lambda->>Lambda: 3. Parse request & generate GUID
+    Lambda->>WS: 4. Subscribe to GUID for results
+    Lambda->>SQS: 5. Queue compilation request<br/>{guid, compilerid, source, options}
+
+    Instance->>SQS: 6. Poll for compilation work
+    SQS->>Instance: 7. Return compilation message
+    Instance->>Instance: 8. Execute compilation
+    Instance->>WS: 9. Send results with GUID
+    WS->>Lambda: 10. Route results to subscriber
+    Lambda->>ALB: 11. Return compilation response
+    ALB->>User: 12. Display compilation output
+```
+
+### Key Interactions Explained
+
+1. **User → ALB**: User submits code for compilation via standard REST API
+2. **ALB → Lambda**: Load balancer routes compilation requests to Lambda function
+3. **Lambda → WebSocket**: Subscribes to unique GUID to receive compilation results (BEFORE sending to SQS)
+4. **Lambda → SQS**: Queues compilation request with GUID and all necessary context
+5. **Instance → SQS**: Backend instances poll queue for compilation work
+6. **Instance → Local**: Executes compilation using existing compiler infrastructure
+7. **Instance → WebSocket**: Sends compilation results with GUID
+8. **WebSocket → Lambda**: Routes results back to waiting Lambda function
+9. **Lambda → User**: Returns compilation output in expected format
+
+## Architecture Comparison
+
+### Traditional Direct-Route Model
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                     Traditional Direct Routing                          │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  [User Request] → [ALB] → [Instance] → [Compilation] → [Results]        │
+│                     │         │             │                           │
+│                     ↓         ↓             ↓                           │
+│                [Direct]   [Immediate]   [Synchronous]                   │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### Lambda-Based Queue Model
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                      Lambda-Based Queue Architecture                    │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│ ┌─────────────────────┐                    ┌─────────────────────┐      │
+│ │   Lambda Layer      │                    │ Compiler Instances  │      │
+│ │  (Request Buffer)   │                    │   (Workers)         │      │
+│ ├─────────────────────┤                    ├─────────────────────┤      │
+│ │ • Request Parsing   │                    │ • Traditional Setup │      │
+│ │ • GUID Generation   │                    │ • Queue Polling     │      │
+│ │ • Response Waiting  │◄────WebSocket─────►│ • Result Publishing │      │
+│ │ • Content Negotiation│                   │ • Compilation Logic │      │
+│ └─────────────────────┘                    └─────────────────────┘      │
+│           │                                           ▲                 │
+│           ▼                                           │                 │
+│ ┌─────────────────────────────────────────────────────────────────────┐ │
+│ │                      SQS FIFO Queue                                 │ │
+│ │                  compilation-queue-{env}                            │ │
+│ └─────────────────────────────────────────────────────────────────────┘ │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## Detailed Component Interactions
+
+```mermaid
+graph LR
+    subgraph lambda [Lambda Layer]
+        LF[Compilation Lambda]
+    end
+
+    subgraph instances [Compiler Instances]
+        CI[Queue Consumer]
+    end
+
+    subgraph infra [Infrastructure]
+        S3[S3 Packages]
+        SQS[SQS Queue]
+        WS[WebSocket API]
+        ALB[Load Balancer]
+        DDB[DynamoDB]
+        LMB[Lambda Functions]
+    end
+
+    ALB -->|1 Route request| LF
+    LF -->|2 Subscribe GUID| WS
+    LF -->|3 Queue compilation| SQS
+
+    CI -->|4 Poll work| SQS
+    CI -->|5 Execute compilation| CI
+    CI -->|6 Send results| WS
+
+    WS -->|7 Route to subscriber| LF
+    LF -->|8 Return response| ALB
+
+    WS <--> DDB
+    WS <--> LMB
+
+    classDef lambda fill:#fff3e0,stroke:#ff8f00,color:#000
+    classDef instance fill:#e1f5fe,stroke:#0277bd,color:#000
+    classDef service fill:#c8e6c9,stroke:#388e3c,color:#000
+
+    class LF lambda
+    class CI instance
+    class S3,SQS,WS,DDB,LMB,ALB service
+```
+
+## Configuration Details
+
+### Lambda Function Environment Variables
+
+```properties
+# Beta Environment Lambda (Currently Active)
+SQS_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/account/beta-compilation-queue.fifo
+WEBSOCKET_URL=wss://events.godbolt.org/beta
+RETRY_COUNT=2
+TIMEOUT_SECONDS=90
+```
+
+### ALB Listener Rules
+
+```terraform
+# Active for Beta Environment Only
+resource "aws_alb_listener_rule" "compilation_beta" {
+  priority = 10
+
+  condition {
+    path_pattern {
+      values = [
+        "/beta/api/compiler/*/compile",
+        "/beta/api/compiler/*/cmake"
+      ]
+    }
+  }
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_alb_target_group.compilation_lambda_beta.arn
+  }
+}
+
+# Note: Staging and Production environments are currently disabled in Terraform
+# configuration for focused beta testing and validation.
+```
+
+### Instance Queue Consumer Configuration
+
+```properties
+# Instances poll same compilation queues
+compilation.queue_url=https://sqs.us-east-1.amazonaws.com/account/beta-compilation-queue.fifo
+compilation.consumer_enabled=true
+compilation.polling_interval=100ms
+compilation.concurrent_workers=2
+```
+
+## Complete Compilation Workflow
+
+### 1. User Submits Compilation Request
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                        Step 1: User Request                             │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  User compiles C++ code via standard API:                               │
+│  • POST /beta/api/compiler/gcc/compile                                  │
+│  • Content-Type: application/json or text/plain                         │
+│  • Accept: application/json or text/plain                               │
+│  • Body: {"source": "int main(){}", "options": {...}}                   │
+│                                                                         │
+│  Request routed by: ALB listener rule (priority 10)                     │
+│  Target: Lambda function (compilation-beta)                             │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 2. Lambda Request Processing
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    Step 2: Lambda Request Handling                      │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  Lambda function execution:                                             │
+│  1. Parse ALB event to extract request details                          │
+│  2. Extract compiler ID from path: /api/compiler/{gcc}/compile          │
+│  3. Parse request body (JSON or plain text)                             │
+│  4. Store Accept header for response formatting                         │
+│  5. Generate unique GUID for request tracking                           │
+│                                                                         │
+│  Request parsing logic:                                                 │
+│  • JSON requests: Parse full options object                             │
+│  • Plain text: Wrap as {"source": body}                                 │
+│  • Headers preserved for downstream processing                          │
+│                                                                         │
+│  Key decision points:                                                   │
+│  • Content-Type determines parsing strategy                             │
+│  • Accept header determines response format                             │
+│  • Path pattern extracts compiler identifier                            │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 3. WebSocket Subscription Setup
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                  Step 3: WebSocket Result Subscription                  │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  Lambda establishes WebSocket connection:                               │
+│                                                                         │
+│  1. Connect to: wss://events.godbolt.org/beta                           │
+│  2. Send subscription message:                                          │
+│     subscribe: abc123def-456-789...                                     │
+│  3. Configure timeout: 90 seconds (configurable)                        │
+│  4. Setup retry logic: 2 attempts (configurable)                        │
+│                                                                         │
+│  WebSocket connection management:                                       │
+│  • Automatic reconnection on connection failure                         │
+│  • Timeout handling for unresponsive connections                        │
+│  • Error logging for debugging purposes                                 │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 4. SQS Message Submission
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                     Step 4: SQS Queue Submission                        │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  Compilation request queued:                                            │
+│                                                                         │
+│  Queue: beta-compilation-queue.fifo                                     │
+│  Message structure:                                                     │
+│  {                                                                      │
+│    "guid": "abc123def-456-789...",                                      │
+│    "compilerId": "gcc",                                                 │
+│    "isCMake": false,                                                    │
+│    "headers": {                                                         │
+│      "Accept": "application/json",                                      │
+│      "Content-Type": "application/json"                                 │
+│    },                                                                   │
+│    "source": "int main() { return 0; }",                               │
+│    "options": ["-O2"],                                                  │
+│    "filters": {},                                                       │
+│    "backendOptions": {},                                                │
+│    "tools": [],                                                         │
+│    "libraries": [],                                                     │
+│    "files": [],                                                         │
+│    "executeParameters": {}                                              │
+│  }                                                                      │
+│                                                                         │
+│  FIFO properties:                                                       │
+│  • MessageGroupId: "default"                                            │
+│  • MessageDeduplicationId: hash(message content)                        │
+│  • VisibilityTimeout: 2 minutes                                         │
+│  • MessageRetention: 30 minutes                                         │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 5. Instance Message Processing
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                   Step 5: Instance Queue Processing                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  Compiler instance receives message:                                    │
+│                                                                         │
+│  1. Queue consumer polls SQS every 100ms                                │
+│  2. Receives compilation message from queue                             │
+│  3. Extract: guid, compilerId, source, options, headers                │
+│  4. Delete message from queue (prevents reprocessing)                   │
+│                                                                         │
+│  Compilation execution:                                                 │
+│  1. Load compiler configuration for compiler_id                         │
+│  2. Setup compilation environment                                       │
+│  3. Execute compilation with provided source/options                    │
+│  4. Capture output: stdout, stderr, exit code                           │
+│  5. Apply any filters or transformations                                │
+│                                                                         │
+│  Standard Compiler Explorer flow:                                       │
+│  • Uses existing compiler infrastructure                                │
+│  • Same filtering and output processing                                 │
+│  • No changes to compilation logic                                      │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 6. Result Publication via WebSocket
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    Step 6: Result Publication                           │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  Instance publishes compilation results:                                │
+│                                                                         │
+│  1. Connect to WebSocket: wss://events.godbolt.org/beta                 │
+│  2. Send result message:                                                │
+│                                                                         │
+│     {                                                                   │
+│       "guid": "abc123def-456-789...",                                   │
+│       "code": 0,                                                        │
+│       "stdout": [{"text": "#include <iostream>..."}],                   │
+│       "stderr": [],                                                     │
+│       "asm": [                                                          │
+│         {"text": "main:", "line": 1},                                   │
+│         {"text": "  push rbp", "line": 2},                              │
+│         {"text": "  mov rbp, rsp", "line": 3}                           │
+│       ],                                                                │
+│       "compileTime": 1250,                                              │
+│       "compilationOptions": ["-O2"],                                    │
+│       "tools": [],                                                      │
+│       "okToCache": true                                                 │
+│     }                                                                   │
+│                                                                         │
+│  WebSocket infrastructure:                                              │
+│  • AWS API Gateway + Lambda routing                                     │
+│  • DynamoDB subscription tracking                                       │
+│  • Automatic message delivery to subscribers                            │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 7. Lambda Response Processing
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    Step 7: Lambda Response Handling                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  Lambda receives and processes results:                                 │
+│                                                                         │
+│  1. WebSocket client receives message with matching GUID                │
+│  2. Parse compilation result JSON                                       │
+│  3. Apply content negotiation based on Accept header:                   │
+│                                                                         │
+│     Accept: application/json (default):                                 │
+│     • Return full compilation result object                             │
+│     • Include asm, stdout, stderr, metadata                             │
+│     • Content-Type: application/json                                    │
+│                                                                         │
+│     Accept: text/plain:                                                 │
+│     • Extract assembly text from asm array                              │
+│     • Return plain text assembly only                                   │
+│     • Content-Type: text/plain                                          │
+│                                                                         │
+│  4. Close WebSocket connection                                          │
+│  5. Return HTTP response to ALB                                         │
+│                                                                         │
+│  Error handling:                                                        │
+│  • Timeout: Return 408 Request Timeout                                  │
+│  • WebSocket failure: Return 503 Service Unavailable                    │
+│  • Compilation errors: Return 200 with error details                    │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 8. User Response and Display
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                       Step 8: User Response                             │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  ALB returns response to user:                                          │
+│                                                                         │
+│  HTTP 200 OK                                                            │
+│  Content-Type: application/json                                         │
+│  Content-Length: 1234                                                   │
+│                                                                         │
+│  {                                                                      │
+│    "code": 0,                                                           │
+│    "stdout": [],                                                        │
+│    "stderr": [],                                                        │
+│    "asm": [                                                             │
+│      {"text": "main:", "line": 1},                                      │
+│      {"text": "  push rbp", "line": 2},                                 │
+│      {"text": "  mov rbp, rsp", "line": 3},                             │
+│      {"text": "  xor eax, eax", "line": 4},                             │
+│      {"text": "  pop rbp", "line": 5},                                  │
+│      {"text": "  ret", "line": 6}                                       │
+│    ],                                                                   │
+│    "compileTime": 1250,                                                 │
+│    "okToCache": true                                                    │
+│  }                                                                      │
+│                                                                         │
+│  User experience:                                                       │
+│  • Same API response format as traditional model                        │
+│  • Transparent queue-based processing                                   │
+│  • Enhanced reliability through async architecture                      │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## Component Deep Dive
+
+### Lambda Function Architecture
+
+**Request Processing Pipeline:**
+
+The Lambda function implements a sophisticated request handling pipeline:
+
+1. **ALB Event Parsing**: Extracts HTTP method, path, headers, and body from ALB event
+2. **Compiler ID Extraction**: Uses regex to extract compiler identifier from URL path
+3. **Content Negotiation**: Supports both JSON and plain text request/response formats
+4. **WebSocket Management**: Establishes subscription before queuing request
+5. **Response Formatting**: Applies Accept header-based content negotiation
+
+**Environment-Specific Configuration:**
+
+| Environment | Lambda Function | SQS Queue | WebSocket URL | Status |
+|-------------|-----------------|-----------|---------------|--------|
+| **Beta** | `compilation-beta` | `beta-compilation-queue.fifo` | `wss://events.godbolt.org/beta` | **Active** |
+| **Staging** | `compilation-staging` | `staging-compilation-queue.fifo` | `wss://events.godbolt.org/staging` | *Provisioned (Inactive)* |
+| **Production** | `compilation-prod` | `prod-compilation-queue.fifo` | `wss://events.godbolt.org/` | *Provisioned (Inactive)* |
+
+### SQS Queue Architecture
+
+**Queue Characteristics:**
+
+- **FIFO Ordering**: Ensures compilation requests are processed in submission order
+- **Exactly-Once Delivery**: Prevents duplicate compilation attempts
+- **Message Deduplication**: Based on content hash to avoid duplicate work
+- **Visibility Timeout**: 2 minutes for message processing
+- **Message Retention**: 30 minutes for unprocessed messages
+
+**Message Structure Standardization:**
+
+All compilation messages follow a consistent schema:
+
+```json
+{
+  "guid": "unique-request-identifier",
+  "compilerId": "extracted-from-url-path",
+  "isCMake": false,
+  "headers": "preserved-request-headers",
+  "source": "int main() { return 0; }",
+  "options": ["-O2"],
+  "filters": {},
+  "backendOptions": {},
+  "tools": [],
+  "libraries": [],
+  "files": [],
+  "executeParameters": {}
+}
+```
+
+### WebSocket Communication
+
+**Bidirectional Communication Model:**
+
+1. **Lambda → WebSocket**: Subscribes to GUID, waits for results
+2. **Instance → WebSocket**: Publishes compilation results with GUID
+3. **WebSocket → Lambda**: Routes results to appropriate subscribers
+
+**Connection Management:**
+
+- **Automatic Retry**: Configurable retry count for failed connections
+- **Timeout Handling**: 90-second timeout for compilation results
+- **Connection Cleanup**: Automatic disconnection after result delivery
+
+### Content Negotiation System
+
+**Request Format Handling:**
+
+| Content-Type | Processing Strategy |
+|--------------|-------------------|
+| `application/json` | Parse as JSON object |
+| `text/plain` | Wrap as `{"source": body}` |
+| *Missing/Other* | Treat as plain text |
+
+**Response Format Selection:**
+
+| Accept Header | Response Format |
+|---------------|-----------------|
+| `application/json` | Full compilation result object |
+| `text/plain` | Assembly text only |
+| *Missing/Other* | Default to JSON |
+
+## Operational Characteristics
+
+### Performance Benefits
+
+**Improved Scalability:**
+
+- **Request Buffering**: Lambda handles traffic spikes through queue buffering
+- **Worker Isolation**: Compilation instances focus solely on compilation work
+- **Horizontal Scaling**: Independent scaling of request handling and compilation
+- **Load Distribution**: Even workload distribution across available instances
+
+**Enhanced Reliability:**
+
+- **Fault Tolerance**: Queue persistence survives instance failures
+- **Retry Capability**: Built-in retry logic for transient failures
+- **Graceful Degradation**: Timeout handling prevents indefinite hangs
+- **Isolation Benefits**: Request processing isolated from compilation environment
+
+### Deployment Strategy
+
+**Environment Rollout:**
+
+1. **Beta Environment**: Active deployment for testing and validation (ALB listener rules enabled)
+2. **Staging Environment**: Infrastructure commented out in Terraform, pending beta validation
+3. **Production Environment**: Infrastructure commented out in Terraform, pending beta validation
+
+**Gradual Migration Approach:**
+
+- **ALB Listener Rules**: Easily toggled for traffic routing
+- **Blue-Green Compatible**: Works with existing blue-green deployment model
+- **Rollback Capability**: Simple rule disabling reverts to direct routing
+
+### Monitoring and Observability
+
+**CloudWatch Metrics:**
+
+- **Lambda Metrics**: Invocation count, duration, error rate, timeout rate
+- **SQS Metrics**: Message count, age of oldest message, receive count
+- **WebSocket Metrics**: Connection count, message delivery success rate
+
+**Log Aggregation:**
+
+- **Lambda Logs**: Error details, warnings, and critical issues only (WARNING level for performance)
+- **Instance Logs**: Queue polling, compilation execution, result publishing
+- **WebSocket Logs**: Connection lifecycle, message routing, subscription management
+
+**Performance Logging:**
+
+The Lambda function uses WARNING level logging by default to optimize performance:
+- Only errors, warnings, and critical issues are logged to CloudWatch
+- Verbose request/response details are excluded for faster execution
+- Timeout and error conditions are still fully logged for debugging
+
+## Error Handling and Edge Cases
+
+### Failure Scenarios
+
+**Lambda Function Failures:**
+
+1. **Timeout During Compilation**: Return 408 Request Timeout with descriptive message
+2. **WebSocket Connection Failure**: Retry with exponential backoff, eventual 503 error
+3. **SQS Queue Failure**: Return 503 Service Unavailable with retry guidance
+4. **Memory/Resource Limits**: Scale function resources, implement request throttling
+
+**Queue Processing Failures:**
+
+1. **Message Parsing Errors**: Log error, delete message, send error result via WebSocket
+2. **Compiler Not Found**: Return compilation error with appropriate message
+3. **Compilation Timeout**: Kill process, return timeout error via WebSocket
+4. **WebSocket Publishing Failure**: Log error, continue processing (fire-and-forget)
+
+**Network and Infrastructure Failures:**
+
+1. **WebSocket Infrastructure Outage**: Lambda timeouts, return 503 to users
+2. **SQS Service Degradation**: Request queuing delays, eventual timeout
+3. **Instance Connectivity Issues**: Message visibility timeout, automatic retry
+4. **Cross-AZ Communication Latency**: Increased end-to-end response times
+
+### Recovery Mechanisms
+
+**Automatic Recovery:**
+
+- **Queue Message Redelivery**: Unprocessed messages automatically redelivered
+- **Lambda Auto-Retry**: Built-in retry for transient Lambda failures
+- **WebSocket Reconnection**: Automatic reconnection on connection drops
+- **Instance Auto-Scaling**: Failed instances replaced automatically
+
+**Operational Recovery:**
+
+- **Manual Queue Purging**: Clear stuck messages during maintenance
+- **Lambda Function Restart**: Redeploy function for persistent issues
+- **Traffic Routing**: Disable Lambda rules, revert to direct routing
+- **Queue Drain Mode**: Process existing messages without accepting new ones
+
+## Integration with Existing Systems
+
+### Blue-Green Deployment Compatibility
+
+**Queue Sharing Model:**
+
+Both blue and green environments share the same compilation queues:
+- **Beta**: `beta-compilation-queue.fifo`
+- **Staging**: `staging-compilation-queue.fifo`
+- **Production**: `prod-compilation-queue.fifo`
+
+**Deployment Scenarios:**
+
+1. **Pre-Deployment**: Blue instances handle all compilation work
+2. **During Deployment**: Both blue and green instances process same queue
+3. **Post-Deployment**: Green instances handle new requests, blue remains standby
+4. **Rollback**: Traffic routing reverted, blue instances resume primary role
+
+### Compiler Infrastructure Integration
+
+**Seamless Backend Integration:**
+
+- **No Compiler Changes**: Existing compiler configurations unchanged
+- **Same Output Formats**: Identical compilation result structures
+- **Filter Compatibility**: All existing filters and transformations preserved
+- **Tool Integration**: Compiler tools (objdump, readelf, etc.) work unchanged
+
+**Queue Consumer Implementation:**
+
+Backend instances implement queue consumers alongside existing HTTP handlers:
+- **Parallel Processing**: HTTP and queue requests processed simultaneously
+- **Shared Resources**: Same compiler pool serves both request types
+- **Configuration Reuse**: Existing compiler configurations apply to queue work
+- **Logging Integration**: Queue processing logged alongside HTTP requests
+
+## Future Enhancements
+
+### Potential Improvements
+
+1. **Priority Queues**: Different priority levels for premium users or urgent requests
+2. **Batch Processing**: Group multiple small compilations for efficiency
+3. **Result Caching**: Cache compilation results in DynamoDB for duplicate requests
+4. **Metrics Collection**: Enhanced telemetry for performance optimization
+5. **Geographic Distribution**: Regional queues for reduced latency
+
+### Scaling Optimizations
+
+1. **Dynamic Timeout Adjustment**: Adaptive timeouts based on queue depth
+2. **Predictive Scaling**: Scale instances based on queue growth trends
+3. **Cost Optimization**: Spot instance integration for cost-effective compilation
+4. **Resource Right-Sizing**: Optimize Lambda memory and timeout based on usage patterns
+
+This Lambda-based compilation architecture provides a more robust, scalable, and maintainable approach to handling compilation requests while maintaining full compatibility with existing Compiler Explorer functionality and user experience.

--- a/start-support.sh
+++ b/start-support.sh
@@ -34,11 +34,8 @@ mount_opt() {
     mountpoint /opt/.health || mount --bind /efs/.health /opt/.health
 
     if [[ "${SKIP_SQUASH}" == "0" ]]; then
-        # don't be tempted to background this, it just causes everything to wedge
-        # during startup (startup time I/O etc goes through the roof).
-        ./mount-all-img.sh
-
-        echo "Done mounting squash images"
+        # backgrounded but mounts in most recent order, serially
+        ./mount-all-img.sh &
     fi
 }
 

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -55,7 +55,7 @@ resource "aws_alb_listener_rule" "compiler-explorer-alb-listen-https-beta" {
     ignore_changes = [action]
   }
 
-  priority = 1
+  priority = 101
   action {
     type = "forward"
     # This target group ARN is managed by blue-green deployment process
@@ -78,7 +78,7 @@ resource "aws_alb_listener_rule" "compiler-explorer-alb-listen-https-staging" {
     ignore_changes = [action]
   }
 
-  priority = 2
+  priority = 111
   action {
     type = "forward"
     # This target group ARN is managed by blue-green deployment process
@@ -101,7 +101,7 @@ resource "aws_alb_listener_rule" "compiler-explorer-alb-listen-https-gpu" {
     ignore_changes = [action]
   }
 
-  priority = 3
+  priority = 121
   action {
     type = "forward"
     # This target group ARN is managed by blue-green deployment process
@@ -124,7 +124,7 @@ resource "aws_alb_listener_rule" "compiler-explorer-alb-listen-https-wintest" {
     ignore_changes = [action]
   }
 
-  priority = 6
+  priority = 151
   action {
     type = "forward"
     # This target group ARN is managed by blue-green deployment process
@@ -147,7 +147,7 @@ resource "aws_alb_listener_rule" "compiler-explorer-alb-listen-https-winstaging"
     ignore_changes = [action]
   }
 
-  priority = 7
+  priority = 161
   action {
     type = "forward"
     # This target group ARN is managed by blue-green deployment process
@@ -170,7 +170,7 @@ resource "aws_alb_listener_rule" "compiler-explorer-alb-listen-https-winprod" {
     ignore_changes = [action]
   }
 
-  priority = 8
+  priority = 171
   action {
     type = "forward"
     # This target group ARN is managed by blue-green deployment process
@@ -193,7 +193,7 @@ resource "aws_alb_listener_rule" "compiler-explorer-alb-listen-https-aarch64prod
     ignore_changes = [action]
   }
 
-  priority = 9
+  priority = 181
   action {
     type = "forward"
     # This target group ARN is managed by blue-green deployment process
@@ -216,7 +216,7 @@ resource "aws_alb_listener_rule" "compiler-explorer-alb-listen-https-aarch64stag
     ignore_changes = [action]
   }
 
-  priority = 10
+  priority = 191
   action {
     type = "forward"
     # This target group ARN is managed by blue-green deployment process
@@ -268,7 +268,7 @@ resource "aws_alb_target_group_attachment" "lambda-stats-endpoint" {
 }
 
 resource "aws_alb_listener_rule" "compiler-explorer-alb-listen-https-lambda" {
-  priority = 4
+  priority = 131
   action {
     type             = "forward"
     target_group_arn = aws_alb_target_group.lambda.arn
@@ -282,7 +282,7 @@ resource "aws_alb_listener_rule" "compiler-explorer-alb-listen-https-lambda" {
 }
 
 resource "aws_alb_listener_rule" "compiler-explorer-alb-listen-https-stats" {
-  priority = 5
+  priority = 141
   action {
     type = "redirect"
     redirect {
@@ -302,7 +302,7 @@ resource "aws_alb_listener_rule" "compiler-explorer-alb-listen-https-stats" {
 
 # Status API ALB listener rule
 resource "aws_alb_listener_rule" "compiler-explorer-alb-listen-https-status" {
-  priority = 11
+  priority = 201
   action {
     type             = "forward"
     target_group_arn = aws_alb_target_group.lambda_status.arn

--- a/terraform/beta-blue-green.tf
+++ b/terraform/beta-blue-green.tf
@@ -14,4 +14,152 @@ module "beta_blue_green" {
   default_cooldown          = local.cooldown
   enabled_metrics           = local.common_enabled_metrics
   initial_active_color      = "blue"
+
+  # Disable default auto-scaling policy - we'll use custom SQS-based scaling
+  enable_autoscaling_policy = false
+}
+
+# Custom auto-scaling policies for Beta environment based on compilation queue depth
+# Scales based on messages in the beta-compilation-queue.fifo, target: 3 compilations per instance
+
+resource "aws_autoscaling_policy" "beta_blue_compilation_scaling" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  autoscaling_group_name    = module.beta_blue_green.blue_asg_name
+  name                      = "beta-compilation-queue-tracker-blue"
+  policy_type               = "TargetTrackingScaling"
+  estimated_instance_warmup = local.cooldown
+
+  target_tracking_configuration {
+    target_value = 3
+    customized_metric_specification {
+      metrics {
+        label = "Get the queue size (the number of compilation messages waiting to be processed)"
+        id    = "m1"
+        metric_stat {
+          metric {
+            namespace   = "AWS/SQS"
+            metric_name = "ApproximateNumberOfMessagesVisible"
+            dimensions {
+              name  = "QueueName"
+              value = module.compilation_lambda_beta.sqs_queue_name
+            }
+          }
+          stat = "Sum"
+        }
+        return_data = false
+      }
+      metrics {
+        label = "Get the group size (the number of InService instances)"
+        id    = "m2"
+        metric_stat {
+          metric {
+            namespace   = "AWS/AutoScaling"
+            metric_name = "GroupInServiceInstances"
+            dimensions {
+              name  = "AutoScalingGroupName"
+              value = module.beta_blue_green.blue_asg_name
+            }
+          }
+          stat = "Average"
+        }
+        return_data = false
+      }
+      metrics {
+        label = "Get blue target group connection count (to check if this ASG is active)"
+        id    = "m3"
+        metric_stat {
+          metric {
+            namespace   = "AWS/ApplicationELB"
+            metric_name = "ActiveConnectionCount"
+            dimensions {
+              name  = "TargetGroup"
+              value = module.beta_blue_green.blue_target_group_arn
+            }
+          }
+          stat = "Average"
+        }
+        return_data = false
+      }
+      metrics {
+        label       = "Calculate backlog per instance, but only scale if this ASG is receiving traffic"
+        id          = "e1"
+        expression  = "IF(m3 > 0 OR m2 > 0, IF(m2 > 0, (m1 + 1) / m2, m1 + 1), 0)"
+        return_data = true
+      }
+    }
+  }
+}
+
+resource "aws_autoscaling_policy" "beta_green_compilation_scaling" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  autoscaling_group_name    = module.beta_blue_green.green_asg_name
+  name                      = "beta-compilation-queue-tracker-green"
+  policy_type               = "TargetTrackingScaling"
+  estimated_instance_warmup = local.cooldown
+
+  target_tracking_configuration {
+    target_value = 3
+    customized_metric_specification {
+      metrics {
+        label = "Get the queue size (the number of compilation messages waiting to be processed)"
+        id    = "m1"
+        metric_stat {
+          metric {
+            namespace   = "AWS/SQS"
+            metric_name = "ApproximateNumberOfMessagesVisible"
+            dimensions {
+              name  = "QueueName"
+              value = module.compilation_lambda_beta.sqs_queue_name
+            }
+          }
+          stat = "Sum"
+        }
+        return_data = false
+      }
+      metrics {
+        label = "Get the group size (the number of InService instances)"
+        id    = "m2"
+        metric_stat {
+          metric {
+            namespace   = "AWS/AutoScaling"
+            metric_name = "GroupInServiceInstances"
+            dimensions {
+              name  = "AutoScalingGroupName"
+              value = module.beta_blue_green.green_asg_name
+            }
+          }
+          stat = "Average"
+        }
+        return_data = false
+      }
+      metrics {
+        label = "Get green target group connection count (to check if this ASG is active)"
+        id    = "m3"
+        metric_stat {
+          metric {
+            namespace   = "AWS/ApplicationELB"
+            metric_name = "ActiveConnectionCount"
+            dimensions {
+              name  = "TargetGroup"
+              value = module.beta_blue_green.green_target_group_arn
+            }
+          }
+          stat = "Average"
+        }
+        return_data = false
+      }
+      metrics {
+        label       = "Calculate backlog per instance, but only scale if this ASG is receiving traffic"
+        id          = "e1"
+        expression  = "IF(m3 > 0 OR m2 > 0, IF(m2 > 0, (m1 + 1) / m2, m1 + 1), 0)"
+        return_data = true
+      }
+    }
+  }
 }

--- a/terraform/compilation-lambda-environments.tf
+++ b/terraform/compilation-lambda-environments.tf
@@ -1,0 +1,138 @@
+# Compilation Lambda Infrastructure for All Environments
+# Uses the compilation_lambda module to create consistent infrastructure
+
+# Beta Environment
+module "compilation_lambda_beta" {
+  source = "./modules/compilation_lambda"
+
+  environment         = "beta"
+  websocket_url       = "wss://events.compiler-explorer.com/beta"
+  alb_listener_arn    = aws_alb_listener.compiler-explorer-alb-listen-https.arn
+  enable_alb_listener = true
+  alb_priority        = 91
+  alb_path_patterns = [
+    "/beta/api/compiler/*/compile",
+    "/beta/api/compiler/*/cmake"
+  ]
+  s3_bucket    = aws_s3_bucket.compiler-explorer.bucket
+  iam_role_arn = aws_iam_role.iam_for_lambda.arn
+
+  tags = {
+    Project = "compiler-explorer"
+  }
+}
+
+# Staging Environment - Commented out for beta testing
+# module "compilation_lambda_staging" {
+#   source = "./modules/compilation_lambda"
+#
+#   environment         = "staging"
+#   websocket_url       = "wss://events.compiler-explorer.com/staging"
+#   alb_listener_arn    = aws_alb_listener.compiler-explorer-alb-listen-https.arn
+#   enable_alb_listener = false # Disabled initially
+#   alb_priority        = 81
+#   alb_path_patterns = [
+#     "/staging/api/compiler/*/compile",
+#     "/staging/api/compiler/*/cmake"
+#   ]
+#   s3_bucket    = aws_s3_bucket.compiler-explorer.bucket
+#   iam_role_arn = aws_iam_role.iam_for_lambda.arn
+#
+#   tags = {
+#     Project = "compiler-explorer"
+#   }
+# }
+
+# Production Environment - Commented out for beta testing
+# module "compilation_lambda_prod" {
+#   source = "./modules/compilation_lambda"
+#
+#   environment         = "prod"
+#   websocket_url       = "wss://events.compiler-explorer.com/prod"
+#   alb_listener_arn    = aws_alb_listener.compiler-explorer-alb-listen-https.arn
+#   enable_alb_listener = false # Disabled initially
+#   alb_priority        = 71
+#   alb_path_patterns = [
+#     "/api/compiler/*/compile",
+#     "/api/compiler/*/cmake"
+#   ]
+#   s3_bucket    = aws_s3_bucket.compiler-explorer.bucket
+#   iam_role_arn = aws_iam_role.iam_for_lambda.arn
+#
+#   tags = {
+#     Project = "compiler-explorer"
+#   }
+# }
+
+# Updated IAM policy to use module outputs - Only beta for testing
+data "aws_iam_policy_document" "compilation_lambda_sqs" {
+  statement {
+    sid = "SQSAccess"
+    actions = [
+      "sqs:SendMessage",
+      "sqs:GetQueueAttributes"
+    ]
+    resources = [
+      module.compilation_lambda_beta.sqs_queue_arn,
+      # module.compilation_lambda_staging.sqs_queue_arn,
+      # module.compilation_lambda_prod.sqs_queue_arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "compilation_lambda_sqs" {
+  name        = "compilation_lambda_sqs"
+  description = "Allow compilation Lambda to send messages to SQS queues"
+  policy      = data.aws_iam_policy_document.compilation_lambda_sqs.json
+}
+
+resource "aws_iam_role_policy_attachment" "compilation_lambda_sqs" {
+  role       = aws_iam_role.iam_for_lambda.name
+  policy_arn = aws_iam_policy.compilation_lambda_sqs.arn
+}
+
+# Outputs for backward compatibility and ASG integration
+output "compilation_queue_beta_id" {
+  description = "Beta compilation queue ID"
+  value       = module.compilation_lambda_beta.sqs_queue_id
+}
+
+# output "compilation_queue_staging_id" {
+#   description = "Staging compilation queue ID"
+#   value       = module.compilation_lambda_staging.sqs_queue_id
+# }
+#
+# output "compilation_queue_prod_id" {
+#   description = "Production compilation queue ID"
+#   value       = module.compilation_lambda_prod.sqs_queue_id
+# }
+
+output "compilation_queue_beta_arn" {
+  description = "Beta compilation queue ARN"
+  value       = module.compilation_lambda_beta.sqs_queue_arn
+}
+
+# output "compilation_queue_staging_arn" {
+#   description = "Staging compilation queue ARN"
+#   value       = module.compilation_lambda_staging.sqs_queue_arn
+# }
+#
+# output "compilation_queue_prod_arn" {
+#   description = "Production compilation queue ARN"
+#   value       = module.compilation_lambda_prod.sqs_queue_arn
+# }
+
+output "compilation_queue_beta_name" {
+  description = "Beta compilation queue name"
+  value       = module.compilation_lambda_beta.sqs_queue_name
+}
+
+# output "compilation_queue_staging_name" {
+#   description = "Staging compilation queue name"
+#   value       = module.compilation_lambda_staging.sqs_queue_name
+# }
+#
+# output "compilation_queue_prod_name" {
+#   description = "Production compilation queue name"
+#   value       = module.compilation_lambda_prod.sqs_queue_name
+# }

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -100,6 +100,29 @@ resource "aws_iam_role_policy_attachment" "alert_on_elb_instance" {
   policy_arn = aws_iam_policy.alert_on_elb_instance.arn
 }
 
+# WebSocket API Gateway permissions for compilation Lambda
+data "aws_iam_policy_document" "compilation_lambda_websocket" {
+  statement {
+    sid       = "WebSocketAccess"
+    actions   = [
+      "execute-api:ManageConnections",
+      "execute-api:Invoke"
+    ]
+    resources = ["arn:aws:execute-api:*:*:*"]
+  }
+}
+
+resource "aws_iam_policy" "compilation_lambda_websocket" {
+  name        = "compilation_lambda_websocket"
+  description = "Allow compilation Lambda to connect to WebSocket API Gateway"
+  policy      = data.aws_iam_policy_document.compilation_lambda_websocket.json
+}
+
+resource "aws_iam_role_policy_attachment" "compilation_lambda_websocket" {
+  role       = aws_iam_role.iam_for_lambda.name
+  policy_arn = aws_iam_policy.compilation_lambda_websocket.arn
+}
+
 data "aws_ssm_parameter" "discord_webhook_url" {
   name = "/admin/discord_webhook_url"
 }

--- a/terraform/lc.tf
+++ b/terraform/lc.tf
@@ -1,6 +1,6 @@
 locals {
   image_id                 = "ami-01297581addf1e7dd"
-  staging_image_id         = "ami-01297581addf1e7dd"
+  staging_image_id         = "ami-01e6bdf443dda1bae"
   beta_image_id            = "ami-01297581addf1e7dd"
   gpu_image_id             = "ami-07ae9e39256e3ede7"
   aarch64prod_image_id     = "ami-079d9b1e36db465bb"

--- a/terraform/modules/compilation_lambda/README.md
+++ b/terraform/modules/compilation_lambda/README.md
@@ -1,0 +1,137 @@
+# Compilation Lambda Module
+
+This Terraform module creates the infrastructure for Lambda-based compilation endpoints in Compiler Explorer.
+
+## Features
+
+- **Lambda Function**: Python 3.12 function to handle compilation requests
+- **SQS FIFO Queue**: Reliable message queuing for compilation requests
+- **ALB Integration**: Target group and optional listener rules for request routing
+- **CloudWatch Logs**: Centralized logging with configurable retention
+- **IAM Integration**: Uses provided IAM role for Lambda execution
+
+## Usage
+
+```terraform
+module "compilation_lambda_beta" {
+  source = "./modules/compilation_lambda"
+
+  environment         = "beta"
+  websocket_url       = "wss://events.compiler-explorer.com/beta"
+  alb_listener_arn    = aws_alb_listener.compiler-explorer-alb-listen-https.arn
+  enable_alb_listener = true
+  alb_priority        = 10
+  alb_path_patterns = [
+    "/beta/api/compilers/*/compile",
+    "/beta/api/compilers/*/cmake"
+  ]
+  s3_bucket    = aws_s3_bucket.compiler-explorer.bucket
+  iam_role_arn = aws_iam_role.iam_for_lambda.arn
+
+  tags = {
+    Project = "compiler-explorer"
+  }
+}
+```
+
+## Auto-Scaling Integration
+
+The module outputs can be used with ASG auto-scaling policies:
+
+```terraform
+resource "aws_autoscaling_policy" "compilation_scaling" {
+  # ... other configuration ...
+
+  target_tracking_configuration {
+    customized_metric_specification {
+      metrics {
+        metric_stat {
+          metric {
+            dimensions {
+              name  = "QueueName"
+              value = module.compilation_lambda_beta.sqs_queue_name
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Architecture
+
+```
+┌─────────────┐    ┌──────────────┐    ┌─────────────┐
+│     ALB     │───▶│    Lambda    │───▶│ SQS Queue   │
+│             │    │   Function   │    │    FIFO     │
+└─────────────┘    └──────────────┘    └─────────────┘
+                          │
+                          ▼
+                   ┌──────────────┐
+                   │  WebSocket   │
+                   │    Events    │
+                   └──────────────┘
+```
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| environment | Environment name for resource naming and tagging | `string` | n/a | yes |
+| websocket_url | WebSocket URL for events system | `string` | n/a | yes |
+| alb_listener_arn | ALB listener ARN for routing rules | `string` | n/a | yes |
+| s3_bucket | S3 bucket for Lambda package | `string` | n/a | yes |
+| iam_role_arn | IAM role ARN for Lambda execution | `string` | n/a | yes |
+| enable_alb_listener | Whether to create ALB listener rule | `bool` | `false` | no |
+| alb_priority | ALB listener rule priority | `number` | n/a | yes |
+| alb_path_patterns | List of path patterns for ALB listener rule | `list(string)` | `[]` | no |
+| lambda_timeout | Lambda function timeout in seconds | `number` | `120` | no |
+| lambda_retry_count | Number of WebSocket retry attempts | `string` | `"2"` | no |
+| lambda_timeout_seconds | WebSocket response timeout in seconds | `string` | `"90"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| sqs_queue_id | SQS queue ID |
+| sqs_queue_arn | SQS queue ARN |
+| sqs_queue_name | SQS queue name |
+| lambda_function_arn | Lambda function ARN |
+| lambda_function_name | Lambda function name |
+| alb_target_group_arn | ALB target group ARN |
+| cloudwatch_log_group_name | CloudWatch log group name |
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.0 |
+| aws | >= 5.0 |
+
+## Resources Created
+
+- `aws_sqs_queue` - FIFO queue for compilation requests
+- `aws_lambda_function` - Lambda function for request processing
+- `aws_cloudwatch_log_group` - Log group for Lambda function
+- `aws_alb_target_group` - ALB target group for Lambda
+- `aws_alb_target_group_attachment` - Target group attachment
+- `aws_lambda_permission` - Permission for ALB to invoke Lambda
+- `aws_alb_listener_rule` - ALB listener rule (conditional)
+
+## Path Patterns
+
+The module uses the `alb_path_patterns` variable to configure ALB listener rules. Common patterns:
+
+- **Production**: `["/api/compilers/*/compile", "/api/compilers/*/cmake"]`
+- **Staging/Beta**: `["/{environment}/api/compilers/*/compile", "/{environment}/api/compilers/*/cmake"]`
+- **Custom**: Any list of path patterns for your specific use case
+
+## Security
+
+This module requires an IAM role with the following permissions:
+- Lambda execution permissions
+- SQS send/receive permissions
+- CloudWatch logs permissions
+
+The IAM role should be created externally and passed via the `iam_role_arn` variable.

--- a/terraform/modules/compilation_lambda/examples/basic/main.tf
+++ b/terraform/modules/compilation_lambda/examples/basic/main.tf
@@ -1,0 +1,31 @@
+# Example usage of the compilation_lambda module
+
+module "compilation_lambda_example" {
+  source = "../../"
+
+  environment         = "test"
+  websocket_url       = "wss://events.compiler-explorer.com/test"
+  alb_listener_arn    = "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/test-alb/50dc6c495c0c9188/0467ef3c8400ae65"
+  enable_alb_listener = true
+  alb_priority        = 100
+  alb_path_patterns = [
+    "/test/api/compilers/*/compile",
+    "/test/api/compilers/*/cmake"
+  ]
+  s3_bucket    = "test-bucket"
+  iam_role_arn = "arn:aws:iam::123456789012:role/test-lambda-role"
+
+  tags = {
+    Environment = "test"
+    Project     = "compiler-explorer"
+  }
+}
+
+# Example output usage
+output "queue_name" {
+  value = module.compilation_lambda_example.sqs_queue_name
+}
+
+output "lambda_arn" {
+  value = module.compilation_lambda_example.lambda_function_arn
+}

--- a/terraform/modules/compilation_lambda/main.tf
+++ b/terraform/modules/compilation_lambda/main.tf
@@ -1,0 +1,124 @@
+# Main configuration for compilation Lambda module
+
+# SQS FIFO Queue for compilation requests
+resource "aws_sqs_queue" "compilation_queue" {
+  name                        = "${var.environment}-compilation-queue.fifo"
+  fifo_queue                  = true
+  content_based_deduplication = false
+  message_retention_seconds   = var.sqs_message_retention_seconds
+  visibility_timeout_seconds  = var.sqs_visibility_timeout_seconds
+
+  tags = merge({
+    Environment = var.environment
+    Purpose     = "compilation-requests"
+  }, var.tags)
+}
+
+# Get compilation lambda package from S3
+data "aws_s3_object" "compilation_lambda_zip" {
+  bucket = var.s3_bucket
+  key    = var.lambda_package_key
+}
+
+data "aws_s3_object" "compilation_lambda_zip_sha" {
+  bucket = var.s3_bucket
+  key    = var.lambda_package_sha_key
+}
+
+# CloudWatch log group for Lambda
+resource "aws_cloudwatch_log_group" "compilation" {
+  name              = "/aws/lambda/compilation-${var.environment}"
+  retention_in_days = var.cloudwatch_log_retention_days
+
+  tags = merge({
+    Environment = var.environment
+    Purpose     = "compilation-logs"
+  }, var.tags)
+}
+
+# Lambda function
+resource "aws_lambda_function" "compilation" {
+  description       = "Handle compilation requests for ${var.environment} environment"
+  s3_bucket         = data.aws_s3_object.compilation_lambda_zip.bucket
+  s3_key            = data.aws_s3_object.compilation_lambda_zip.key
+  s3_object_version = data.aws_s3_object.compilation_lambda_zip.version_id
+  source_code_hash  = chomp(data.aws_s3_object.compilation_lambda_zip_sha.body)
+  function_name     = "compilation-${var.environment}"
+  role              = var.iam_role_arn
+  handler           = "lambda_function.lambda_handler"
+  timeout           = var.lambda_timeout
+
+  runtime = "python3.12"
+
+  environment {
+    variables = {
+      SQS_QUEUE_URL   = aws_sqs_queue.compilation_queue.id
+      WEBSOCKET_URL   = var.websocket_url
+      RETRY_COUNT     = var.lambda_retry_count
+      TIMEOUT_SECONDS = var.lambda_timeout_seconds
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.compilation]
+
+  tags = merge({
+    Environment = var.environment
+    Purpose     = "compilation"
+  }, var.tags)
+}
+
+# ALB Target Group for Lambda function
+resource "aws_alb_target_group" "compilation_lambda" {
+  name        = "compilation-lambda-${var.environment}"
+  target_type = "lambda"
+
+  # Health checks are not applicable for Lambda target groups
+  # Lambda functions are automatically considered healthy
+
+  tags = merge({
+    Environment = var.environment
+    Purpose     = "compilation-lambda"
+  }, var.tags)
+}
+
+# ALB Target Group Attachment for Lambda function
+resource "aws_alb_target_group_attachment" "compilation_lambda" {
+  target_group_arn = aws_alb_target_group.compilation_lambda.arn
+  target_id        = aws_lambda_function.compilation.arn
+
+  depends_on = [aws_lambda_permission.compilation_alb]
+}
+
+# Lambda permission for ALB to invoke function
+resource "aws_lambda_permission" "compilation_alb" {
+  statement_id  = "AllowExecutionFromALB"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.compilation.arn
+  principal     = "elasticloadbalancing.amazonaws.com"
+  source_arn    = aws_alb_target_group.compilation_lambda.arn
+}
+
+# ALB Listener Rule (conditional based on enable_alb_listener)
+resource "aws_alb_listener_rule" "compilation" {
+  count = var.enable_alb_listener ? 1 : 0
+
+  priority = var.alb_priority
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_alb_target_group.compilation_lambda.arn
+  }
+
+  condition {
+    path_pattern {
+      values = var.alb_path_patterns
+    }
+  }
+
+  listener_arn = var.alb_listener_arn
+
+  tags = merge({
+    Environment = var.environment
+    Purpose     = "compilation-routing"
+  }, var.tags)
+}

--- a/terraform/modules/compilation_lambda/outputs.tf
+++ b/terraform/modules/compilation_lambda/outputs.tf
@@ -1,0 +1,36 @@
+# Outputs for compilation Lambda module
+
+output "sqs_queue_id" {
+  description = "SQS queue ID"
+  value       = aws_sqs_queue.compilation_queue.id
+}
+
+output "sqs_queue_arn" {
+  description = "SQS queue ARN"
+  value       = aws_sqs_queue.compilation_queue.arn
+}
+
+output "sqs_queue_name" {
+  description = "SQS queue name"
+  value       = aws_sqs_queue.compilation_queue.name
+}
+
+output "lambda_function_arn" {
+  description = "Lambda function ARN"
+  value       = aws_lambda_function.compilation.arn
+}
+
+output "lambda_function_name" {
+  description = "Lambda function name"
+  value       = aws_lambda_function.compilation.function_name
+}
+
+output "alb_target_group_arn" {
+  description = "ALB target group ARN"
+  value       = aws_alb_target_group.compilation_lambda.arn
+}
+
+output "cloudwatch_log_group_name" {
+  description = "CloudWatch log group name"
+  value       = aws_cloudwatch_log_group.compilation.name
+}

--- a/terraform/modules/compilation_lambda/variables.tf
+++ b/terraform/modules/compilation_lambda/variables.tf
@@ -1,0 +1,97 @@
+# Variables for compilation Lambda module
+
+variable "environment" {
+  description = "Environment name for resource naming and tagging"
+  type        = string
+}
+
+variable "websocket_url" {
+  description = "WebSocket URL for events system"
+  type        = string
+}
+
+variable "alb_listener_arn" {
+  description = "ALB listener ARN for routing rules"
+  type        = string
+}
+
+variable "enable_alb_listener" {
+  description = "Whether to create ALB listener rule"
+  type        = bool
+  default     = false
+}
+
+variable "alb_priority" {
+  description = "ALB listener rule priority"
+  type        = number
+}
+
+variable "alb_path_patterns" {
+  description = "List of path patterns for ALB listener rule"
+  type        = list(string)
+  default     = []
+}
+
+variable "lambda_timeout" {
+  description = "Lambda function timeout in seconds"
+  type        = number
+  default     = 120
+}
+
+variable "lambda_retry_count" {
+  description = "Number of WebSocket retry attempts"
+  type        = string
+  default     = "2"
+}
+
+variable "lambda_timeout_seconds" {
+  description = "WebSocket response timeout in seconds"
+  type        = string
+  default     = "90"
+}
+
+variable "sqs_message_retention_seconds" {
+  description = "SQS message retention period in seconds"
+  type        = number
+  default     = 60 # 1 minute
+}
+
+variable "sqs_visibility_timeout_seconds" {
+  description = "SQS visibility timeout in seconds"
+  type        = number
+  default     = 5 # 5 seconds
+}
+
+variable "cloudwatch_log_retention_days" {
+  description = "CloudWatch log retention period in days"
+  type        = number
+  default     = 14
+}
+
+variable "s3_bucket" {
+  description = "S3 bucket for Lambda package"
+  type        = string
+}
+
+variable "lambda_package_key" {
+  description = "S3 key for Lambda package"
+  type        = string
+  default     = "lambdas/compilation-lambda-package.zip"
+}
+
+variable "lambda_package_sha_key" {
+  description = "S3 key for Lambda package SHA"
+  type        = string
+  default     = "lambdas/compilation-lambda-package.zip.sha256"
+}
+
+variable "iam_role_arn" {
+  description = "IAM role ARN for Lambda execution"
+  type        = string
+}
+
+variable "tags" {
+  description = "Additional tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/compilation_lambda/versions.tf
+++ b/terraform/modules/compilation_lambda/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/terraform/security.tf
+++ b/terraform/security.tf
@@ -342,11 +342,22 @@ data "aws_iam_policy_document" "CeSqsPushPop" {
       aws_sqs_queue.staging-execqueue-aarch64-linux-cpu.arn,
     ]
   }
+  statement {
+    sid = "CompilationQueueAccess"
+    actions = [
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes"
+    ]
+    resources = [
+      module.compilation_lambda_beta.sqs_queue_arn,
+    ]
+  }
 }
 
 resource "aws_iam_policy" "CeSqsPushPop" {
   name        = "CeSqsPushPop"
-  description = "Can push/pop Sqs"
+  description = "Can push/pop SQS execution queues and receive compilation queue messages"
   policy      = data.aws_iam_policy_document.CeSqsPushPop.json
 }
 


### PR DESCRIPTION
## WINE failed with a weird error:

```
Jul 02 21:53:23Z ip-172-30-1-106 amazon.staging info: Initialising WINE in /tmp/ce-wine-prefix 
Jul 02 21:53:23Z ip-172-30-1-106 amazon.staging info: Killing any pre-existing wine-server 
Jul 02 21:53:23Z ip-172-30-1-106 amazon.staging info: Starting a new, firejailed, long-lived wineserver complex 
Jul 02 21:53:25Z ip-172-30-1-106 amazon.staging info: stderr output from wine server complex: Access error: uid 119, last mount name:/ dir:/efs/compiler-explorer/libs/boost-1.87.0 type:squashfs - invalid noexec mount 
Jul 02 21:53:25Z ip-172-30-1-106 amazon.staging info: stderr output from wine server complex: Error: proc 3805 cannot sync with peer: unexpected EOF 
```

## Timings:
- 21:52:20 boot
- 21:53:00 `compiler-explorer` startup script starts
- 21:53:01 mount-all.sh starts in the background (starts listing the squashfs images...)
- 21:53:06 node.js starts up and CE starts booting
- 21:53:15 mount-all.sh starts mounting images in the background
- 21:53:23(wine failed)
- 21:53:29 CE starts creating compilers
- 21:54:24 CE is done and is ready to serve
- 21:56:31 mounting finishes

Empirically the staging instance was "as fast as normal" while it was still mounting, at least with gcc 15.1.0 and me forcing recompiles.