### PR TITLE
Add Fortran library roots_fortran v1.4.0

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -2923,6 +2923,14 @@ libraries:
         targets:
         - stdlib-fpm
         type: github
+    roots_fortran:
+      build_type: fpm
+      check_file: fpm.toml
+      repo: jacobwilliams/roots-fortran
+      requires_tree_copy: true
+      targets:
+      - 1.4.0
+      type: github
   rust:
     ahash:
       build_type: cargo


### PR DESCRIPTION
This PR adds the Fortran library **roots_fortran** version 1.4.0 to Compiler Explorer.

- GitHub URL: https://github.com/jacobwilliams/roots-fortran
- Package Manager: FPM (Fortran Package Manager)

---
_PR created with [ce-lib-wizard](https://github.com/compiler-explorer/ce-lib-wizard)_