### PR TITLE
Fix cpp-library generate-linux-props: add missing name/url properties…

### DIFF
--- a/bin/lib/cli/cpp_libraries.py
+++ b/bin/lib/cli/cpp_libraries.py
@@ -227,9 +227,8 @@ def generate_cpp_linux_props(input_file, output_file, library, version):
             click.echo(f"Error: {e}", err=True)
             sys.exit(1)
 
-        # When generating standalone (no input file), include all properties
-        if not input_file and version and "name" not in lib_props:
-            # Add library-level properties for standalone generation
+        # Always include name and url properties when generating for a specific version
+        if version and "name" not in lib_props:
             lib_props["name"] = library
             if lib_info.get("type") == "github" and "repo" in lib_info:
                 lib_props["url"] = f"https://github.com/{lib_info['repo']}"

--- a/docs/cpp_library_commands.md
+++ b/docs/cpp_library_commands.md
@@ -134,3 +134,5 @@ ce_install cpp-library generate-linux-props --output-file cpp_libraries.properti
 - Properties generation can be done for all libraries or filtered to specific libraries/versions
 - Windows and Linux properties may include different libraries based on build compatibility
 - Library paths and linking information are automatically configured based on library type
+- When generating properties for a specific library version, the command automatically includes the required `.name` and `.url` properties
+- New library properties are inserted before the tools section in the properties file, maintaining proper file structure


### PR DESCRIPTION
… and fix placement

- Always include .name and .url properties when generating for specific versions
- Insert new library properties before tools section instead of at end of file
- Move inline imports to top of library_props.py file
- Update documentation to reflect the fixes

🤖 Generated with [Claude Code](https://claude.ai/code)