### PR TITLE
update clad nightly to compile with clang 21

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1197,7 +1197,7 @@ compilers:
           compiler_name: clad-{{name}}
           type: nightly
           targets:
-          - trunk-clang-20.1.0
+          - trunk-clang-21.1.0
     qnx:
       if: non-free
       compression: xz


### PR DESCRIPTION
Changes to the front end were already done at https://github.com/compiler-explorer/compiler-explorer/commit/26bcb7369d351bdd316b0aa4ef73633fa5afedfb#diff-3de56af8a969340307fdcd39521640fcb702ba13ae788f93ef70a4e6f0ae5297R1312.
And this happens to be broken (look at https://godbolt.org/z/6678a94s1), because nightly was still being built with clang 20.
Hopefully this fixes stuff.

cc @vgvassilev