### PR TITLE
Add Nvidia-Cutlass library

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -2706,6 +2706,13 @@ libraries:
       targets:
       - 1.8.0
       type: github
+    cutlass:
+      check_file: README.md
+      method: clone_branch
+      repo: NVIDIA/cutlass
+      targets:
+      - trunk
+      type: github
     matx:
       check_file: README.md
       method: clone_branch


### PR DESCRIPTION
Thanks for the wonderful CE project! 

This PR adds Nvidia's Cutlass library.

The repo is at: https://github.com/NVIDIA/cutlass
Cutlass is the premier library for high-performance BLAS kernels on Nvidia GPUs. 

As the underlying PTX ISA can change from generation to generation, CE is fantastic for studying the assembly. Compiler times with this library can be long, but I hope CE can shoulder it.   