### PR TITLE
Fix broken symlink handling in installation permissions

### DIFF
--- a/bin/lib/installation_context.py
+++ b/bin/lib/installation_context.py
@@ -279,6 +279,11 @@ class InstallationContext:
 
     def _fix_single_permission(self, file_path: Path) -> None:
         """Fix permissions for a single file or directory."""
+        # Skip symlinks - they don't have their own permissions and
+        # chmod would affect the target, which may not exist (broken symlinks)
+        if file_path.is_symlink():
+            return
+
         current_mode = file_path.stat().st_mode
         current_perms = stat.S_IMODE(current_mode)
 

--- a/bin/test/installation_context_test.py
+++ b/bin/test/installation_context_test.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock
+
+from lib.installation_context import InstallationContext
+from lib.library_platform import LibraryPlatform
+
+
+def test_fix_permissions_skips_broken_symlinks():
+    """Test that _fix_permissions handles broken symlinks gracefully."""
+    # Create a temporary directory for testing
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_dir = Path(temp_dir)
+
+        # Create a regular file
+        regular_file = test_dir / "regular.txt"
+        regular_file.write_text("test")
+
+        # Create a broken symlink
+        broken_link = test_dir / "broken_link"
+        broken_link.symlink_to("non_existent_target")
+
+        # Verify the symlink is indeed broken
+        assert broken_link.is_symlink()
+        assert not broken_link.exists()
+
+        # Create a mock installation context
+        config = Mock()
+        ic = InstallationContext(
+            destination=test_dir,
+            staging_root=test_dir,
+            s3_url="",
+            dry_run=False,
+            is_nightly_enabled=False,
+            only_nightly=False,
+            cache=None,
+            yaml_dir=test_dir,
+            allow_unsafe_ssl=False,
+            resource_dir=test_dir,
+            keep_staging=False,
+            check_user="test",
+            platform=LibraryPlatform.Linux,
+            config=config,
+        )
+
+        # This should not raise an exception
+        ic._fix_permissions(test_dir)
+
+        # Verify the regular file still exists
+        assert regular_file.exists()
+        # Verify the broken symlink still exists
+        assert broken_link.is_symlink()
+
+
+def test_fix_permissions_handles_valid_symlinks():
+    """Test that _fix_permissions handles valid symlinks gracefully."""
+    # Create a temporary directory for testing
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_dir = Path(temp_dir)
+
+        # Create a target file
+        target_file = test_dir / "target.txt"
+        target_file.write_text("target content")
+
+        # Create a valid symlink
+        valid_link = test_dir / "valid_link"
+        valid_link.symlink_to(target_file)
+
+        # Verify the symlink is valid
+        assert valid_link.is_symlink()
+        assert valid_link.exists()
+
+        # Create a mock installation context
+        config = Mock()
+        ic = InstallationContext(
+            destination=test_dir,
+            staging_root=test_dir,
+            s3_url="",
+            dry_run=False,
+            is_nightly_enabled=False,
+            only_nightly=False,
+            cache=None,
+            yaml_dir=test_dir,
+            allow_unsafe_ssl=False,
+            resource_dir=test_dir,
+            keep_staging=False,
+            check_user="test",
+            platform=LibraryPlatform.Linux,
+            config=config,
+        )
+
+        # This should not raise an exception
+        ic._fix_permissions(test_dir)
+
+        # Verify both files still exist
+        assert target_file.exists()
+        assert valid_link.is_symlink()
+        assert valid_link.exists()


### PR DESCRIPTION
## Summary

Fixes #1730 - Resolves FileNotFoundError when installation packages contain broken symlinks during permission fixing.

The issue occurred when `_fix_permissions` encountered broken symlinks (like `dmd-master` in dmd-nightly installations). The code would attempt to call `stat()` on the symlink, which follows the link to a non-existent target, causing a FileNotFoundError.

## Changes

- Modified `_fix_single_permission` to skip symlinks entirely using `is_symlink()` check
- Symlinks don't have their own permissions and chmod would affect the target anyway
- Added comprehensive test coverage for both broken and valid symlinks

## Test Plan

- Added `installation_context_test.py` with tests for broken and valid symlinks
- All existing tests continue to pass
- Pre-commit hooks pass