### PR TITLE
Remove premature directory creation in installer classes

### DIFF
--- a/bin/lib/installable/archives.py
+++ b/bin/lib/installable/archives.py
@@ -87,11 +87,6 @@ class S3TarballInstallable(Installable):
         super().install()
         with self.install_context.new_staging_dir() as staging:
             self.stage(staging)
-            if self.subdir:
-                self.install_context.make_subdir(self.subdir)
-            elif self.install_path:
-                self.install_context.make_subdir(self.install_path)
-
             self.install_context.move_from_staging(staging, self.untar_dir, self.install_path)
 
     def __repr__(self) -> str:

--- a/bin/lib/installable/edg.py
+++ b/bin/lib/installable/edg.py
@@ -241,7 +241,6 @@ class EdgCompilerInstallable(NonFreeS3TarballInstallable):
         super().install()
         with self.install_context.new_staging_dir() as staging:
             self.stage(staging)
-            self.install_context.make_subdir(self.install_path)
             self.install_context.move_from_staging(staging, self.untar_dir, self.install_path)
 
     def __repr__(self) -> str:

--- a/bin/lib/installable/git.py
+++ b/bin/lib/installable/git.py
@@ -211,8 +211,6 @@ class GitHubInstallable(Installable):
         super().install()
         with self.install_context.new_staging_dir() as staging:
             self.stage(staging)
-            if self.subdir:
-                self.install_context.make_subdir(self.subdir)
             self.install_context.move_from_staging(
                 staging, self.untar_dir if self.method == "archive" else self.install_path, self.install_path
             )


### PR DESCRIPTION
Remove make_subdir() calls that create empty target directories before move_from_staging(). This prevents empty .bak directories in CEFS installations and eliminates "exists but is empty; deleting it" messages in traditional installations.

🤖 Generated with [Claude Code](https://claude.ai/code)