### PR TITLE
Update Solidity solc and solx compiler versions

### DIFF
--- a/bin/yaml/solidity.yaml
+++ b/bin/yaml/solidity.yaml
@@ -13,6 +13,7 @@ compilers:
       - 0.8.25
       - 0.8.26
       - 0.8.29
+      - 0.8.30
   solidity_zksync:
     type: singleFile
     dir: zksync-solc-{{name}}
@@ -52,4 +53,6 @@ compilers:
     filename: solx
     check_exe: solx --version
     targets:
-      - 0.1.0-alpha.2
+      - 0.1.0
+      - 0.1.1
+      - 0.1.2


### PR DESCRIPTION
## What?

Update Solidity compilers:
* [x] Add `solx` 0.1.0, 0.1.1 and 0.1.2 versions support
* [x] Add `solc` 0.8.30 version support

Related PR in compiler-explorer: https://github.com/compiler-explorer/compiler-explorer/pull/8124