### PR TITLE
Fix squash-verify to handle filenames with spaces

### DIFF
--- a/bin/lib/ce_install.py
+++ b/bin/lib/ce_install.py
@@ -5,9 +5,7 @@ import logging
 import logging.config
 import multiprocessing
 import os
-import re
 import signal
-import subprocess
 import sys
 import traceback
 from dataclasses import dataclass
@@ -27,6 +25,7 @@ from lib.installation import installers_for
 from lib.installation_context import FetchFailure, InstallationContext
 from lib.library_platform import LibraryPlatform
 from lib.library_yaml import LibraryYaml
+from lib.squashfs import verify_squashfs_contents
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -109,174 +108,6 @@ def squash_mount_check(rootfolder: Path, subdir: str, context: CliContext) -> in
                 error_count += squash_mount_check(rootfolder, filename, context)
             else:
                 error_count += squash_mount_check(rootfolder, f"{subdir}/{filename}", context)
-    return error_count
-
-
-@dataclass(frozen=True)
-class SquashfsEntry:
-    """Represents a parsed entry from unsquashfs -ll output."""
-
-    file_type: str  # 'd', 'l', '-', 'c', 'b', etc.
-    size: int  # File size in bytes (0 for non-regular files)
-    path: str  # Relative path without leading slash
-    target: Optional[str] = None  # Target for symlinks
-
-
-def parse_unsquashfs_line(line: str) -> Optional[SquashfsEntry]:
-    """Parse a single line from unsquashfs -ll output.
-
-    Returns SquashfsEntry with parsed data, or None if line cannot be parsed.
-    """
-    pattern = re.compile(
-        r"^(?P<permissions>[dlcbps-][rwxst-]{9})\s+"
-        r"(?P<owner_group>\S+)\s+"
-        r"(?P<size>\d+)\s+"
-        r"(?P<date>\d{4}-\d{2}-\d{2})\s+"
-        r"(?P<time>\d{2}:\d{2})"
-        r"(?:\s+(?P<path_part>.+?))?"
-        r"$"
-    )
-
-    match = pattern.match(line.strip())
-    if not match:
-        return None
-
-    groups = match.groupdict()
-
-    # No path means root directory - skip it
-    if not groups["path_part"]:
-        return None
-
-    file_type = groups["permissions"][0]
-
-    # Handle symlinks: "path -> target"
-    # Only split on ' -> ' if this is actually a symlink (type 'l')
-    target = None
-    path_part = groups["path_part"]
-    if file_type == "l" and " -> " in path_part:
-        path, target = path_part.split(" -> ", 1)
-    else:
-        path = path_part
-
-    # Remove leading slash for relative comparison
-    if path.startswith("/"):
-        path = path[1:]
-
-    if not path:  # Skip empty paths
-        return None
-
-    return SquashfsEntry(
-        file_type=file_type,
-        size=int(groups["size"]) if file_type == "-" else 0,
-        path=path,
-        target=target if target else None,
-    )
-
-
-def verify_squashfs_contents(img_path: Path, nfs_path: Path) -> int:
-    """Verify squashfs image contents match NFS directory. Returns error count."""
-    error_count = 0
-
-    try:
-        # Extract squashfs metadata without mounting
-        result = subprocess.run(
-            ["unsquashfs", "-ll", "-d", "", str(img_path)], capture_output=True, text=True, check=True
-        )
-        sqfs_output = result.stdout
-    except subprocess.CalledProcessError as e:
-        _LOGGER.error("Failed to read squashfs image %s: %s", img_path, e)
-        return 1
-    except FileNotFoundError:
-        _LOGGER.error("unsquashfs command not found - install squashfs-tools")
-        return 1
-
-    # Parse squashfs output to get file list
-    sqfs_files = {}
-    for line in sqfs_output.split("\n"):
-        if not line.strip():
-            continue
-
-        # Skip known header lines from unsquashfs
-        if line.startswith("Parallel unsquashfs:") or line.startswith("Filesystem on"):
-            continue
-
-        parsed = parse_unsquashfs_line(line)
-        if parsed:
-            sqfs_files[parsed.path] = (parsed.file_type, str(parsed.size))
-        else:
-            # Fail on any line we can't parse
-            raise ValueError(f"Failed to parse unsquashfs output line: {line}")
-
-    # Build equivalent from directory filesystem
-    dir_files = {}
-    if not nfs_path.exists():
-        _LOGGER.error("Directory does not exist: %s", nfs_path)
-        return 1
-
-    for item in nfs_path.rglob("*"):
-        rel_path = str(item.relative_to(nfs_path))
-
-        stat_result = item.lstat()
-
-        if item.is_symlink():
-            file_type = "l"
-            size = "0"
-        elif item.is_dir():
-            file_type = "d"
-            size = "0"
-        elif item.is_file():
-            file_type = "-"
-            size = str(stat_result.st_size)
-        else:
-            raise ValueError(f"Unknown file type for {item}")
-
-        dir_files[rel_path] = (file_type, size)
-
-    # Compare file sets
-    only_in_sqfs = set(sqfs_files.keys()) - set(dir_files.keys())
-    only_in_dir = set(dir_files.keys()) - set(sqfs_files.keys())
-
-    # Report files only in one location
-    if only_in_sqfs:
-        error_count += len(only_in_sqfs)
-        _LOGGER.error(
-            "Files only in squashfs (%d): %s",
-            len(only_in_sqfs),
-            ", ".join(sorted(list(only_in_sqfs)[:5])) + ("..." if len(only_in_sqfs) > 5 else ""),
-        )
-
-    if only_in_dir:
-        error_count += len(only_in_dir)
-        _LOGGER.error(
-            "Files only in directory (%d): %s",
-            len(only_in_dir),
-            ", ".join(sorted(list(only_in_dir)[:5])) + ("..." if len(only_in_dir) > 5 else ""),
-        )
-
-    # Check common files for mismatches
-    mismatches = 0
-    for path in set(sqfs_files.keys()) & set(dir_files.keys()):
-        sqfs_meta = sqfs_files[path]
-        dir_meta = dir_files[path]
-
-        # Compare type and size
-        if sqfs_meta[0] != dir_meta[0]:
-            _LOGGER.error("Type mismatch for %s: squashfs=%s, directory=%s", path, sqfs_meta[0], dir_meta[0])
-            mismatches += 1
-        elif sqfs_meta[0] == "-" and sqfs_meta[1] != dir_meta[1]:
-            _LOGGER.error("Size mismatch for %s: squashfs=%s, directory=%s", path, sqfs_meta[1], dir_meta[1])
-            mismatches += 1
-
-    error_count += mismatches
-
-    # Debug info
-    _LOGGER.info("Found %d files in squashfs, %d files in directory", len(sqfs_files), len(dir_files))
-
-    if error_count == 0:
-        _LOGGER.info("✓ Contents match: %d files verified", len(sqfs_files))
-    else:
-        _LOGGER.error("✗ Contents mismatch: %d errors found", error_count)
-
     return error_count
 
 

