### PR TITLE
Add C++ library graaf v1.1.1

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -714,6 +714,13 @@ libraries:
       - release-1.12.0
       - release-1.12.1
       type: github
+    graaf:
+      check_file: README.md
+      repo: bobluppes/graaf
+      targets:
+      - 1.1.1
+      type: github
+      use_compiler: g105
     gsl:
       check_file: README.md
       repo: Microsoft/GSL


### PR DESCRIPTION
This PR adds the C++ library **graaf** version 1.1.1 to Compiler Explorer.

- GitHub URL: https://github.com/bobluppes/graaf
- Library Type: header-only

---
_PR created with [ce-lib-wizard](https://github.com/compiler-explorer/ce-library-wizard)_