### PR TITLE
Add Pydantic-based configuration system

### DIFF
--- a/bin/lib/config.py
+++ b/bin/lib/config.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Configuration management for CE infrastructure.
+
+Handles loading configuration from YAML files to control behavior
+of ce_install and other tools.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from lib.config_safe_loader import ConfigSafeLoader
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SquashfsConfig(BaseModel):
+    """Configuration for squashfs creation and management."""
+
+    enabled: bool = True
+    image_dir: Path = Path("/efs/squash-images")
+    compression: str = "zstd"
+    compression_level: int = 19
+    mksquashfs_path: str = "/usr/bin/mksquashfs"
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+
+class CefsConfig(BaseModel):
+    """Configuration for CEFS (Compiler Explorer FileSystem) v2."""
+
+    enabled: bool = False
+    mount_point: str = "/cefs"
+    image_dir: Path = Path("/efs/cefs-images")
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+
+class Config(BaseModel):
+    """Main CE infrastructure configuration."""
+
+    squashfs: SquashfsConfig = SquashfsConfig()
+    cefs: CefsConfig = CefsConfig()
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    @classmethod
+    def load(cls, config_path: Path) -> Config:
+        """Load configuration from config path.
+
+        Args:
+            config_path: Path to the configuration file (e.g., /opt/compiler-explorer/config.yaml)
+
+        Returns:
+            Config instance with loaded values, or defaults if file doesn't exist
+
+        Raises:
+            ValidationError: If config contains invalid values or unknown keys
+        """
+        if not config_path.exists():
+            _LOGGER.debug("Config file %s does not exist, using defaults", config_path)
+            return cls()
+
+        try:
+            with config_path.open(encoding="utf-8") as config_file:
+                config_data = yaml.load(config_file, Loader=ConfigSafeLoader)
+
+            if config_data is None:
+                _LOGGER.warning("Config file %s is empty, using defaults", config_path)
+                return cls()
+
+            return cls.model_validate(config_data)
+
+        except ValidationError as e:
+            _LOGGER.error("Invalid config in %s: %s", config_path, e)
+            raise
+        except Exception as e:
+            _LOGGER.error("Failed to load config from %s: %s", config_path, e)
+            raise

--- a/bin/lib/installable/installable.py
+++ b/bin/lib/installable/installable.py
@@ -11,6 +11,7 @@ from functools import partial
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 
+from lib.config import SquashfsConfig
 from lib.fortran_library_builder import FortranLibraryBuilder
 from lib.installation_context import InstallationContext, is_windows
 from lib.library_build_config import LibraryBuildConfig
@@ -313,7 +314,7 @@ class Installable:
             return rbuilder.makebuild(buildfor)
         raise RuntimeError(f"Unsupported build_type ${self.build_config.build_type}")
 
-    def squash_to(self, destination_image: Path):
+    def squash_to(self, destination_image: Path, squashfs_config: SquashfsConfig):
         destination_image.parent.mkdir(parents=True, exist_ok=True)
         source_folder = self.install_context.destination / self.install_path
         temp_image = destination_image.with_suffix(".tmp")
@@ -321,15 +322,15 @@ class Installable:
         self._logger.info("Squashing %s...", source_folder)
         self.install_context.check_call(
             [
-                "/usr/bin/mksquashfs",
+                squashfs_config.mksquashfs_path,
                 str(source_folder),
                 str(temp_image),
                 "-all-root",
                 "-progress",
                 "-comp",
-                "zstd",
+                squashfs_config.compression,
                 "-Xcompression-level",
-                "19",
+                str(squashfs_config.compression_level),
             ]
         )
         temp_image.replace(destination_image)

