### PR TITLE
[swift]: add 6.2 release builds (x86 & static SDK)

### DIFF
--- a/bin/yaml/swift.yaml
+++ b/bin/yaml/swift.yaml
@@ -37,11 +37,11 @@ compilers:
           - '5.10'
           - '6.0.3'
           - '6.1'
-    # post-6-2:
-    #   url: https://download.swift.org/{{build}}/ubuntu2204/{{toolchain}}/{{toolchain}}-ubuntu22.04.tar.gz
-    #   targets:
-    #       - '6.2'
-    #   TODO: use this for 6.2+ releases since ubuntu 20.04 urls will no longer work
+    post-6-2:
+      url: https://download.swift.org/{{build}}/ubuntu2204/{{toolchain}}/{{toolchain}}-ubuntu22.04.tar.gz
+      targets:
+          - '6.2'
+
     static-sdk:
       url: https://download.swift.org/{{build}}/static-sdk/{{toolchain}}/{{toolchain}}_static-linux-0.0.1.artifactbundle.tar.gz
       dir: swift-{{name}}-static-sdk
@@ -52,6 +52,7 @@ compilers:
       targets:
           - '6.0.3'
           - '6.1'
+          - '6.2'
     nightly:
       if: nightly
       type: restQueryTarballs


### PR DESCRIPTION
- adds support for Swift 6.2 release builds
- updates to new Ubuntu 22.04 URL pattern for future x86 builds
- at time of writing, the 6.3 development branch didn't appear to yet be live, so development snapshots are still on 6.2