### PR TITLE
Add Triton 3.4.0 and simplify check_exe

### DIFF
--- a/bin/yaml/triton.yaml
+++ b/bin/yaml/triton.yaml
@@ -10,8 +10,9 @@ compilers:
       - torch
       - numpy
       - setuptools # Unfortunately, Triton 2.x requires this
-    check_exe: [ "bin/python3.12", "-c", "import triton; import torch; print(triton.__version__, torch.__version__)" ]
+    check_exe: [ "bin/python3.12", "-c", "import triton; print(triton.__version__)" ]
     targets:
+      - 3.4.0
       - 3.3.1
       - 3.3.0
       - 3.2.0


### PR DESCRIPTION
Surprise know that Triton 3.4.0 was released the same day Triton support for CE was merged: https://pypi.org/project/triton/3.4.0/#history