### PR TITLE
Add C++ library graaf v1.1.0

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -715,6 +715,13 @@ libraries:
       - release-1.12.0
       - release-1.12.1
       type: github
+    graaf:
+      check_file: README.md
+      repo: bobluppes/graaf
+      target_prefix: v
+      targets:
+      - 1.1.0
+      type: github
     gsl:
       check_file: README.md
       repo: Microsoft/GSL


### PR DESCRIPTION
This PR adds the C++ library **graaf** version 1.1.0 to Compiler Explorer.

- GitHub URL: https://github.com/bobluppes/graaf
- Library Type: header-only

---
_PR created with [ce-lib-wizard](https://github.com/compiler-explorer/ce-library-wizard)_