### PR TITLE
Fix cross-repository issue notifications

### DIFF
--- a/bin/test/notify_test.py
+++ b/bin/test/notify_test.py
@@ -21,11 +21,13 @@ class TestNotify(unittest.TestCase):
             patch("builtins.print") as mock_print,
             patch("lib.notify.should_send_comment_to_issue", return_value=True),
         ):
-            send_live_message("123", "fake_token", dry_run=True)
+            send_live_message("123", "compiler-explorer/compiler-explorer", "fake_token", dry_run=True)
 
             print_calls = [call[0][0] for call in mock_print.call_args_list]
-            self.assertIn("[DRY RUN] Would add 'live' label to issue #123", print_calls)
-            self.assertIn("[DRY RUN] Would comment 'This is now live' on issue #123", print_calls)
+            self.assertIn("[DRY RUN] Would add 'live' label to compiler-explorer/compiler-explorer#123", print_calls)
+            self.assertIn(
+                "[DRY RUN] Would comment 'This is now live' on compiler-explorer/compiler-explorer#123", print_calls
+            )
 
     def test_handle_notify_dry_run(self):
         """Test that handle_notify processes correctly in dry-run mode."""
@@ -44,7 +46,7 @@ class TestNotify(unittest.TestCase):
         ):
             handle_notify("old_commit", "new_commit", "fake_token", dry_run=True)
 
-            mock_send.assert_called_once_with(456, "fake_token", dry_run=True)
+            mock_send.assert_called_once_with(456, "compiler-explorer/compiler-explorer", "fake_token", dry_run=True)
             print_calls = [call[0][0] for call in mock_print.call_args_list]
             self.assertTrue(any("[DRY RUN] Would notify PR #456" in call for call in print_calls))
 
@@ -60,6 +62,123 @@ class TestNotify(unittest.TestCase):
             handle_notify("old_commit", "new_commit", "fake_token", dry_run=False)
 
             mock_send.assert_not_called()
+
+    def test_should_notify_issue_filters_external_repos(self):
+        """Test that should_notify_issue filters out external repository issues."""
+        from lib.notify import should_notify_issue
+
+        # External repository issue (should be filtered out)
+        external_edge = {
+            "repository": {"owner": {"login": "sinonjs"}, "name": "samsam"},
+            "number": 253,
+            "labels": {"edges": []},
+        }
+        self.assertFalse(should_notify_issue(external_edge))
+
+        # Compiler Explorer main repo (should be notified)
+        ce_main_edge = {
+            "repository": {"owner": {"login": "compiler-explorer"}, "name": "compiler-explorer"},
+            "number": 123,
+            "labels": {"edges": []},
+        }
+        self.assertTrue(should_notify_issue(ce_main_edge))
+
+        # Compiler Explorer infra repo (should be notified)
+        ce_infra_edge = {
+            "repository": {"owner": {"login": "compiler-explorer"}, "name": "infra"},
+            "number": 456,
+            "labels": {"edges": []},
+        }
+        self.assertTrue(should_notify_issue(ce_infra_edge))
+
+        # Issue with no number (should be filtered out)
+        no_number_edge = {
+            "repository": {"owner": {"login": "compiler-explorer"}, "name": "compiler-explorer"},
+            "labels": {"edges": []},
+        }
+        self.assertFalse(should_notify_issue(no_number_edge))
+
+        # Issue already marked as live (should be filtered out)
+        live_edge = {
+            "repository": {"owner": {"login": "compiler-explorer"}, "name": "compiler-explorer"},
+            "number": 789,
+            "labels": {"edges": [{"node": {"name": "live"}}]},
+        }
+        self.assertFalse(should_notify_issue(live_edge))
+
+    def test_handle_notify_supports_cross_repo_issues(self):
+        """Test that handle_notify can notify issues across CE repositories."""
+        mock_commits = [{"sha": "abc123"}]
+        mock_pr = {"number": 456, "labels": []}
+
+        # Mock linked issues with both main repo and infra repo issues
+        mock_linked_issues = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "closingIssuesReferences": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "repository": {
+                                            "owner": {"login": "compiler-explorer"},
+                                            "name": "compiler-explorer",
+                                        },
+                                        "number": 123,
+                                        "labels": {"edges": []},
+                                    }
+                                },
+                                {
+                                    "node": {
+                                        "repository": {"owner": {"login": "compiler-explorer"}, "name": "infra"},
+                                        "number": 456,
+                                        "labels": {"edges": []},
+                                    }
+                                },
+                                {
+                                    "node": {
+                                        "repository": {"owner": {"login": "sinonjs"}, "name": "samsam"},
+                                        "number": 253,
+                                        "labels": {"edges": []},
+                                    }
+                                },
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+
+        with (
+            patch("lib.notify.list_inbetween_commits", return_value=mock_commits),
+            patch("lib.notify.get_linked_pr", return_value=mock_pr),
+            patch("lib.notify.send_live_message") as mock_send,
+            patch("lib.notify.get_linked_issues", return_value=mock_linked_issues),
+            patch("builtins.print") as mock_print,
+        ):
+            handle_notify("old_commit", "new_commit", "fake_token", dry_run=True)
+
+            # Should be called 3 times: PR + 2 CE issues (external issue filtered out)
+            self.assertEqual(mock_send.call_count, 3)
+
+            # Check that PR notification happened
+            mock_send.assert_any_call(456, "compiler-explorer/compiler-explorer", "fake_token", dry_run=True)
+
+            # Check that CE main repo issue notification happened
+            mock_send.assert_any_call(123, "compiler-explorer/compiler-explorer", "fake_token", dry_run=True)
+
+            # Check that CE infra repo issue notification happened
+            mock_send.assert_any_call(456, "compiler-explorer/infra", "fake_token", dry_run=True)
+
+            # Verify external repo issue was NOT notified (sinonjs/samsam#253)
+            for call_args in mock_send.call_args_list:
+                self.assertNotIn("sinonjs", str(call_args))
+                self.assertNotIn("samsam", str(call_args))
+
+            # Check print output shows correct repo formatting
+            print_calls = [call[0][0] for call in mock_print.call_args_list]
+            self.assertTrue(any("compiler-explorer/compiler-explorer#123" in call for call in print_calls))
+            self.assertTrue(any("compiler-explorer/infra#456" in call for call in print_calls))
 
 
 class TestBlueGreenVersionHelpers(unittest.TestCase):


