### PR TITLE
Add Scala 2.12.20, 2.13.16, 3.3.6, 3.6.4, 3.7.1

### DIFF
--- a/bin/yaml/scala.yaml
+++ b/bin/yaml/scala.yaml
@@ -12,10 +12,14 @@ compilers:
     targets:
       - name: 2.12.14
         url: https://downloads.lightbend.com/scala/2.12.14/scala-2.12.14.tgz
+      - name: 2.12.20
+        url: https://downloads.lightbend.com/scala/2.12.20/scala-2.12.20.tgz
       - name: 2.13.6
         url: https://downloads.lightbend.com/scala/2.13.6/scala-2.13.6.tgz
       - name: 2.13.15
         url: https://downloads.lightbend.com/scala/2.13.15/scala-2.13.15.tgz
+      - name: 2.13.16
+        url: https://downloads.lightbend.com/scala/2.13.16/scala-2.13.16.tgz
       - name: 3.0.0
         url: https://github.com/scala/scala3/releases/download/3.0.0/scala3-3.0.0.tar.gz
         dir: scala3-{{name}}
@@ -31,6 +35,9 @@ compilers:
       - name: 3.3.4
         url: https://github.com/lampepfl/dotty/releases/download/3.3.4/scala3-3.3.4.tar.gz
         dir: scala3-{{name}}
+      - name: 3.3.6
+        url: https://github.com/lampepfl/dotty/releases/download/3.3.6/scala3-3.3.6.tar.gz
+        dir: scala3-{{name}}
       - name: 3.4.0
         url: https://github.com/lampepfl/dotty/releases/download/3.4.0/scala3-3.4.0.tar.gz
         dir: scala3-{{name}}
@@ -39,4 +46,10 @@ compilers:
         dir: scala3-{{name}}
       - name: 3.6.2
         url: https://github.com/lampepfl/dotty/releases/download/3.6.2/scala3-3.6.2.tar.gz
+        dir: scala3-{{name}}
+      - name: 3.6.4
+        url: https://github.com/lampepfl/dotty/releases/download/3.6.4/scala3-3.6.4.tar.gz
+        dir: scala3-{{name}}
+      - name: 3.7.1
+        url: https://github.com/lampepfl/dotty/releases/download/3.7.1/scala3-3.7.1.tar.gz
         dir: scala3-{{name}}


### PR DESCRIPTION
These are, in order:
- The latest Scala in the 2.12.x cycle
- The latest Scala in the 2.13.x cycle
- The latest Scala 3.3.x LTS
- The latest Scala 3.6.x (previous latest version was 3.6.2)
- The latest Scala 3.x