### PR TITLE
Add --ignore-hash-mismatch flag to deployment commands

### DIFF
--- a/bin/lib/blue_green_deploy.py
+++ b/bin/lib/blue_green_deploy.py
@@ -223,6 +223,7 @@ class BlueGreenDeployment:
         skip_confirmation: bool = False,
         version: Optional[str] = None,
         branch: Optional[str] = None,
+        ignore_hash_mismatch: bool = False,
     ) -> None:
         """Perform a blue-green deployment with optional version setting."""
         active_color = self.get_active_color()
@@ -402,7 +403,7 @@ class BlueGreenDeployment:
                         if not release:
                             raise RuntimeError(f"Version {version} not found") from None
 
-                if not set_version_for_deployment(self.cfg, release):
+                if not set_version_for_deployment(self.cfg, release, ignore_hash_mismatch=ignore_hash_mismatch):
                     raise RuntimeError(f"Failed to set version {version}")
 
                 version_was_changed = True

--- a/bin/lib/cdn.py
+++ b/bin/lib/cdn.py
@@ -295,21 +295,16 @@ class DeploymentJob:
                     files_to_upload.append(f)
 
             if files_with_mismatch:
+                log_level = logging.WARNING if self.ignore_hash_mismatch else logging.ERROR
+                logger.log(log_level, "%d files have mismatching hashes", len(files_with_mismatch))
+                for f in files_with_mismatch:
+                    logger.log(log_level, "%s: expected hash %s != %s", f["name"], f["hash"], f["s3hash"])
+
                 if self.ignore_hash_mismatch:
-                    logger.warning(
-                        "%d files have mismatching hashes (ignoring due to --ignore-hash-mismatch)",
-                        len(files_with_mismatch),
-                    )
-                    for f in files_with_mismatch:
-                        logger.warning("%s: expected hash %s != %s", f["name"], f["hash"], f["s3hash"])
                     logger.warning("continuing deployment despite hash mismatches")
                     # Treat mismatched files as files to upload
                     files_to_upload.extend(files_with_mismatch)
                 else:
-                    logger.error("%d files have mismatching hashes", len(files_with_mismatch))
-                    for f in files_with_mismatch:
-                        logger.error("%s: expected hash %s != %s", f["name"], f["hash"], f["s3hash"])
-
                     logger.error("aborting cdn deployment due to errors")
                     return False
 

--- a/bin/lib/cli/blue_green.py
+++ b/bin/lib/cli/blue_green.py
@@ -200,6 +200,9 @@ def blue_green_status(cfg: Config, detailed: bool):
 @click.option("--notify/--no-notify", help="Send GitHub notifications for newly released PRs (prod only)", default=None)
 @click.option("--dry-run-notify", is_flag=True, help="Show what notifications would be sent without sending them")
 @click.option("--check-notifications", is_flag=True, help="Only check what notifications would be sent, don't deploy")
+@click.option(
+    "--ignore-hash-mismatch", help="Continue deployment even if files have unexpected hash values", is_flag=True
+)
 @click.argument("version", required=False)
 @click.pass_obj
 def blue_green_deploy(
@@ -210,6 +213,7 @@ def blue_green_deploy(
     notify: Optional[bool],
     dry_run_notify: bool,
     check_notifications: bool,
+    ignore_hash_mismatch: bool,
     version: Optional[str],
 ):
     """Deploy to the inactive color using blue-green strategy.
@@ -342,7 +346,13 @@ def blue_green_deploy(
             should_notify = False  # Don't notify immediately
 
     try:
-        deployment.deploy(target_capacity=capacity, skip_confirmation=skip_confirmation, version=version, branch=branch)
+        deployment.deploy(
+            target_capacity=capacity,
+            skip_confirmation=skip_confirmation,
+            version=version,
+            branch=branch,
+            ignore_hash_mismatch=ignore_hash_mismatch,
+        )
         print("\nDeployment successful!")
         print("Run 'ce blue-green rollback' if you need to revert")
 

--- a/bin/lib/cli/builds.py
+++ b/bin/lib/cli/builds.py
@@ -104,8 +104,13 @@ def check_hashes(cfg: Config, branch: Optional[str], version: str, raw: bool):
 @click.option("--branch", help="if version == latest, branch to get latest version from")
 @click.option("--raw/--no-raw", help="Set a raw path for a version")
 @click.option("--confirm", help="Skip confirmation questions", is_flag=True)
+@click.option(
+    "--ignore-hash-mismatch", help="Continue deployment even if files have unexpected hash values", is_flag=True
+)
 @click.argument("version")
-def builds_set_current(cfg: Config, branch: Optional[str], version: str, raw: bool, confirm: bool):
+def builds_set_current(
+    cfg: Config, branch: Optional[str], version: str, raw: bool, confirm: bool, ignore_hash_mismatch: bool
+):
     """Set the current version to VERSION for this environment.
 
     If VERSION is "latest" then the latest version (optionally filtered by --branch), is set.
@@ -156,11 +161,11 @@ def builds_set_current(cfg: Config, branch: Optional[str], version: str, raw: bo
         log_new_build(cfg, to_set)
         if release and release.static_key:
             if cfg.env.is_windows:
-                if not deploy_staticfiles_windows(release):
+                if not deploy_staticfiles_windows(release, ignore_hash_mismatch=ignore_hash_mismatch):
                     print("...aborted due to deployment failure!")
                     sys.exit(1)
             else:
-                if not deploy_staticfiles(release):
+                if not deploy_staticfiles(release, ignore_hash_mismatch=ignore_hash_mismatch):
                     print("...aborted due to deployment failure!")
                     sys.exit(1)
         else:


### PR DESCRIPTION
## Summary
- Add `--ignore-hash-mismatch` flag to deployment commands to allow deployments to continue with warnings instead of failing when files have unexpected hash values
- Useful when deploying over existing files that may have been modified or when hash mismatches are expected and acceptable

## Changes
- Add `ignore_hash_mismatch` parameter to `DeploymentJob` class in `cdn.py`
- Update `deploy_staticfiles()` and `deploy_staticfiles_windows()` functions to accept the flag
- Add `--ignore-hash-mismatch` CLI flag to:
  - `ce builds set_current`  
  - `ce blue-green deploy`
- Thread the flag through all deployment call chains

## Behavior
- **Without flag (default)**: Hash mismatches cause deployment to fail with errors (existing behavior preserved)
- **With flag**: Hash mismatches generate warnings and deployment continues by treating mismatched files as files to upload

## Test plan
- [x] Verify CLI flags are available in both commands
- [x] Confirm `DeploymentJob` accepts the new parameter  
- [x] All static checks pass
- [x] All pre-commit hooks pass
- [x] Backward compatibility maintained

🤖 Generated with [Claude Code](https://claude.ai/code)