### PR TITLE
Update dex2oat with new versions

### DIFF
--- a/bin/yaml/android-java.yaml
+++ b/bin/yaml/android-java.yaml
@@ -43,6 +43,9 @@ compilers:
       after_stage_script:
         - "{{yaml_dir}}/android-java/create_boot_images.sh"
       targets:
+        - "36.0"
+        - "35.14"
+        - "35.13"
         - "35.11"
         - "35.10"
         - "35.9"


### PR DESCRIPTION
This adds 35.13, 35.14, and android16.