### PR DESCRIPTION
## Summary

Fixes the notification system incorrectly processing external repository references as internal issues.

**Root Cause**: When a PR mentions an external repository issue like `sinonjs/samsam#253`, GitHub's `closingIssuesReferences` API correctly returns repository information, but our notification code was ignoring the repository field and processing all issues as if they belonged to the current repository.

**Example**: PR #7955 mentioned "Picks up fix sinonjs/samsam#253" but our system incorrectly notified compiler-explorer/compiler-explorer#253 ("Watcom C/C++ compiler") as being "live".

## Changes

- ✅ **Enhanced GraphQL Query**: Added repository information to `closingIssuesReferences` 
- ✅ **Repository Validation**: Only process issues from `compiler-explorer/*` repositories
- ✅ **Cross-Repository Support**: Can notify issues in both main repo and infra repo
- ✅ **External Filtering**: Properly filters out external repositories like `sinonjs/samsam`
- ✅ **Updated API Functions**: All notification functions now accept repository parameters
- ✅ **Enhanced Logging**: Better output showing which repo issues belong to

## Test Coverage

- Added comprehensive tests for cross-repository functionality
- Tests verify external repos are filtered out
- Tests confirm CE repositories are properly supported
- All existing tests continue to pass (147 passing, 1 skipped)

## Before/After

**Before**: 
- External repo reference `sinonjs/samsam#253` → incorrectly notifies `compiler-explorer/compiler-explorer#253`
- Could only notify issues in main repository

**After**:
- External repo references are filtered out completely
- Can notify issues across CE repositories (`compiler-explorer/compiler-explorer`, `compiler-explorer/infra`)
- Clear logging shows which repository each issue belongs to

## Verification

Tested against the original failing case (PR #7955):
- External `sinonjs/samsam#253` reference is correctly filtered out
- No false notifications to unrelated CE issues
- Cross-repository CE issues work correctly

Fixes #1725

🤖 Generated with [Claude Code](https://claude.ai/code)