--- a/bin/lib/squashfs.py
+++ b/bin/lib/squashfs.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Utilities for working with squashfs images."""
+
+import logging
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SquashfsEntry:
+    """Represents a parsed entry from unsquashfs -ll output."""
+
+    file_type: str  # 'd', 'l', '-', 'c', 'b', etc.
+    size: int  # File size in bytes (0 for non-regular files)
+    path: str  # Relative path without leading slash
+    target: Optional[str] = None  # Target for symlinks
+
+
+def parse_unsquashfs_line(line: str) -> Optional[SquashfsEntry]:
+    """Parse a single line from unsquashfs -ll output.
+
+    Returns SquashfsEntry with parsed data, or None if line cannot be parsed.
+    """
+    pattern = re.compile(
+        r"^(?P<permissions>[dlcbps-][rwxst-]{9})\s+"
+        r"(?P<owner_group>\S+)\s+"
+        r"(?P<size>\d+)\s+"
+        r"(?P<date>\d{4}-\d{2}-\d{2})\s+"
+        r"(?P<time>\d{2}:\d{2})"
+        r"(?:\s+(?P<path_part>.+?))?"
+        r"$"
+    )
+
+    match = pattern.match(line.strip())
+    if not match:
+        return None
+
+    groups = match.groupdict()
+
+    # No path means root directory - skip it
+    if not groups["path_part"]:
+        return None
+
+    file_type = groups["permissions"][0]
+
+    # Handle symlinks: "path -> target"
+    # Only split on ' -> ' if this is actually a symlink (type 'l')
+    target = None
+    path_part = groups["path_part"]
+    if file_type == "l" and " -> " in path_part:
+        path, target = path_part.split(" -> ", 1)
+    else:
+        path = path_part
+
+    # Remove leading slash for relative comparison
+    if path.startswith("/"):
+        path = path[1:]
+
+    if not path:  # Skip empty paths
+        return None
+
+    return SquashfsEntry(
+        file_type=file_type,
+        size=int(groups["size"]) if file_type == "-" else 0,
+        path=path,
+        target=target if target else None,
+    )
+
+
+def verify_squashfs_contents(img_path: Path, nfs_path: Path) -> int:
+    """Verify squashfs image contents match NFS directory. Returns error count."""
+    error_count = 0
+
+    try:
+        # Extract squashfs metadata without mounting
+        result = subprocess.run(
+            ["unsquashfs", "-ll", "-d", "", str(img_path)], capture_output=True, text=True, check=True
+        )
+        sqfs_output = result.stdout
+    except subprocess.CalledProcessError as e:
+        _LOGGER.error("Failed to read squashfs image %s: %s", img_path, e)
+        return 1
+    except FileNotFoundError:
+        _LOGGER.error("unsquashfs command not found - install squashfs-tools")
+        return 1
+
+    # Parse squashfs output to get file list
+    sqfs_files: Dict[str, Tuple[str, str]] = {}
+    for line in sqfs_output.split("\n"):
+        if not line.strip():
+            continue
+
+        # Skip known header lines from unsquashfs
+        if line.startswith("Parallel unsquashfs:") or line.startswith("Filesystem on"):
+            continue
+
+        parsed = parse_unsquashfs_line(line)
+        if parsed:
+            sqfs_files[parsed.path] = (parsed.file_type, str(parsed.size))
+        else:
+            # Fail on any line we can't parse
+            raise ValueError(f"Failed to parse unsquashfs output line: {line}")
+
+    # Build equivalent from directory filesystem
+    dir_files: Dict[str, Tuple[str, str]] = {}
+    if not nfs_path.exists():
+        _LOGGER.error("Directory does not exist: %s", nfs_path)
+        return 1
+
+    for item in nfs_path.rglob("*"):
+        rel_path = str(item.relative_to(nfs_path))
+
+        stat_result = item.lstat()
+
+        if item.is_symlink():
+            file_type = "l"
+            size = "0"
+        elif item.is_dir():
+            file_type = "d"
+            size = "0"
+        elif item.is_file():
+            file_type = "-"
+            size = str(stat_result.st_size)
+        else:
+            raise ValueError(f"Unknown file type for {item}")
+
+        dir_files[rel_path] = (file_type, size)
+
+    # Compare file sets
+    only_in_sqfs = set(sqfs_files.keys()) - set(dir_files.keys())
+    only_in_dir = set(dir_files.keys()) - set(sqfs_files.keys())
+
+    # Report files only in one location
+    if only_in_sqfs:
+        error_count += len(only_in_sqfs)
+        _LOGGER.error(
+            "Files only in squashfs (%d): %s",
+            len(only_in_sqfs),
+            ", ".join(sorted(list(only_in_sqfs)[:5])) + ("..." if len(only_in_sqfs) > 5 else ""),
+        )
+
+    if only_in_dir:
+        error_count += len(only_in_dir)
+        _LOGGER.error(
+            "Files only in directory (%d): %s",
+            len(only_in_dir),
+            ", ".join(sorted(list(only_in_dir)[:5])) + ("..." if len(only_in_dir) > 5 else ""),
+        )
+
+    # Check common files for mismatches
+    mismatches = 0
+    for path in set(sqfs_files.keys()) & set(dir_files.keys()):
+        sqfs_meta = sqfs_files[path]
+        dir_meta = dir_files[path]
+
+        # Compare type and size
+        if sqfs_meta[0] != dir_meta[0]:
+            _LOGGER.error("Type mismatch for %s: squashfs=%s, directory=%s", path, sqfs_meta[0], dir_meta[0])
+            mismatches += 1
+        elif sqfs_meta[0] == "-" and sqfs_meta[1] != dir_meta[1]:
+            _LOGGER.error("Size mismatch for %s: squashfs=%s, directory=%s", path, sqfs_meta[1], dir_meta[1])
+            mismatches += 1
+
+    error_count += mismatches
+
+    # Debug info
+    _LOGGER.info("Found %d files in squashfs, %d files in directory", len(sqfs_files), len(dir_files))
+
+    if error_count == 0:
+        _LOGGER.info("✓ Contents match: %d files verified", len(sqfs_files))
+    else:
+        _LOGGER.error("✗ Contents mismatch: %d errors found", error_count)
+
+    return error_count

--- a/bin/test/test_squashfs.py
+++ b/bin/test/test_squashfs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
+"""Tests for squashfs utilities."""
 
-
-from lib.ce_install import SquashfsEntry, parse_unsquashfs_line
+from lib.squashfs import SquashfsEntry, parse_unsquashfs_line
 
 
 class TestUnsquashfsParser:

--- a/bin/test/test_unsquashfs_parser.py
+++ b/bin/test/test_unsquashfs_parser.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+
+
+from lib.ce_install import SquashfsEntry, parse_unsquashfs_line
+
+
+class TestUnsquashfsParser:
+    def test_parse_regular_file(self):
+        """Test parsing a regular file without spaces."""
+        line = "-rw-r--r-- root/root      1234 2021-03-12 09:29 /usr/bin/gcc"
+        result = parse_unsquashfs_line(line)
+        assert result == SquashfsEntry(file_type="-", size=1234, path="usr/bin/gcc")
+
+    def test_parse_regular_file_with_spaces(self):
+        """Test parsing a regular file with spaces in the name."""
+        line = "-rw-r--r-- root/root       628 2021-03-12 09:29 /debugger/10.1.1/dep/lib/python3.9/site-packages/setuptools/command/launcher manifest.xml"
+        result = parse_unsquashfs_line(line)
+        assert result == SquashfsEntry(
+            file_type="-",
+            size=628,
+            path="debugger/10.1.1/dep/lib/python3.9/site-packages/setuptools/command/launcher manifest.xml",
+        )
+
+    def test_intel_compiler_case(self):
+        """Test the exact Intel compiler case that was failing."""
+        line = "-rw-r--r-- root/root               628 2021-03-12 09:29 /debugger/10.1.1/dep/lib/python3.9/site-packages/setuptools/command/launcher manifest.xml"
+        result = parse_unsquashfs_line(line)
+        assert result == SquashfsEntry(
+            file_type="-",
+            size=628,
+            path="debugger/10.1.1/dep/lib/python3.9/site-packages/setuptools/command/launcher manifest.xml",
+        )
+
+    def test_parse_directory(self):
+        """Test parsing a directory."""
+        line = "drwxr-xr-x root/root         0 2021-03-12 09:29 /usr/include"
+        result = parse_unsquashfs_line(line)
+        assert result == SquashfsEntry(file_type="d", size=0, path="usr/include")
+
+    def test_parse_directory_with_spaces(self):
+        """Test parsing a directory with spaces."""
+        line = "drwxr-xr-x root/root         0 2021-03-12 09:29 /my special directory/with spaces"
+        result = parse_unsquashfs_line(line)
+        assert result == SquashfsEntry(file_type="d", size=0, path="my special directory/with spaces")
+
+    def test_parse_symlink(self):
+        """Test parsing a symlink without spaces."""
+        line = "lrwxrwxrwx root/root         0 2021-03-12 09:29 /usr/bin/g++ -> /usr/bin/gcc"
+        result = parse_unsquashfs_line(line)
+        assert result == SquashfsEntry(file_type="l", size=0, path="usr/bin/g++", target="/usr/bin/gcc")
+
+    def test_parse_symlink_with_spaces_in_source(self):
+        """Test parsing a symlink with spaces in the source path."""
+        line = "lrwxrwxrwx root/root         0 2021-03-12 09:29 /my link with spaces -> /target"
+        result = parse_unsquashfs_line(line)
+        assert result == SquashfsEntry(file_type="l", size=0, path="my link with spaces", target="/target")
+
+    def test_parse_symlink_with_spaces_in_target(self):
+        """Test parsing a symlink with spaces in the target path."""
+        line = "lrwxrwxrwx root/root         0 2021-03-12 09:29 /mylink -> /target with spaces"
+        result = parse_unsquashfs_line(line)
+        assert result == SquashfsEntry(file_type="l", size=0, path="mylink", target="/target with spaces")
+
+    def test_parse_symlink_with_spaces_in_both(self):
+        """Test parsing a symlink with spaces in both source and target."""
+        line = "lrwxrwxrwx root/root         0 2021-03-12 09:29 /my link file -> /my target file"
+        result = parse_unsquashfs_line(line)
+        assert result == SquashfsEntry(file_type="l", size=0, path="my link file", target="/my target file")
+
+    def test_parse_root_directory(self):
+        """Test parsing the root directory line (no path)."""
+        line = "drwxr-xr-x root/root         0 2021-03-12 09:29"
+        result = parse_unsquashfs_line(line)
+        assert result is None  # Root directory should be skipped
+
+    def test_parse_executable_file(self):
+        """Test parsing an executable file."""
+        line = "-rwxr-xr-x root/root     12345 2021-03-12 09:29 /bin/bash"
+        result = parse_unsquashfs_line(line)
+        assert result == SquashfsEntry(file_type="-", size=12345, path="bin/bash")
+
+    def test_parse_setuid_file(self):
+        """Test parsing a file with setuid bit."""
+        line = "-rwsr-xr-x root/root      5678 2021-03-12 09:29 /usr/bin/sudo"
+        result = parse_unsquashfs_line(line)
+        assert result == SquashfsEntry(file_type="-", size=5678, path="usr/bin/sudo")
+
+    def test_parse_sticky_bit_directory(self):
+        """Test parsing a directory with sticky bit."""
+        line = "drwxrwxrwt root/root         0 2021-03-12 09:29 /tmp"
+        result = parse_unsquashfs_line(line)
+        assert result == SquashfsEntry(file_type="d", size=0, path="tmp")
+
+    def test_parse_block_device(self):
+        """Test parsing a block device (if present in squashfs)."""
+        line = "brw-r--r-- root/root       123 2021-03-12 09:29 /dev/sda"
+        result = parse_unsquashfs_line(line)
+        assert result == SquashfsEntry(
+            file_type="b",
+            size=0,  # Block devices get size 0
+            path="dev/sda",
+        )
+
+    def test_parse_character_device(self):
+        """Test parsing a character device (if present in squashfs)."""
+        line = "crw-r--r-- root/root       456 2021-03-12 09:29 /dev/null"
+        result = parse_unsquashfs_line(line)
+        assert result == SquashfsEntry(
+            file_type="c",
+            size=0,  # Character devices get size 0
+            path="dev/null",
+        )
+
+    def test_invalid_line(self):
+        """Test that invalid lines return None."""
+        assert parse_unsquashfs_line("invalid line") is None
+        assert parse_unsquashfs_line("") is None
+        assert parse_unsquashfs_line("   ") is None
+
+    def test_large_file_size(self):
+        """Test parsing files with large sizes."""
+        line = "-rw-r--r-- root/root 1234567890 2021-03-12 09:29 /huge/file.dat"
+        result = parse_unsquashfs_line(line)
+        assert result == SquashfsEntry(file_type="-", size=1234567890, path="huge/file.dat")
+
+    def test_arrow_in_filename(self):
+        """Test parsing a regular file with ' -> ' in its name (edge case)."""
+        # This is tricky - a file actually named "file -> something.txt"
+        # In unsquashfs output, this would NOT be a symlink (note the file type is '-' not 'l')
+        line = "-rw-r--r-- root/root       100 2021-03-12 09:29 /weird/file -> not_a_link.txt"
+        result = parse_unsquashfs_line(line)
+        # Since file type is '-' not 'l', this should be treated as a filename with arrow
+        assert result == SquashfsEntry(file_type="-", size=100, path="weird/file -> not_a_link.txt")


### PR DESCRIPTION
## Summary
Fixes the squash-verify command that was failing on filenames containing spaces, particularly affecting Intel C++ compiler verification.

## Problem
The `ce_install squash-check --verify` command was failing with:
```
ValueError: Unexpected unsquashfs output format (7 parts): -rw-r--r-- root/root 628 2021-03-12 09:29 /debugger/10.1.1/dep/lib/python3.9/site-packages/setuptools/command/launcher manifest.xml
```

The parser was using simple string splitting which broke on filenames with spaces.

## Solution
1. **Implemented regex-based parsing** with named groups for clear, maintainable parsing
2. **Created `SquashfsEntry` dataclass** for type-safe representation of parsed entries
3. **Fixed symlink detection** to only treat ' -> ' as a separator when file type is 'l'
4. **Extracted squashfs utilities** to separate `lib/squashfs.py` module for better organization
5. **Added comprehensive tests** including specific test for the Intel compiler case

## Changes
- Created `lib/squashfs.py` module with all squashfs-related utilities
- Updated `ce_install.py` to import from the new module
- Added 18 unit tests covering various edge cases
- Tests include files/directories/symlinks with spaces, special permissions, and edge cases

## Testing
- All existing tests pass
- New test suite specifically validates the Intel compiler case that was failing
- Tested with various filename patterns including spaces and special characters