--- a/bin/test/config_test.py
+++ b/bin/test/config_test.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Tests for config module."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+from lib.config import CefsConfig, Config, SquashfsConfig
+from pydantic import ValidationError
+
+
+class TestConfig(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.config_file = self.temp_dir / "config.yaml"
+
+    def tearDown(self):
+        if self.config_file.exists():
+            self.config_file.unlink()
+        if self.temp_dir.exists():
+            self.temp_dir.rmdir()
+
+    def test_default_config(self):
+        """Test loading config when no config file exists."""
+        config = Config.load(self.config_file)
+
+        # Check squashfs defaults
+        self.assertTrue(config.squashfs.enabled)
+        self.assertEqual(config.squashfs.image_dir, Path("/efs/squash-images"))
+        self.assertEqual(config.squashfs.compression, "zstd")
+        self.assertEqual(config.squashfs.compression_level, 19)
+        self.assertEqual(config.squashfs.mksquashfs_path, "/usr/bin/mksquashfs")
+
+        # Check cefs defaults
+        self.assertFalse(config.cefs.enabled)
+        self.assertEqual(config.cefs.mount_point, "/cefs")
+        self.assertEqual(config.cefs.image_dir, Path("/efs/cefs-images"))
+
+    def test_empty_config_file(self):
+        """Test loading empty config file."""
+        self.config_file.write_text("")
+        config = Config.load(self.config_file)
+
+        # Should use defaults
+        self.assertTrue(config.squashfs.enabled)
+        self.assertFalse(config.cefs.enabled)
+
+    def test_partial_config(self):
+        """Test loading config with only some values specified."""
+        config_data = {"squashfs": {"enabled": True, "compression_level": 15}}
+
+        with self.config_file.open("w", encoding="utf-8") as f:
+            yaml.dump(config_data, f)
+
+        config = Config.load(self.config_file)
+
+        # Check specified values
+        self.assertTrue(config.squashfs.enabled)
+        self.assertEqual(config.squashfs.compression_level, 15)
+
+        # Check defaults are preserved
+        self.assertEqual(config.squashfs.compression, "zstd")
+        self.assertEqual(config.squashfs.image_dir, Path("/efs/squash-images"))
+        self.assertFalse(config.cefs.enabled)
+
+    def test_full_config(self):
+        """Test loading complete config file."""
+        config_data = {
+            "squashfs": {
+                "enabled": True,
+                "image_dir": "/custom/squash-images",
+                "compression": "gzip",
+                "compression_level": 9,
+                "mksquashfs_path": "/custom/bin/mksquashfs",
+            },
+            "cefs": {
+                "enabled": True,
+                "mount_point": "/custom/cefs",
+                "image_dir": "/custom/cefs-images",
+            },
+        }
+
+        with self.config_file.open("w", encoding="utf-8") as f:
+            yaml.dump(config_data, f)
+
+        config = Config.load(self.config_file)
+
+        # Check squashfs values
+        self.assertTrue(config.squashfs.enabled)
+        self.assertEqual(config.squashfs.image_dir, Path("/custom/squash-images"))
+        self.assertEqual(config.squashfs.compression, "gzip")
+        self.assertEqual(config.squashfs.compression_level, 9)
+        self.assertEqual(config.squashfs.mksquashfs_path, "/custom/bin/mksquashfs")
+
+        # Check cefs values
+        self.assertTrue(config.cefs.enabled)
+        self.assertEqual(config.cefs.mount_point, "/custom/cefs")
+        self.assertEqual(config.cefs.image_dir, Path("/custom/cefs-images"))
+
+    def test_unknown_keys_rejected(self):
+        """Test that unknown keys in config are rejected."""
+        config_data = {"squashfs": {"enabled": True, "unknown_key": "should_fail"}}
+
+        with self.config_file.open("w", encoding="utf-8") as f:
+            yaml.dump(config_data, f)
+
+        with self.assertRaises(ValidationError) as cm:
+            Config.load(self.config_file)
+
+        error_str = str(cm.exception)
+        self.assertIn("unknown_key", error_str)
+        self.assertIn("Extra inputs are not permitted", error_str)
+
+    def test_unknown_top_level_keys_rejected(self):
+        """Test that unknown top-level keys are rejected."""
+        config_data = {
+            "squashfs": {"enabled": True},
+            "unknown_section": {"some": "value"},
+        }
+
+        with self.config_file.open("w", encoding="utf-8") as f:
+            yaml.dump(config_data, f)
+
+        with self.assertRaises(ValidationError) as cm:
+            Config.load(self.config_file)
+
+        error_str = str(cm.exception)
+        self.assertIn("unknown_section", error_str)
+
+    def test_invalid_types(self):
+        """Test that invalid types are rejected."""
+        config_data = {"squashfs": {"enabled": "not_a_boolean", "compression_level": "not_an_int"}}
+
+        with self.config_file.open("w", encoding="utf-8") as f:
+            yaml.dump(config_data, f)
+
+        with self.assertRaises(ValidationError) as cm:
+            Config.load(self.config_file)
+
+        error_str = str(cm.exception)
+        self.assertIn("enabled", error_str)
+        self.assertIn("compression_level", error_str)
+
+    def test_path_conversion(self):
+        """Test that strings are properly converted to Path objects."""
+        config_data = {
+            "squashfs": {"image_dir": "/string/path"},
+            "cefs": {"image_dir": "/another/string/path"},
+        }
+
+        with self.config_file.open("w", encoding="utf-8") as f:
+            yaml.dump(config_data, f)
+
+        config = Config.load(self.config_file)
+
+        self.assertIsInstance(config.squashfs.image_dir, Path)
+        self.assertEqual(config.squashfs.image_dir, Path("/string/path"))
+        self.assertIsInstance(config.cefs.image_dir, Path)
+        self.assertEqual(config.cefs.image_dir, Path("/another/string/path"))
+
+    def test_config_immutability(self):
+        """Test that config objects are immutable."""
+        config = Config.load(self.config_file)
+
+        with self.assertRaises(ValidationError):
+            config.squashfs.enabled = True
+
+        with self.assertRaises(ValidationError):
+            config.cefs.enabled = True
+
+
+class TestSquashfsConfig(unittest.TestCase):
+    def test_direct_construction(self):
+        """Test creating SquashfsConfig directly."""
+        config = SquashfsConfig(enabled=True, compression="gzip", compression_level=9)
+
+        self.assertTrue(config.enabled)
+        self.assertEqual(config.compression, "gzip")
+        self.assertEqual(config.compression_level, 9)
+        # Defaults should be preserved
+        self.assertEqual(config.image_dir, Path("/efs/squash-images"))
+        self.assertEqual(config.mksquashfs_path, "/usr/bin/mksquashfs")
+
+    def test_validation_error_on_unknown_field(self):
+        """Test that unknown fields raise ValidationError."""
+        with self.assertRaises(ValidationError):
+            SquashfsConfig(unknown_field="value")
+
+
+class TestCefsConfig(unittest.TestCase):
+    def test_direct_construction(self):
+        """Test creating CefsConfig directly."""
+        config = CefsConfig(enabled=True, mount_point="/custom/mount")
+
+        self.assertTrue(config.enabled)
+        self.assertEqual(config.mount_point, "/custom/mount")
+        # Default should be preserved
+        self.assertEqual(config.image_dir, Path("/efs/cefs-images"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "click>=8.1.3",
     "Jinja2>=3.1.6",
     "paramiko>=3.4.0",
+    "pydantic>=2.0.0",
     "python-dateutil>=2.8.2",
     "requests>=2.32.2",
     "PyYAML>=6.0",


### PR DESCRIPTION
Introduces flexible configuration system using Pydantic for squashfs parameters and future CEFS configuration.

## Changes
- Add `Config`, `SquashfsConfig`, and `CefsConfig` classes with validation
- Replace hardcoded squashfs parameters in CLI commands  
- Config loaded from `/opt/compiler-explorer/config.yaml`
- Add `squashfs.enabled` check to prevent squashing when disabled
- Comprehensive test suite (12 tests)
- Maintains backward compatibility

Prepares infrastructure for CEFS v2 work and improves configurability.