### PR TITLE
Fix compiler routing issues for deployments

### DIFF
--- a/bin/lib/compiler_routing.py
+++ b/bin/lib/compiler_routing.py
@@ -110,6 +110,12 @@ def fetch_discovery_compilers(environment: str, version: Optional[str] = None) -
     Raises:
         CompilerRoutingError: If API cannot be fetched or parsed
     """
+    # aarch64 environments are execution-only and don't have their own compilers
+    # They receive work from other environments, so skip compiler fetch
+    if environment in ["aarch64prod", "aarch64staging"]:
+        LOGGER.info(f"Skipping compiler fetch for {environment} - execution-only environment without compilers")
+        return {}
+
     try:
         # Map environment to API URL with fields parameter to reduce bandwidth
         if environment == "prod":


### PR DESCRIPTION
- Add retry logic with exponential backoff for 503 errors when fetching compiler lists
- Skip compiler fetch for aarch64prod/aarch64staging execution-only environments
- Improve error handling to prevent deployment failures

These changes address:
1. Transient 503 errors during staging deployments
2. Incorrect attempts to fetch compilers for aarch64 environments that don't have any

🤖 Generated with [Claude Code](https://claude.ai/code)