### PR TITLE
Fix CEFS permission issues preventing installation and access

### DIFF
--- a/bin/lib/installable/installable.py
+++ b/bin/lib/installable/installable.py
@@ -218,11 +218,18 @@ class Installable:
             return False
 
         if self.check_file:
-            res = (self.install_context.destination / self.check_file).is_file()
-            self._logger.debug(
-                'Check file for "%s" returned %s', self.install_context.destination / self.check_file, res
-            )
-            return res
+            try:
+                res = (self.install_context.destination / self.check_file).is_file()
+                self._logger.debug(
+                    'Check file for "%s" returned %s', self.install_context.destination / self.check_file, res
+                )
+                return res
+            except PermissionError:
+                self._logger.warning(
+                    "Permission denied checking %s - assuming not installed",
+                    self.install_context.destination / self.check_file,
+                )
+                return False
 
         try:
             res_call = self.check_output_under_different_user()

--- a/bin/lib/installation_context.py
+++ b/bin/lib/installation_context.py
@@ -268,6 +268,10 @@ class InstallationContext:
         Mirrors user permissions to group and other, but never grants write to group/other.
         Always ensures user has write permission for future editing.
         """
+        # Fix the root directory itself first
+        self._fix_single_permission(path)
+
+        # Then fix all subdirectories and files
         for root, dirs, files in os.walk(path):
             for dir_name in dirs:
                 dir_path = Path(root) / dir_name

--- a/bin/test/installable/installable_test.py
+++ b/bin/test/installable/installable_test.py
@@ -1,4 +1,5 @@
-from unittest.mock import MagicMock
+from pathlib import Path
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from lib.installable.installable import Installable
@@ -23,3 +24,36 @@ def test_installable_sort(fake_context):
         v10_2,
         ab_c,
     ]
+
+
+def test_is_installed_handles_permission_error_on_check_file(fake_context):
+    """Test that is_installed() returns False when check_file raises PermissionError.
+
+    This handles the case where CEFS mounts have restrictive permissions that prevent
+    stat operations, allowing reinstallation to fix the issue.
+    """
+    # Setup: Create an installable with check_file set
+    config = {"context": [], "name": "test-package", "check_file": "test.txt"}
+    installable = Installable(fake_context, config)
+
+    # Mock the destination property to return a Path
+    mock_destination = MagicMock(spec=Path)
+    type(fake_context).destination = PropertyMock(return_value=mock_destination)
+
+    # Mock the path resolution to raise PermissionError on is_file()
+    mock_path = MagicMock(spec=Path)
+    mock_path.is_file.side_effect = PermissionError("[Errno 13] Permission denied")
+    mock_destination.__truediv__.return_value = mock_path
+
+    # Mock the logger to verify warning is logged
+    with patch.object(installable, "_logger") as mock_logger:
+        result = installable.is_installed()
+
+        # Should return False to allow reinstallation
+        assert result is False
+
+        # Should log a warning about the permission issue
+        mock_logger.warning.assert_called_once()
+        warning_call = mock_logger.warning.call_args[0][0]
+        assert "Permission denied" in warning_call
+        assert "assuming not installed" in warning_call

--- a/bin/test/installation_context_test.py
+++ b/bin/test/installation_context_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import stat
 import tempfile
 from pathlib import Path
 from unittest.mock import Mock
@@ -98,3 +99,62 @@ def test_fix_permissions_handles_valid_symlinks():
         assert target_file.exists()
         assert valid_link.is_symlink()
         assert valid_link.exists()
+
+
+def test_fix_permissions_fixes_root_directory():
+    """Test that _fix_permissions fixes the root directory itself, not just subdirectories.
+
+    This is a regression test for a bug where tarballs with restrictive root directory
+    permissions (like Qt 6.10.0 with 700) would create CEFS images that were inaccessible.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_dir = Path(temp_dir)
+
+        # Create a subdirectory and file
+        subdir = test_dir / "subdir"
+        subdir.mkdir()
+        test_file = subdir / "test.txt"
+        test_file.write_text("test content")
+
+        # Set restrictive permissions on root directory (like Qt's broken tarball)
+        test_dir.chmod(0o700)
+        subdir.chmod(0o700)
+        test_file.chmod(0o600)
+
+        # Verify permissions are restrictive
+        assert stat.S_IMODE(test_dir.stat().st_mode) == 0o700
+        assert stat.S_IMODE(subdir.stat().st_mode) == 0o700
+        assert stat.S_IMODE(test_file.stat().st_mode) == 0o600
+
+        config = Mock()
+        ic = InstallationContext(
+            destination=test_dir,
+            staging_root=test_dir,
+            s3_url="",
+            dry_run=False,
+            is_nightly_enabled=False,
+            only_nightly=False,
+            cache=None,
+            yaml_dir=test_dir,
+            allow_unsafe_ssl=False,
+            resource_dir=test_dir,
+            keep_staging=False,
+            check_user="test",
+            platform=LibraryPlatform.Linux,
+            config=config,
+        )
+
+        # Fix permissions
+        ic._fix_permissions(test_dir)
+
+        # Verify root directory permissions are fixed (should be 755)
+        root_mode = stat.S_IMODE(test_dir.stat().st_mode)
+        assert root_mode == 0o755, f"Expected 0o755, got {oct(root_mode)}"
+
+        # Verify subdirectory permissions are fixed (should be 755)
+        subdir_mode = stat.S_IMODE(subdir.stat().st_mode)
+        assert subdir_mode == 0o755, f"Expected 0o755, got {oct(subdir_mode)}"
+
+        # Verify file permissions are fixed (should be 644)
+        file_mode = stat.S_IMODE(test_file.stat().st_mode)
+        assert file_mode == 0o644, f"Expected 0o644, got {oct(file_mode)}"


### PR DESCRIPTION
## Summary

Fixes two related issues with CEFS installations that have restrictive permissions:

1. Root directory permissions not fixed during installation (e.g., Qt 6.10.0 with 700)
2. PermissionError preventing verification and reinstallation of broken packages

## Problem

When installing packages like Qt 6.10.0, the tarball extracts with 700 permissions on the root directory. This created two issues:

1. The `_fix_permissions` method only walked subdirectories and files, never fixing the root directory itself
2. Post-installation verification failed with PermissionError, preventing both verification and reinstallation

Example error:
```
PermissionError: [Errno 13] Permission denied: '/opt/compiler-explorer/libs/qt/6.10.0/CMakeLists.txt'
```

## Changes

### installation_context.py
Fix the root directory permissions before walking subdirectories. This ensures CEFS mounts are created with proper 755 permissions on the root directory.

### installable.py
Catch `PermissionError` in the `check_file` path, mirroring existing behavior in the `check_call` path. This allows reinstallation to fix broken packages.

### Tests
Added regression tests for both fixes to prevent future issues.

## Result

Packages with restrictive permissions can now be:
- Installed successfully with correct permissions (755/644)
- Reinstalled to fix existing broken installations
- Verified without permission errors

## Test Plan

Verified by installing Qt 6.10.0:
- Old mount had 700 permissions (inaccessible)
- New mount has 755 permissions (accessible)
- All 378 tests pass
- Static checks pass

Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>