### PR TITLE
[swift]: update URLs for nightly/dev builds

### DIFF
--- a/bin/yaml/swift.yaml
+++ b/bin/yaml/swift.yaml
@@ -38,7 +38,7 @@ compilers:
           - '6.0.3'
           - '6.1'
     # post-6-2:
-    #   url: https://download.swift.org/{{build}}/ubuntu2404/{{toolchain}}/{{toolchain}}-ubuntu24.04.tar.gz
+    #   url: https://download.swift.org/{{build}}/ubuntu2204/{{toolchain}}/{{toolchain}}-ubuntu22.04.tar.gz
     #   targets:
     #       - '6.2'
     #   TODO: use this for 6.2+ releases since ubuntu 20.04 urls will no longer work
@@ -57,9 +57,9 @@ compilers:
       type: restQueryTarballs
       install_always: true
       toolchain: development
-      url: https://download.swift.org/{{toolchain}}/ubuntu2404/latest-build.yml
+      url: https://download.swift.org/{{toolchain}}/ubuntu2204/latest-build.yml
       query: |
-        'https://download.swift.org/{{toolchain}}/ubuntu2404' \
+        'https://download.swift.org/{{toolchain}}/ubuntu2204' \
         + '/' + document['dir'] \
         + '/' + document['download']
       targets:


### PR DESCRIPTION
Swift will [soon stop publishing](https://forums.swift.org/t/dropping-support-for-ubuntu-20-04/81109) builds at the ubuntu 20.04 URLs. this updates the config for the nightly builds to use the Ubuntu 22.04 URLs instead, and adds a placeholder config entry for future compiler releases that should also use the updated URL pattern.