### PR TITLE
Add Resolc 0.4.0 compiler

### DIFF
--- a/bin/yaml/solidity.yaml
+++ b/bin/yaml/solidity.yaml
@@ -59,6 +59,8 @@ compilers:
   resolc:
     type: singleFile
     dir: resolc-{{name}}
+    depends:
+      - compilers/solidity 0.8.30
     url: https://github.com/paritytech/revive/releases/download/v{{name}}/resolc-x86_64-unknown-linux-musl
     filename: resolc
     check_exe: resolc --version


### PR DESCRIPTION
## What

Adds [Revive's Resolc](https://github.com/paritytech/revive) Solidity compiler.

## CE

This infra addition is used by the accompanying CE PR: https://github.com/compiler-explorer/compiler-explorer/pull/8164