### PR TITLE
Fix CEFS reconsolidation double-nesting issue

### DIFF
--- a/bin/lib/cefs/consolidation.py
+++ b/bin/lib/cefs/consolidation.py
@@ -62,16 +62,16 @@ def _extract_single_squashfs(args: tuple[str, str, str, str | None, str, str]) -
     """Worker function to extract a single squashfs image.
 
     Args are serialized as strings for pickling:
-        unsquashfs_path, squashfs_path, subdir_path, extraction_path, subdir_name, nfs_path
+        unsquashfs_path, squashfs_path, extraction_dir, extraction_path, subdir_name, nfs_path
 
     Returns:
         Dictionary with extraction metrics and status
     """
     logger = logging.getLogger(__name__)
-    unsquashfs_path, squashfs_path_str, subdir_path_str, extraction_path_str, subdir_name, nfs_path_str = args
+    unsquashfs_path, squashfs_path_str, extraction_dir_str, extraction_path_str, subdir_name, nfs_path_str = args
 
     squashfs_path = Path(squashfs_path_str)
-    subdir_path = Path(subdir_path_str)
+    extraction_dir = Path(extraction_dir_str)
     extraction_path = Path(extraction_path_str) if extraction_path_str else None
 
     config = SquashfsConfig(
@@ -83,25 +83,33 @@ def _extract_single_squashfs(args: tuple[str, str, str, str | None, str, str]) -
 
     try:
         compressed_size = squashfs_path.stat().st_size
-        is_partial_extraction = extraction_path is not None and extraction_path != Path(".")
+        is_partial_extraction = extraction_path is not None
 
+        # Determine where to extract based on whether this is partial extraction
+        # For partial extraction: the extraction path itself creates the subdirectory
+        # For full extraction: we need to create the subdirectory
         if is_partial_extraction:
+            actual_extraction_dir = extraction_dir
             logger.info(
                 "Partially extracting %s from %s (%s) to %s",
                 extraction_path,
                 squashfs_path,
                 humanfriendly.format_size(compressed_size, binary=True),
-                subdir_path,
+                actual_extraction_dir,
             )
         else:
+            actual_extraction_dir = extraction_dir / subdir_name
             logger.info(
                 "Extracting %s (%s) to %s",
                 squashfs_path,
                 humanfriendly.format_size(compressed_size, binary=True),
-                subdir_path,
+                actual_extraction_dir,
             )
 
-        extract_squashfs_image(config, squashfs_path, subdir_path, extraction_path)
+        extract_squashfs_image(config, squashfs_path, actual_extraction_dir, extraction_path)
+
+        # Always measure size at the expected location
+        subdir_path = extraction_dir / subdir_name
         extracted_size = get_directory_size(subdir_path)
 
         if is_partial_extraction:
@@ -149,7 +157,7 @@ def _extract_single_squashfs(args: tuple[str, str, str, str | None, str, str]) -
 
 def create_consolidated_image(
     squashfs_config: SquashfsConfig,
-    items: list[tuple[Path, Path, str, Path]],
+    items: list[tuple[Path, Path, str, Path | None]],
     temp_dir: Path,
     output_path: Path,
     max_parallel_extractions: int | None = None,
@@ -180,7 +188,7 @@ def create_consolidated_image(
             (
                 squashfs_config.unsquashfs_path,
                 str(squashfs_path),
-                str(extraction_dir / subdir_name),
+                str(extraction_dir),
                 str(extraction_path) if extraction_path else None,
                 subdir_name,
                 str(nfs_path),
@@ -507,7 +515,7 @@ def should_include_manifest_item(
     return True, targets
 
 
-def determine_extraction_path(targets: list[Path], image_path: Path, mount_point: Path) -> Path:
+def determine_extraction_path(targets: list[Path], image_path: Path, mount_point: Path) -> Path | None:
     """Determine the extraction path from symlink targets.
 
     Args:
@@ -516,14 +524,14 @@ def determine_extraction_path(targets: list[Path], image_path: Path, mount_point
         mount_point: CEFS mount point
 
     Returns:
-        Path within the consolidated image to extract from
+        Path within the consolidated image to extract from, or None to extract everything
     """
     for target in targets:
         if is_item_still_using_image(target, image_path, mount_point):
             if len(target.parts) > 4:
                 return Path(*target.parts[4:])
             break
-    return Path(".")
+    return None
 
 
 def extract_candidates_from_manifest(
@@ -657,7 +665,7 @@ def validate_space_requirements(groups: list[list[ConsolidationCandidate]], temp
 
 def prepare_consolidation_items(
     group: list[ConsolidationCandidate], mount_point: Path
-) -> tuple[list[tuple[Path, Path, str, Path]], dict[Path, str]]:
+) -> tuple[list[tuple[Path, Path, str, Path | None]], dict[Path, str]]:
     """Prepare items for consolidation by determining extraction paths and subdirectory names.
 
     Args:

--- a/bin/lib/cefs/models.py
+++ b/bin/lib/cefs/models.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 
@@ -15,7 +15,7 @@ class ConsolidationCandidate:
     nfs_path: Path
     squashfs_path: Path
     size: int
-    extraction_path: Path = field(default_factory=lambda: Path("."))
+    extraction_path: Path | None = None
     from_reconsolidation: bool = False
 
 

--- a/bin/test/cefs/consolidation_test.py
+++ b/bin/test/cefs/consolidation_test.py
@@ -189,12 +189,12 @@ def test_determine_extraction_path():
 
     # Test with empty targets - should return current directory
     extraction_path = determine_extraction_path([], image_path, mount_point)
-    assert extraction_path == Path(".")
+    assert extraction_path is None
 
     # Test with short path (less than 5 parts) - should return current directory
     targets = [Path("/cefs/ab")]
     extraction_path = determine_extraction_path(targets, image_path, mount_point)
-    assert extraction_path == Path(".")
+    assert extraction_path is None
 
 
 def test_should_include_manifest_item(tmp_path):
@@ -413,7 +413,7 @@ def test_reconsolidation_symlink_mapping():
         # The mapping should preserve the structure for proper symlink targeting
         # For an extraction_path of "gcc/compilers_c++_x86_gcc_12.3.0",
         # the symlink needs to point to the full path within the consolidated image
-        if candidate.extraction_path != Path("."):
+        if candidate.extraction_path is not None:
             # For reconsolidated items with nested paths, we need special handling
             # The mapped subdir should indicate where the symlink should point
             expected_name = sanitize_path_for_filename(Path(candidate.name))
@@ -578,7 +578,7 @@ def test_pack_items_into_groups():
             nfs_path=Path("/opt/gcc-15.0.0"),
             squashfs_path=Path("/efs/gcc.sqfs"),
             size=500 * 1024 * 1024,  # 500MB
-            extraction_path=Path("."),
+            extraction_path=None,
             from_reconsolidation=False,
         ),
         ConsolidationCandidate(
@@ -586,7 +586,7 @@ def test_pack_items_into_groups():
             nfs_path=Path("/opt/clang-18.0.0"),
             squashfs_path=Path("/efs/clang.sqfs"),
             size=400 * 1024 * 1024,  # 400MB
-            extraction_path=Path("."),
+            extraction_path=None,
             from_reconsolidation=False,
         ),
         ConsolidationCandidate(
@@ -594,7 +594,7 @@ def test_pack_items_into_groups():
             nfs_path=Path("/opt/rust-1.80.0"),
             squashfs_path=Path("/efs/rust.sqfs"),
             size=300 * 1024 * 1024,  # 300MB
-            extraction_path=Path("."),
+            extraction_path=None,
             from_reconsolidation=False,
         ),
         ConsolidationCandidate(
@@ -602,7 +602,7 @@ def test_pack_items_into_groups():
             nfs_path=Path("/opt/go-1.21.0"),
             squashfs_path=Path("/efs/go.sqfs"),
             size=200 * 1024 * 1024,  # 200MB
-            extraction_path=Path("."),
+            extraction_path=None,
             from_reconsolidation=False,
         ),
     ]
@@ -648,7 +648,7 @@ def test_validate_space_requirements(tmp_path):
             nfs_path=Path("/opt/item1"),
             squashfs_path=Path("/efs/item1.sqfs"),
             size=100 * 1024 * 1024,  # 100MB
-            extraction_path=Path("."),
+            extraction_path=None,
             from_reconsolidation=False,
         ),
         ConsolidationCandidate(
@@ -656,7 +656,7 @@ def test_validate_space_requirements(tmp_path):
             nfs_path=Path("/opt/item2"),
             squashfs_path=Path("/efs/item2.sqfs"),
             size=200 * 1024 * 1024,  # 200MB
-            extraction_path=Path("."),
+            extraction_path=None,
             from_reconsolidation=False,
         ),
     ]
@@ -667,7 +667,7 @@ def test_validate_space_requirements(tmp_path):
             nfs_path=Path("/opt/item3"),
             squashfs_path=Path("/efs/item3.sqfs"),
             size=150 * 1024 * 1024,  # 150MB
-            extraction_path=Path("."),
+            extraction_path=None,
             from_reconsolidation=False,
         ),
     ]


### PR DESCRIPTION
## Summary

Fix double-nesting issue that occurred when reconsolidating items from already-consolidated CEFS images.

## Problem

When reconsolidating, we were seeing paths like:
```
/cefs/23/237c01431531f0d5dd94dd5e_consolidated/libraries_c++_llvm_21.1.0/libraries_c++_llvm_21.1.0/
```

This happened because `unsquashfs` preserves directory structure when extracting a specific path, and we were extracting to `extraction_dir/subdir_name` which created double nesting.

## Solution

- Changed `_extract_single_squashfs` to receive the base extraction directory instead of `extraction_dir/subdir_name`
- The function now determines where to extract based on whether it's partial extraction:
  - Partial extraction: use `extraction_dir` directly (the extraction path creates its own subdirectory)
  - Full extraction: use `extraction_dir/subdir_name`
- Also standardized on `None` instead of `Path(".")` for "extract everything" for consistency

## Testing

- All CEFS tests pass
- Static checks pass
- Pre-commit hooks pass