### PR TITLE
Updating nvrtc_cli.cpp for CUDA 13

### DIFF
--- a/bin/yaml/cuda.yaml
+++ b/bin/yaml/cuda.yaml
@@ -7,7 +7,7 @@ compilers:
       - compilers/c++/x86/gcc 13.4.0
     fetch:
       - https://developer.download.nvidia.com/compute/cuda/{{name}}/local_installers/cuda_{{name}}_{{build}}_linux.run combined.sh
-      - https://raw.githubusercontent.com/NVIDIA/jitify/6bc6e25e13300a8bc7520ed3bf977865201183b7/nvrtc_cli.cpp nvrtc_cli.cpp
+      - https://raw.githubusercontent.com/cliffburdick/jitify/refs/heads/patch-3/nvrtc_cli.cpp
     script: |
       mkdir -p cuda/{{name}}
       sh combined.sh --silent --toolkit --toolkitpath=$(pwd)/cuda/{{name}}


### PR DESCRIPTION
CUDA 13 changed the NVVM API to LTOIR in the NVRTC API. The old jitify `master` branch hasn't been updated in years since `jitify2` is the current branch. However, the `jitify2` branch doesn't contain nvrtc_cli.cpp anymore. As a workaround we have a patched version of nvrtc_cli.cpp in a branch in my fork that resolves the issue.