### PR TITLE
Add path relocation support to ScriptInstallable

### DIFF
--- a/bin/lib/installable/script.py
+++ b/bin/lib/installable/script.py
@@ -2,12 +2,44 @@ from __future__ import annotations
 
 import shutil
 from collections.abc import Callable
+from functools import partial
 from pathlib import Path
 from typing import Any
 
 from lib.installable.installable import Installable
 from lib.installation_context import InstallationContext
 from lib.staging import StagingDir
+
+
+def relocate_script_paths(source: str | Path, dest: str | Path, dirs: list[str]) -> None:
+    """
+    Relocate paths in script-installed files from staging to final destination.
+
+    Performs byte-level replacement of staging path with destination path in files
+    within specified subdirectories. Only processes regular files, not symlinks.
+
+    Args:
+        source: Staging directory path
+        dest: Final destination path
+        dirs: List of subdirectories to process (e.g., ["bin", "libexec"])
+    """
+    source_path = Path(source).absolute()
+    dest_path = Path(dest).absolute()
+
+    source_path_bytes = bytes(str(source_path), "utf-8")
+    dest_path_bytes = bytes(str(dest_path), "utf-8")
+
+    for dir_name in dirs:
+        target_dir = source_path / dir_name
+        if not target_dir.exists():
+            continue
+
+        for file_path in target_dir.iterdir():
+            if file_path.is_file() and not file_path.is_symlink():
+                content = file_path.read_bytes()
+                if source_path_bytes in content:
+                    content = content.replace(source_path_bytes, dest_path_bytes)
+                    file_path.write_bytes(content)
 
 
 class ScriptInstallable(Installable):
@@ -18,6 +50,7 @@ class ScriptInstallable(Installable):
         self.fetch = self.config_get("fetch", [])
         self.script = self.config_get("script")
         self.strip = self.config_get("strip", False)
+        self.relocate_paths = self.config_get("relocate_paths", [])
 
     def stage(self, staging: StagingDir) -> None:
         for url in self.fetch:
@@ -56,7 +89,10 @@ class ScriptInstallable(Installable):
         super().install()
         with self.install_context.new_staging_dir() as staging:
             self.stage(staging)
-            self.install_context.move_from_staging(staging, self.name, self.install_path)
+            relocate = None
+            if self.relocate_paths:
+                relocate = partial(relocate_script_paths, dirs=self.relocate_paths)
+            self.install_context.move_from_staging(staging, self.name, self.install_path, relocate=relocate)
             if self.install_path_symlink:
                 self.install_context.set_link(Path(self.install_path), self.install_path_symlink)
 

--- a/bin/yaml/clojure.yaml
+++ b/bin/yaml/clojure.yaml
@@ -7,7 +7,9 @@ compilers:
     script_filename: "clojure-{{name}}.sh"
     script: |
       chmod +x {{script_filename}}
-      ./{{script_filename}} --prefix ./clojure/{{name}}
+      ./{{script_filename}} --prefix $(pwd)/clojure/{{name}}
+    relocate_paths:
+      - bin
     depends:
       - compilers/java 21.0.2
     check_env:


### PR DESCRIPTION
## Summary

Script installers often embed absolute paths during installation. When these scripts run in a staging directory, the embedded paths become invalid after files are moved to the final destination.

This PR adds a `relocate_paths` configuration option to ScriptInstallable that specifies directories where path fixup should occur. The relocation function performs byte-level replacement of staging paths with destination paths in regular files within the specified directories.

The clojure installer has been updated to use this relocation for the `bin/` directory, fixing the issue where clojure scripts embedded staging directory paths that broke after relocation to `/opt/compiler-explorer`.

Generated with Claude Code