### PR TITLE
Fix ce_install performance bottleneck in consolidation checks

### DIFF
--- a/bin/lib/config_expand.py
+++ b/bin/lib/config_expand.py
@@ -9,6 +9,7 @@ import jinja2
 _MAX_ITERS = 5
 _LOGGER = logging.getLogger(__name__)
 _JINJA_ENV = jinja2.Environment()
+_TEMPLATE_CACHE: dict[str, jinja2.Template] = {}
 
 
 def is_list_of_strings(value: Any) -> bool:
@@ -48,10 +49,11 @@ def needs_expansion(target: MutableMapping[str, Any]) -> bool:
 
 def expand_one(template_string: str, configuration: Mapping[str, Any]) -> str:
     try:
-        return _JINJA_ENV.from_string(template_string).render(**configuration)
-    except jinja2.exceptions.TemplateError:
-        # in python 3.11 we would...
-        # e.add_note(f"Template '{template_string}'")
+        if template_string not in _TEMPLATE_CACHE:
+            _TEMPLATE_CACHE[template_string] = _JINJA_ENV.from_string(template_string)
+        return _TEMPLATE_CACHE[template_string].render(**configuration)
+    except jinja2.exceptions.TemplateError as e:
+        e.add_note(f"Template '{template_string}'")
         _LOGGER.warning("Failed to expand '%s'", template_string)
         raise
 


### PR DESCRIPTION
## Summary

Fixes a severe performance issue causing 6-10 second delays per library during CEFS consolidation post-checks.

## Problem

During `ce cefs consolidate`, the post-consolidation verification was taking 6-10 seconds per library to check if it was still installed. With hundreds/thousands of libraries, this made consolidation extremely slow.

py-spy profiling showed:
- 80% of CPU time spent in Jinja2 template compilation
- Repeated calls to `get_installables([])` for every library lookup
- No caching of compiled templates or installable lookups

## Solution

1. **Template caching**: Cache compiled Jinja2 templates to avoid recompilation
2. **Installable caching**: Cache the name→installable mapping on first lookup
3. **Fix regression**: Use `bypass_enable_check=True` to find ALL installables including conditionally disabled ones (nightly, non-free)

## Additional Fix

This also fixes a regression where `find_installable_by_exact_name` wasn't using `bypass_enable_check=True`. This could cause spurious rollbacks during consolidation when conditionally disabled installables (e.g., nightly builds) couldn't be found even though they exist on disk.

## Testing

- All tests pass (312 passed)
- Static checks pass (mypy, ruff, black)
- Performance: Post-consolidation checks reduced from 6-10s per library to milliseconds

## Notes

The `bypass_enable_check` parameter was previously used in CEFS GC but was lost in a refactor. This PR restores that functionality where needed.