### PR TITLE
updated OSACA to v0.7.1

### DIFF
--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -114,7 +114,7 @@ tools:
     package: osaca=={{name}}
     check_exe: bin/osaca --version
     targets:
-      - 0.7.0
+      - 0.7.1
   rustfmt:
     type: tarballs
     dir: rustfmt-{{name}}


### PR DESCRIPTION
Updated OSACA to version 0.7.1 that includes bugfixes for Intel syntax support and support for a few more instruction.

See also corresponding PR in https://github.com/compiler-explorer/compiler-explorer/pull/8084