### PR TITLE
Add Mojo 0.25.6

### DIFF
--- a/bin/yaml/mojo.yaml
+++ b/bin/yaml/mojo.yaml
@@ -6,10 +6,10 @@ compilers:
     dir: mojo-{{name}}
     python: "%DEP0%/bin/python3.13"
     package:
-      - max=={{name}}
+      - mojo=={{name}}
     check_exe: bin/mojo --version
     targets:
-      - 25.3.0
+      - 0.25.6.0
     nightly:
       if: nightly
       install_always: true
@@ -17,4 +17,4 @@ compilers:
         - name: nightly
           package:
             - --index-url=https://dl.modular.com/public/nightly/python/simple/
-            - max
+            - "mojo<1.0.0"


### PR DESCRIPTION
A few relevant changes:
- We're using the new `mojo` package, which was just uploaded to PyPI for the first time just a few hours ago! `max` previously had all the extra Mojo bits, now it's under `mojo`.
- The versioning scheme is prefixed with a `0.`, and we make sure to install `<1.0.0` so that we don't pull the "latest" (we did some weird things with our versioning, this is temporary but just ensures we don't pull old packages).