### PR TITLE
Enable CPU accounting - cgroup fix

### DIFF
--- a/init/compiler-explorer.service
+++ b/init/compiler-explorer.service
@@ -16,6 +16,9 @@ WorkingDirectory=/infra
 ExecStart=/infra/init/start.sh
 StandardOutput=journal
 StandardError=journal
+# Keep CPU controller enabled during daemon-reload to prevent cgroup setup race - see #1761
+CPUAccounting=yes
+CPUQuota=100%
 
 [Install]
 WantedBy=multi-user.target

--- a/start-support.sh
+++ b/start-support.sh
@@ -126,6 +126,9 @@ setup_cgroups() {
     # Debugging a weird apparent race condition at boot that means we don't get the "cpu" delegation
     # despite the cgcreates below all succeeding.
     # See https://github.com/compiler-explorer/infra/issues/1761
+    # TODO(mattgodbolt) 2025-08-20 we should no longer need this or log_cgroups. Check for any
+    # times we see the "CPU controller missing" message and after a few weeks if no problems,
+    # consider removing this complexity.
     echo "Current cgroup.subtree_control: $(cat /sys/fs/cgroup/cgroup.subtree_control)"
     if ! grep -q cpu /sys/fs/cgroup/cgroup.subtree_control; then
         echo "CPU controller missing, adding it"
@@ -145,21 +148,6 @@ setup_cgroups() {
     ######################
     # Debugging, again see above
     log_cgroups
-    # Disabled for now as it upsets the runner
-    # (
-    #     set +x
-    #     while true; do
-    #         if ! grep -q cpu /sys/fs/cgroup/cgroup.subtree_control; then
-    #             echo "ALERT: CPU controller disappeared!"
-    #             # Log what's running at the time
-    #             ps aux --sort=-start_time | head -20
-    #             log_cgroups
-    #             echo "Re-adding cpu controller"
-    #             echo "+cpu" > /sys/fs/cgroup/cgroup.subtree_control
-    #         fi
-    #         sleep 5
-    #     done
-    # ) &
     ######################
 }
 


### PR DESCRIPTION
There's a window during startup where, if we haven't started using the cgroup controller with "cpu" in it, systemd may reload its configuration and determine that nothing needs it, taking it away from us. Subsequent `nsjail`s will fail with error 255.

Seemingly once `nsjail` has run at all, the `cgroup`s (even though not in use) make the CPU set "busy" (we can't remove cpu from `/sys/fs/cgroup/cgroup.subtree_control` gettin EBUSY). Presumably this is what "protects" running instances from losing cpu control once we've booted up. Systemd reloads but can't remove the (apparently unused) cpu cgroup control.

The correct fix is to make the compiler explorer service declare that it needs CPU control. That seems to be `CPUAccounting=yes` *AND* `CPUQuota=100%` (see https://unix.stackexchange.com/a/757423/167092).

I was able to reproduce the "startup race" in an isolated staging instance, and show that adding these two lines fixes the issue: in fact, now systemd itself adds the "cpu" so in theory we will be able to remove the code that adds it in start-support.sh

See #1761 - we believe this fixes it