### PR TITLE
Add zig 0.15.1

### DIFF
--- a/bin/yaml/zig.yaml
+++ b/bin/yaml/zig.yaml
@@ -28,6 +28,7 @@ compilers:
       url: https://ziglang.org/download/{{name}}/zig-x86_64-linux-{{name}}.tar.xz
       targets:
         - 0.14.1
+        - 0.15.1
     nightly:
       if: nightly
       type: restQueryTarballs


### PR DESCRIPTION
zig `0.15.0` was tagged but did not have binaries published due to having critical bugs.

Companion to https://github.com/compiler-explorer/compiler-explorer/pull/8060.