### PR TITLE
Add new C++ library med

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1110,13 +1110,6 @@ libraries:
       - 0.6.0
       type: github
       untar_dir: mdspan-mdspan-{{name}}
-    med:
-      build_type: none
-      check_file: med/med.hpp
-      repo: cppden/med
-      targets:
-      - trunk
-      type: github
     mfem:
       build_type: cmake
       lib_type: static
@@ -1742,6 +1735,14 @@ libraries:
         targets:
         - trunk
         type: github
+      med:
+        build_type: none
+        check_file: med/med.hpp
+        repo: cppden/med
+        targets:
+        - trunk
+        type: github
+        method: nightlyclone
       mimicpp:
         check_file: README.md
         method: nightlyclone


### PR DESCRIPTION
Hello. I would like to add new C++ library to CE. Meta-Encoder/Decoder (med) is a header only library. https://github.com/cppden/med