### PR TITLE
Packer and runner update

### DIFF
--- a/packer/builder.pkr.hcl
+++ b/packer/builder.pkr.hcl
@@ -22,10 +22,10 @@ variable "MY_SECRET_KEY" {
   default = ""
 }
 
-data "amazon-ami" "focal" {
+data "amazon-ami" "ubuntu" {
   access_key = "${var.MY_ACCESS_KEY}"
   filters = {
-    name                = "ubuntu/images/*ubuntu-focal-20.04-amd64-server-*"
+    name                = "ubuntu-minimal/images/*ubuntu-*-22.04-amd64-minimal-*"
     root-device-type    = "ebs"
     virtualization-type = "hvm"
   }
@@ -37,22 +37,22 @@ data "amazon-ami" "focal" {
 
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
-source "amazon-ebs" "focal" {
+source "amazon-ebs" "ubuntu" {
   access_key = "${var.MY_ACCESS_KEY}"
   ami_block_device_mappings {
     delete_on_termination = true
     device_name           = "/dev/sda1"
-    volume_size           = 6
+    volume_size           = 16
     volume_type           = "gp2"
   }
-  ami_name                    = "compiler-explorer builder packer 20.04 @ ${local.timestamp}"
+  ami_name                    = "compiler-explorer builder packer @ ${local.timestamp}"
   associate_public_ip_address = true
   iam_instance_profile        = "XaniaBlog"
   instance_type               = "c5.xlarge"
   launch_block_device_mappings {
     delete_on_termination = true
     device_name           = "/dev/sda1"
-    volume_size           = 24
+    volume_size           = 8
     volume_type           = "gp2"
   }
   region = "us-east-1"
@@ -61,7 +61,7 @@ source "amazon-ebs" "focal" {
   }
   secret_key        = "${var.MY_SECRET_KEY}"
   security_group_id = "sg-f53f9f80"
-  source_ami        = "${data.amazon-ami.focal.id}"
+  source_ami        = "${data.amazon-ami.ubuntu.id}"
   ssh_username      = "ubuntu"
   subnet_id         = "subnet-1df1e135"
   tags = {
@@ -71,7 +71,7 @@ source "amazon-ebs" "focal" {
 }
 
 build {
-  sources = ["source.amazon-ebs.focal"]
+  sources = ["source.amazon-ebs.ubuntu"]
 
   provisioner "file" {
     destination = "/home/ubuntu/"
@@ -83,7 +83,8 @@ build {
     inline = [
       "set -euo pipefail",
       "cloud-init status --wait",
-      "export DEBIAN_FRONTEND=noninteractive", "cp /home/ubuntu/packer/known_hosts /home/ubuntu/.ssh/",
+      "export DEBIAN_FRONTEND=noninteractive", "mkdir -p /root/.ssh",
+      "cp /home/ubuntu/packer/known_hosts /root/.ssh/", "cp /home/ubuntu/packer/known_hosts /home/ubuntu/.ssh/",
       "rm -rf /home/ubuntu/packer", "apt-get -y update", "apt-get -y install git",
       "git clone -b ${var.BRANCH} https://github.com/compiler-explorer/infra.git /infra", "cd /infra",
       "env PACKER_SETUP=yes bash setup-builder.sh 2>&1 | tee /tmp/setup.log"

--- a/packer/builder.pkr.hcl
+++ b/packer/builder.pkr.hcl
@@ -39,12 +39,6 @@ locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
 source "amazon-ebs" "ubuntu" {
   access_key = "${var.MY_ACCESS_KEY}"
-  ami_block_device_mappings {
-    delete_on_termination = true
-    device_name           = "/dev/sda1"
-    volume_size           = 16
-    volume_type           = "gp2"
-  }
   ami_name                    = "compiler-explorer builder packer @ ${local.timestamp}"
   associate_public_ip_address = true
   iam_instance_profile        = "XaniaBlog"

--- a/setup-builder.sh
+++ b/setup-builder.sh
@@ -9,7 +9,7 @@ env EXTRA_NFS_ARGS="" "${DIR}/setup-common.sh"
 wget -qO- https://get.docker.com/ | sh
 usermod -aG docker ubuntu
 
-apt -y install mosh fish cronic subversion upx gdb
+apt -y install mosh fish cronic subversion upx gdb cron
 chsh ubuntu -s /usr/bin/fish
 
 aws ssm get-parameter --name /admin/ce_private_key | jq -r .Parameter.Value >/home/ubuntu/.ssh/id_rsa

--- a/setup-builder.sh
+++ b/setup-builder.sh
@@ -9,7 +9,7 @@ env EXTRA_NFS_ARGS="" "${DIR}/setup-common.sh"
 wget -qO- https://get.docker.com/ | sh
 usermod -aG docker ubuntu
 
-apt -y install mosh fish cronic subversion upx gdb cron
+apt -y install mosh fish cronic subversion upx gdb cron make
 chsh ubuntu -s /usr/bin/fish
 
 aws ssm get-parameter --name /admin/ce_private_key | jq -r .Parameter.Value >/home/ubuntu/.ssh/id_rsa

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -1,7 +1,7 @@
 locals {
-  runner_image_id        = "ami-0a1472d1b7c289619"
+  runner_image_id        = "ami-0c46636e49e134607"
   conan_image_id         = "ami-0b41dc7a318b530bd"
-  builder_image_id       = "ami-0ef4921e9d82c03fb"
+  builder_image_id       = "ami-00f7a50c24eddfbfb"
   smbserver_image_id     = "ami-01e7c7963a9c4755d"
   smbtestserver_image_id = "ami-0284c821376912369"
   admin_subnet           = module.ce_network.subnet["1a"].id


### PR DESCRIPTION
- builder 22.04 (some minor changes needed to get it working)
- builder packer updated to be less rubbish. disk space comes from the ec2.tf, so removed confusing differences there (checked before and after)
- runner using latest ami

both tested:
- builder ran some of `admin-daily-builds.sh` (I edited to get just the c++ libraries and watched it)
- runner successfully discovered compilers