### PR TITLE
CEFS enabling change - don't mount if there's a symlink

### DIFF
--- a/mount-all-img.sh
+++ b/mount-all-img.sh
@@ -12,6 +12,8 @@ for img_file in "${IMG_DIR}"/**/*.img; do
   dst_path=${dst_path%.img}
   if mountpoint -q "$dst_path"; then
     echo "$dst_path is mounted already, skipping"
+  elif [ -L "$dst_path" ]; then
+    echo "$dst_path is a symlink, skipping"
   else
     mounts["$img_file"]="$dst_path"
   fi


### PR DESCRIPTION
If the destination is a symlink, assume it's a /cefs link and don't mount the squashfs image over it. Part of #1742 but harmless if we don't merge. None of our existing stuff is a symlink.

Tested locally by hacking the script to print out what it'd do.