### PR TITLE
[HLSL] Add DXC 1.8.2505 releases

### DIFF
--- a/bin/yaml/hlsl.yaml
+++ b/bin/yaml/hlsl.yaml
@@ -11,6 +11,8 @@ compilers:
       type: s3tarballs
       check_exe: bin/dxc --version
       targets:
+        - "1.8.2505.1"
+        - "1.8.2505"
         - "1.8.2502"
         - "1.8.2407"
         - "1.8.2405"


### PR DESCRIPTION
This adds the last 2 DXC releases based on the 1.8.2505 release branch