### PR TITLE
Startup changes

### DIFF
--- a/grafana/make-config.sh
+++ b/grafana/make-config.sh
@@ -2,10 +2,12 @@
 
 set -ex
 
-ENV=$(cloud-init query userdata)
-ENV=${ENV:-prod}
-if [ "$ENV" = "envbeta" ]; then
-    ENV="beta"
+METADATA_TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+ENV=$(curl -s -H "X-aws-ec2-metadata-token: $METADATA_TOKEN" http://169.254.169.254/latest/meta-data/tags/instance/Environment)
+
+if [ -z "${ENV}" ]; then
+    echo "Environment not set!!"
+    exit 1
 fi
 
 HOSTNAME=$(hostname)

--- a/start-support.sh
+++ b/start-support.sh
@@ -4,16 +4,18 @@
 
 SKIP_SQUASH=0
 CE_USER=ce
-ENV=$(cloud-init query userdata)
-ENV=${ENV:-prod}
-if [ "$ENV" = "envbeta" ]; then
-    ENV="beta"
+
+METADATA_TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+ENV=$(curl -s -H "X-aws-ec2-metadata-token: $METADATA_TOKEN" http://169.254.169.254/latest/meta-data/tags/instance/Environment)
+if [ -z "${ENV}" ]; then
+    echo "Environment not set!!"
+    exit 1
 fi
+echo Running in environment "${ENV}"
 
 DEPLOY_DIR=${PWD}/.deploy
 COMPILERS_FILE=$DEPLOY_DIR/discovered-compilers.json
 
-echo Running in environment "${ENV}"
 # shellcheck disable=SC1090
 source "${PWD}/site-${ENV}.sh"
 

--- a/terraform/lc.tf
+++ b/terraform/lc.tf
@@ -20,76 +20,50 @@ locals {
 
   launch_templates = {
     beta = {
-      description   = "Beta launch template"
       image_id      = local.beta_image_id
       user_data     = local.beta_user_data
       instance_type = "m5.large"
-      iam_role      = "linux"
-      environment   = "Beta"
     }
     staging = {
-      description   = "Staging launch template"
       image_id      = local.staging_image_id
       user_data     = local.staging_user_data
       instance_type = "m5.large"
-      iam_role      = "linux"
-      environment   = "Staging"
     }
     prod = {
-      description   = "Production launch template"
       image_id      = local.image_id
       user_data     = local.prod_user_data
       instance_type = "c6i.large"
-      iam_role      = "linux"
-      environment   = "Prod"
     }
     "prod-gpu" = {
-      description   = "Prod GPU launch template"
       image_id      = local.gpu_image_id
       user_data     = local.gpu_user_data
       instance_type = "g4dn.xlarge"
-      iam_role      = "linux"
-      environment   = "GPU"
     }
     aarch64prod = {
-      description   = "Prod Aarch64 launch template"
       image_id      = local.aarch64prod_image_id
       user_data     = local.aarch64prod_user_data
       instance_type = "c7g.xlarge"
-      iam_role      = "linux"
-      environment   = "AARCH64prod"
     }
     aarch64staging = {
-      description   = "Staging Aarch64 launch template"
       image_id      = local.aarch64staging_image_id
       user_data     = local.aarch64staging_user_data
       instance_type = "c7g.xlarge"
-      iam_role      = "linux"
-      environment   = "AARCH64staging"
     }
+    // Windows machines - ensure the key starts with "win"
     wintest = {
-      description   = "WinTest launch template"
       image_id      = local.wintest_image_id
       user_data     = local.wintest_user_data
       instance_type = "c5ad.large"
-      iam_role      = "windows"
-      environment   = "Wintest"
     }
     winstaging = {
-      description   = "WinStaging launch template"
       image_id      = local.winstaging_image_id
       user_data     = local.winstaging_user_data
       instance_type = "m6i.large"
-      iam_role      = "windows"
-      environment   = "Winstaging"
     }
     winprod = {
-      description   = "WinProd launch template"
       image_id      = local.winprod_image_id
       user_data     = local.winprod_user_data
       instance_type = "m6i.large"
-      iam_role      = "windows"
-      environment   = "Winprod"
     }
   }
 }
@@ -98,11 +72,11 @@ resource "aws_launch_template" "ce" {
   for_each = local.launch_templates
 
   name          = "ce-${each.key}"
-  description   = each.value.description
+  description   = "${title(each.key)} launch template"
   ebs_optimized = true
 
   iam_instance_profile {
-    arn = each.value.iam_role == "windows" ? aws_iam_instance_profile.CompilerExplorerWindowsRole.arn : aws_iam_instance_profile.CompilerExplorerRole.arn
+    arn = startswith(each.key, "win") ? aws_iam_instance_profile.CompilerExplorerWindowsRole.arn : aws_iam_instance_profile.CompilerExplorerRole.arn
   }
 
   image_id               = each.value.image_id
@@ -110,23 +84,10 @@ resource "aws_launch_template" "ce" {
   key_name               = "mattgodbolt"
   vpc_security_group_ids = [aws_security_group.CompilerExplorer.id]
   instance_type          = each.value.instance_type
-
-  tag_specifications {
-    resource_type = "volume"
-
-    tags = {
-      Site        = "CompilerExplorer"
-      Environment = each.value.environment
-    }
-  }
-
-  tag_specifications {
-    resource_type = "instance"
-
-    tags = {
-      Site        = "CompilerExplorer"
-      Environment = each.value.environment
-      Name        = each.value.environment
-    }
+  metadata_options {
+    # once Windows has been updated to use Tokens...
+    # http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+    instance_metadata_tags      = "enabled"
   }
 }

--- a/terraform/modules/blue_green/main.tf
+++ b/terraform/modules/blue_green/main.tf
@@ -109,7 +109,7 @@ resource "aws_autoscaling_group" "color" {
 
   tag {
     key                 = "Name"
-    value               = "CompilerExplorer-${var.environment}-${each.value}"
+    value               = "ce-${var.environment}-${each.value}"
     propagate_at_launch = true
   }
 }

--- a/terraform/windows-blue-green.tf
+++ b/terraform/windows-blue-green.tf
@@ -1,5 +1,7 @@
 # Blue-Green deployment infrastructure for Windows environments
 # Uses the blue_green module to create matching blue and green infrastructure
+# NB the "environment" here sets the environment that's found by the startup
+# scripts and configured the CE environment etc
 
 # Windows Test Environment
 module "wintest_blue_green" {


### PR DESCRIPTION
- use consistent "v2" approach to getting metadata
- use instance tags for "environment"
- remove tags in the LC that were being overwritten in the blue-green
- blue-green "environment" now controls all the things

windows stuff _untested_ but linux tested in staging and beta.

Will merge and then tweak until windows is happy, then roll out across the fleet.

then finally can remove user data