### PR TITLE
Fix: Make squashfs builds deterministic

### DIFF
--- a/bin/lib/cefs.py
+++ b/bin/lib/cefs.py
@@ -74,10 +74,15 @@ def get_cefs_paths(image_dir: Path, mount_point: Path, filename: Path) -> CEFSPa
 def calculate_squashfs_hash(squashfs_path: Path) -> str:
     """Calculate SHA256 hash of squashfs image using Python hashlib."""
     sha256_hash = hashlib.sha256()
+    file_size = squashfs_path.stat().st_size
+    _LOGGER.debug("Calculating hash for %s (size: %d bytes)", squashfs_path, file_size)
     with open(squashfs_path, "rb") as f:
         for chunk in iter(lambda: f.read(1024 * 1024), b""):
             sha256_hash.update(chunk)
-    return sha256_hash.hexdigest()[:24]
+    full_hash = sha256_hash.hexdigest()
+    truncated_hash = full_hash[:24]
+    _LOGGER.debug("Hash for %s: full=%s, truncated=%s", squashfs_path, full_hash, truncated_hash)
+    return truncated_hash
 
 
 def get_cefs_filename_for_image(squashfs_path: Path, operation: str, path: Path | None = None) -> Path:

--- a/bin/lib/installation_context.py
+++ b/bin/lib/installation_context.py
@@ -33,6 +33,7 @@ from lib.cefs_manifest import (
 from lib.config import Config
 from lib.config_safe_loader import ConfigSafeLoader
 from lib.library_platform import LibraryPlatform
+from lib.squashfs import create_squashfs_image
 from lib.staging import StagingDir
 
 _LOGGER = logging.getLogger(__name__)
@@ -501,19 +502,7 @@ class InstallationContext:
 
             # Create squashfs image from processed content
             _LOGGER.info("Creating squashfs image from %s", final_source_path)
-            subprocess.check_call(
-                [
-                    self.config.squashfs.mksquashfs_path,
-                    str(final_source_path),
-                    str(temp_squash_file),
-                    "-all-root",
-                    "-progress",
-                    "-comp",
-                    self.config.squashfs.compression,
-                    "-Xcompression-level",
-                    str(self.config.squashfs.compression_level),
-                ]
-            )
+            create_squashfs_image(self.config.squashfs, final_source_path, temp_squash_file)
 
             filename = get_cefs_filename_for_image(temp_squash_file, "install", Path(dest))
             cefs_paths = get_cefs_paths(self.config.cefs.image_dir, self.config.cefs.mount_point, filename)


### PR DESCRIPTION
## Problem

Installing the same compiler/library twice with `--force` produced different squashfs hashes, even with identical content. This prevented proper deduplication and caching in the CEFS system.

## Root Cause Analysis

Investigation revealed that while `mksquashfs` has `-reproducible` as default, it still includes:
1. **Filesystem creation timestamp** in the superblock (bytes 8-11)
2. **File modification times** that vary between installations

Even though file permissions fixing via `chmod()` didn't change actual timestamps, the filesystem creation time was always "current time".

## Solution

Added deterministic timestamp flags to `mksquashfs` calls:
- **`-mkfs-time 0`**: Sets filesystem creation time to epoch (1970-01-01) 
- **`-all-time 0`**: Sets all file timestamps to epoch
- **Refactored**: `installation_context.py` to use `create_squashfs_image()` from `squashfs.py`
- **Fixed**: Subprocess output capture to properly interleave stdout/stderr

## Testing Results

**Before**: gcc 15.1.0 produced different hashes on repeated installs:
- First: `12ce27515cb4a32a9686ed3b_gcc-15.1.0.sqfs`
- Second: `e28b22179b3192c3a79ace82_gcc-15.1.0.sqfs`

**After**: gcc 15.1.0 produces identical hash:
- Both installs: `2cd2d3d7ca800f5328e4d552_gcc-15.1.0.sqfs`
- Second install correctly detects existing image and skips recreation

## Additional Benefits

- **Storage savings**: No duplicate images with identical content
- **Faster installs**: Automatic detection when image already exists  
- **Better caching**: Deterministic hashes enable proper deduplication
- **Code quality**: Eliminated duplication between installation paths
- **Error handling**: Better subprocess error messages with interleaved output

🤖 Generated with [Claude Code](https://claude.ai/code)