### PR TITLE
Updates to service

### DIFF
--- a/init/compiler-explorer.service
+++ b/init/compiler-explorer.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Compiler Explorer
-After=remote-fs.target
+After=remote-fs.target systemd-logind.service network-online.target cloud-final.service
+Wants=network-online.target
+Requires=remote-fs.target
 
 [Service]
 Type=simple
@@ -8,8 +10,8 @@ User=root
 TimeoutStartSec=infinity
 WorkingDirectory=/infra
 ExecStart=/infra/init/start.sh
-StandardOutput=syslog
-StandardError=syslog
+StandardOutput=journal
+StandardError=journal
 SyslogIdentifier=compiler-explorer
 
 [Install]

--- a/init/compiler-explorer.service
+++ b/init/compiler-explorer.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Compiler Explorer
-After=remote-fs.target systemd-logind.service network-online.target cloud-final.service
+After=remote-fs.target systemd-logind.service network-online.target cloud-config.service
 Wants=network-online.target
 Requires=remote-fs.target
 


### PR DESCRIPTION
Based on an apparently rare cgroups issue, I went down the rabbit hole of
our service configuration. After lots of conversations with various Claudes:

- declare a bunch more dependencies, particularly `systemd-logind.service`
  which _might_ be the cause of our cgroups issue
- based on best practices, use journal logging

cgroups issue was everything starting up fine, but `nsjail` complaining about
not being able to set `+cpu`. Manually running the `cgcreate` command again
"fixed" it.


Tested in staging and looks good: logs turned up and MAYBE this fixes what we saw.