### PR TITLE
Add CEFS unpack and repack commands for in-place modifications

### DIFF
--- a/bin/lib/cefs/unpack.py
+++ b/bin/lib/cefs/unpack.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""CEFS unpack and repack operations for in-place modifications."""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import shutil
+import uuid
+from pathlib import Path
+
+from lib.cefs.deployment import backup_and_symlink, deploy_to_cefs_transactional
+from lib.cefs.paths import get_cefs_filename_for_image, get_cefs_paths, parse_cefs_target
+from lib.cefs_manifest import create_installable_manifest_entry, create_manifest
+from lib.config import SquashfsConfig
+from lib.squashfs import create_squashfs_image, extract_squashfs_image
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def unpack_cefs_item(
+    installable_name: str,
+    nfs_path: Path,
+    cefs_image_dir: Path,
+    mount_point: Path,
+    squashfs_config: SquashfsConfig,
+    defer_cleanup: bool,
+    dry_run: bool,
+) -> bool:
+    """Unpack a CEFS image to a real directory for in-place modifications.
+
+    Extracts the CEFS image and replaces the symlink with the actual directory.
+    The original symlink is saved as .bak for rollback.
+
+    Args:
+        installable_name: Full installable name (for logging)
+        nfs_path: Path to the NFS installation (currently a symlink to CEFS)
+        cefs_image_dir: Base directory for CEFS images
+        mount_point: CEFS mount point
+        squashfs_config: Squashfs configuration for extraction
+        defer_cleanup: If True, rename old .bak to .DELETE_ME instead of deleting
+        dry_run: If True, only log what would be done
+
+    Returns:
+        True if successful, False otherwise
+
+    Raises:
+        RuntimeError: If unpacking fails
+    """
+    # Verify it's a CEFS symlink
+    if not nfs_path.is_symlink():
+        raise RuntimeError(f"{nfs_path} is not a symlink (already unpacked or not a CEFS installation?)")
+
+    try:
+        symlink_target = nfs_path.readlink()
+    except OSError as e:
+        raise RuntimeError(f"Failed to read symlink {nfs_path}: {e}") from e
+
+    # Parse the CEFS target to find the image
+    try:
+        cefs_image_path, is_consolidated = parse_cefs_target(symlink_target, cefs_image_dir, mount_point)
+    except ValueError as e:
+        raise RuntimeError(f"Invalid CEFS symlink target {symlink_target}: {e}") from e
+
+    if not cefs_image_path.exists():
+        raise RuntimeError(f"CEFS image not found: {cefs_image_path}")
+
+    _LOGGER.info("Unpacking %s from %s", installable_name, cefs_image_path)
+    if is_consolidated:
+        _LOGGER.info("This is from a consolidated image, will extract only the needed subdirectory")
+
+    # Determine what to extract
+    extraction_path = None
+    if is_consolidated:
+        # Extract only the subdirectory we need
+        # symlink_target format: /cefs/XX/HASH/subdir
+        parts = symlink_target.parts
+        mount_parts = mount_point.parts
+        if len(parts) > len(mount_parts) + 2:
+            extraction_path = Path(*parts[len(mount_parts) + 2 :])
+            _LOGGER.debug("Will extract subdirectory: %s", extraction_path)
+
+    if dry_run:
+        _LOGGER.info("DRY RUN: Would unpack %s to %s", cefs_image_path, nfs_path)
+        if extraction_path:
+            _LOGGER.info("DRY RUN: Would extract only: %s", extraction_path)
+        return True
+
+    # Create temp directory for extraction with unique name
+    temp_name = f"{nfs_path.name}.UNPACK_{uuid.uuid4().hex[:8]}"
+    temp_path = nfs_path.parent / temp_name
+
+    try:
+        # Extract to temp directory
+        _LOGGER.info("Extracting to temporary location: %s", temp_path)
+        extract_squashfs_image(squashfs_config, cefs_image_path, temp_path, extraction_path)
+
+        backup_path = nfs_path.with_name(nfs_path.name + ".bak")
+
+        # Handle old .bak if it exists
+        if backup_path.exists(follow_symlinks=False):
+            if defer_cleanup:
+                timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+                delete_me_path = nfs_path.with_name(f"{nfs_path.name}.DELETE_ME_{timestamp}")
+                backup_path.rename(delete_me_path)
+                _LOGGER.info("Renamed old backup %s to %s for deferred cleanup", backup_path, delete_me_path)
+            else:
+                if backup_path.is_symlink():
+                    backup_path.unlink()
+                else:
+                    shutil.rmtree(backup_path)
+                _LOGGER.debug("Removed old backup: %s", backup_path)
+
+        # Atomic rename sequence: symlink → .bak, temp → main
+        _LOGGER.info("Replacing symlink with unpacked directory")
+        nfs_path.rename(backup_path)
+        _LOGGER.debug("Renamed symlink %s to %s", nfs_path, backup_path)
+
+        temp_path.rename(nfs_path)
+        _LOGGER.info("Unpacked %s successfully", installable_name)
+
+        return True
+
+    except Exception as e:
+        # Clean up temp directory on failure
+        if temp_path.exists():
+            shutil.rmtree(temp_path)
+            _LOGGER.debug("Cleaned up temp directory: %s", temp_path)
+        raise RuntimeError(f"Failed to unpack {installable_name}: {e}") from e
+
+
+def repack_cefs_item(
+    installable_name: str,
+    nfs_path: Path,
+    cefs_image_dir: Path,
+    mount_point: Path,
+    squashfs_config: SquashfsConfig,
+    local_temp_dir: Path,
+    defer_cleanup: bool,
+    dry_run: bool,
+) -> bool:
+    """Repack a directory back into a CEFS image.
+
+    Creates a new squashfs image from the unpacked directory and deploys it
+    to CEFS with a new hash. The directory is replaced with a symlink.
+
+    Args:
+        installable_name: Full installable name
+        nfs_path: Path to the NFS installation (currently a directory)
+        cefs_image_dir: Base directory for CEFS images
+        mount_point: CEFS mount point
+        squashfs_config: Squashfs configuration for compression
+        local_temp_dir: Temporary directory for creating images
+        defer_cleanup: If True, rename old .bak to .DELETE_ME instead of deleting
+        dry_run: If True, only log what would be done
+
+    Returns:
+        True if successful, False otherwise
+
+    Raises:
+        RuntimeError: If repacking fails
+    """
+    # Verify it's a directory (not a symlink)
+    if nfs_path.is_symlink():
+        raise RuntimeError(f"{nfs_path} is a symlink (not unpacked, use 'ce install' instead)")
+
+    if not nfs_path.is_dir():
+        raise RuntimeError(f"{nfs_path} is not a directory")
+
+    _LOGGER.info("Repacking %s from %s", installable_name, nfs_path)
+
+    if dry_run:
+        _LOGGER.info("DRY RUN: Would repack %s to new CEFS image", nfs_path)
+        return True
+
+    # Create temp directory for the new squashfs image
+    repack_dir = local_temp_dir / f"repack_{uuid.uuid4().hex[:8]}"
+    repack_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        # Create squashfs image from the directory
+        temp_image_path = repack_dir / "repacked.sqfs"
+        _LOGGER.info("Creating squashfs image from %s", nfs_path)
+        create_squashfs_image(squashfs_config, nfs_path, temp_image_path)
+
+        # Generate new filename with hash
+        filename = get_cefs_filename_for_image(temp_image_path, "install", nfs_path)
+        cefs_paths = get_cefs_paths(cefs_image_dir, mount_point, filename)
+
+        _LOGGER.info("New CEFS image will be: %s", cefs_paths.image_path)
+
+        # Create manifest for the new image
+        manifest_entry = create_installable_manifest_entry(installable_name, nfs_path)
+        manifest = create_manifest(
+            operation="install",
+            description=f"Repacked from modified directory: {installable_name}",
+            contents=[manifest_entry],
+        )
+
+        # Deploy to CEFS
+        with deploy_to_cefs_transactional(temp_image_path, cefs_paths.image_path, manifest, dry_run):
+            # Replace directory with symlink using backup_and_symlink
+            # This handles the backup and rollback for us
+            backup_and_symlink(nfs_path, cefs_paths.mount_path, dry_run, defer_cleanup)
+            _LOGGER.info("Replaced directory with CEFS symlink")
+
+        _LOGGER.info("Repacked %s successfully to %s", installable_name, cefs_paths.image_path)
+        return True
+
+    except Exception as e:
+        raise RuntimeError(f"Failed to repack {installable_name}: {e}") from e
+
+    finally:
+        # Clean up temp directory
+        if repack_dir.exists():
+            shutil.rmtree(repack_dir)
+            _LOGGER.debug("Cleaned up repack directory: %s", repack_dir)

--- a/bin/test/cefs/unpack_test.py
+++ b/bin/test/cefs/unpack_test.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Tests for CEFS unpack and repack operations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from lib.cefs.unpack import repack_cefs_item, unpack_cefs_item
+from lib.config import SquashfsConfig
+
+
+@pytest.fixture
+def squashfs_config():
+    """Create a test squashfs config."""
+    return SquashfsConfig(
+        mksquashfs_path="/usr/bin/mksquashfs",
+        unsquashfs_path="/usr/bin/unsquashfs",
+        compression="zstd",
+        compression_level=15,
+    )
+
+
+@pytest.fixture
+def mock_paths(tmp_path):
+    """Create mock paths for testing."""
+    return {
+        "nfs_path": tmp_path / "gcc-12.3.0",
+        "cefs_image_dir": tmp_path / "cefs-images",
+        "mount_point": Path("/cefs"),
+        "local_temp_dir": tmp_path / "temp",
+    }
+
+
+@patch("lib.cefs.unpack.extract_squashfs_image")
+@patch("lib.cefs.unpack.parse_cefs_target")
+def test_unpack_simple_cefs_image(mock_parse, mock_extract, tmp_path, squashfs_config, mock_paths):
+    """Test unpacking a simple (non-consolidated) CEFS image."""
+    nfs_path = mock_paths["nfs_path"]
+    cefs_image_path = mock_paths["cefs_image_dir"] / "ab" / "abc123_gcc.sqfs"
+    cefs_image_path.parent.mkdir(parents=True, exist_ok=True)
+    cefs_image_path.touch()
+
+    # Create symlink pointing to CEFS
+    nfs_path.symlink_to("/cefs/ab/abc123")
+
+    # Mock parse_cefs_target to return the image path and indicate not consolidated
+    mock_parse.return_value = (cefs_image_path, False)
+
+    # Mock extract to just create the temp directory
+    def mock_extract_impl(config, image_path, output_dir, extract_path):
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "bin").mkdir()
+        (output_dir / "bin" / "gcc").touch()
+
+    mock_extract.side_effect = mock_extract_impl
+
+    result = unpack_cefs_item(
+        "compilers/c++/x86/gcc 12.3.0",
+        nfs_path,
+        mock_paths["cefs_image_dir"],
+        mock_paths["mount_point"],
+        squashfs_config,
+        defer_cleanup=False,
+        dry_run=False,
+    )
+
+    assert result is True
+    assert nfs_path.is_dir()  # Should now be a directory
+    assert not nfs_path.is_symlink()
+    backup_path = nfs_path.with_name(nfs_path.name + ".bak")
+    assert backup_path.is_symlink()  # Old symlink saved as .bak
+    assert (nfs_path / "bin" / "gcc").exists()
+
+    # Verify extract was called
+    mock_extract.assert_called_once()
+    args = mock_extract.call_args[0]
+    assert args[1] == cefs_image_path
+    assert args[3] is None  # extract_path should be None for simple images
+
+
+@patch("lib.cefs.unpack.extract_squashfs_image")
+@patch("lib.cefs.unpack.parse_cefs_target")
+def test_unpack_consolidated_image(mock_parse, mock_extract, tmp_path, squashfs_config, mock_paths):
+    """Test unpacking from a consolidated CEFS image (extracts only the subdir)."""
+    nfs_path = mock_paths["nfs_path"]
+    cefs_image_path = mock_paths["cefs_image_dir"] / "ab" / "abc123_consolidated.sqfs"
+    cefs_image_path.parent.mkdir(parents=True, exist_ok=True)
+    cefs_image_path.touch()
+
+    # Create symlink pointing to CEFS with subdirectory (consolidated)
+    nfs_path.symlink_to("/cefs/ab/abc123/gcc-12.3.0")
+
+    # Mock parse_cefs_target to return the image path and indicate consolidated
+    mock_parse.return_value = (cefs_image_path, True)
+
+    # Mock extract to create the directory
+    def mock_extract_impl(config, image_path, output_dir, extract_path):
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "bin").mkdir()
+        (output_dir / "bin" / "gcc").touch()
+
+    mock_extract.side_effect = mock_extract_impl
+
+    result = unpack_cefs_item(
+        "compilers/c++/x86/gcc 12.3.0",
+        nfs_path,
+        mock_paths["cefs_image_dir"],
+        mock_paths["mount_point"],
+        squashfs_config,
+        defer_cleanup=False,
+        dry_run=False,
+    )
+
+    assert result is True
+    assert nfs_path.is_dir()
+
+    # Verify extract was called with the subdirectory path
+    mock_extract.assert_called_once()
+    args = mock_extract.call_args[0]
+    assert args[1] == cefs_image_path
+    assert args[3] == Path("gcc-12.3.0")  # Should extract only this subdir
+
+
+def test_unpack_not_a_symlink(tmp_path, squashfs_config, mock_paths):
+    """Test that unpacking a non-symlink raises an error."""
+    nfs_path = mock_paths["nfs_path"]
+    nfs_path.mkdir()  # Create as directory, not symlink
+
+    with pytest.raises(RuntimeError, match="not a symlink"):
+        unpack_cefs_item(
+            "compilers/c++/x86/gcc 12.3.0",
+            nfs_path,
+            mock_paths["cefs_image_dir"],
+            mock_paths["mount_point"],
+            squashfs_config,
+            defer_cleanup=False,
+            dry_run=False,
+        )
+
+
+@patch("lib.cefs.unpack.parse_cefs_target")
+def test_unpack_missing_image(mock_parse, tmp_path, squashfs_config, mock_paths):
+    """Test that unpacking when the CEFS image is missing raises an error."""
+    nfs_path = mock_paths["nfs_path"]
+    cefs_image_path = mock_paths["cefs_image_dir"] / "ab" / "abc123_gcc.sqfs"
+    # Don't create the actual image file
+
+    nfs_path.symlink_to("/cefs/ab/abc123")
+    mock_parse.return_value = (cefs_image_path, False)
+
+    with pytest.raises(RuntimeError, match="CEFS image not found"):
+        unpack_cefs_item(
+            "compilers/c++/x86/gcc 12.3.0",
+            nfs_path,
+            mock_paths["cefs_image_dir"],
+            mock_paths["mount_point"],
+            squashfs_config,
+            defer_cleanup=False,
+            dry_run=False,
+        )
+
+
+@patch("lib.cefs.unpack.extract_squashfs_image")
+@patch("lib.cefs.unpack.parse_cefs_target")
+def test_unpack_with_defer_cleanup(mock_parse, mock_extract, tmp_path, squashfs_config, mock_paths):
+    """Test unpacking with defer_cleanup creates .DELETE_ME instead of deleting old .bak."""
+    nfs_path = mock_paths["nfs_path"]
+    cefs_image_path = mock_paths["cefs_image_dir"] / "ab" / "abc123_gcc.sqfs"
+    cefs_image_path.parent.mkdir(parents=True, exist_ok=True)
+    cefs_image_path.touch()
+
+    # Create symlink and old .bak
+    nfs_path.symlink_to("/cefs/ab/abc123")
+    old_backup = nfs_path.with_name(nfs_path.name + ".bak")
+    old_backup.symlink_to("/cefs/cd/old_hash")
+
+    mock_parse.return_value = (cefs_image_path, False)
+
+    def mock_extract_impl(config, image_path, output_dir, extract_path):
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    mock_extract.side_effect = mock_extract_impl
+
+    result = unpack_cefs_item(
+        "compilers/c++/x86/gcc 12.3.0",
+        nfs_path,
+        mock_paths["cefs_image_dir"],
+        mock_paths["mount_point"],
+        squashfs_config,
+        defer_cleanup=True,
+        dry_run=False,
+    )
+
+    assert result is True
+
+    # Old .bak should be renamed to .DELETE_ME_<timestamp>, not deleted
+    delete_me_files = list(nfs_path.parent.glob("*.DELETE_ME_*"))
+    assert len(delete_me_files) == 1
+    assert not old_backup.exists()
+
+
+def test_unpack_dry_run(tmp_path, squashfs_config, mock_paths):
+    """Test that dry run doesn't actually unpack anything."""
+    nfs_path = mock_paths["nfs_path"]
+    cefs_image_path = mock_paths["cefs_image_dir"] / "ab" / "abc123_gcc.sqfs"
+    cefs_image_path.parent.mkdir(parents=True, exist_ok=True)
+    cefs_image_path.touch()
+
+    nfs_path.symlink_to("/cefs/ab/abc123")
+
+    with patch("lib.cefs.unpack.parse_cefs_target") as mock_parse:
+        mock_parse.return_value = (cefs_image_path, False)
+
+        result = unpack_cefs_item(
+            "compilers/c++/x86/gcc 12.3.0",
+            nfs_path,
+            mock_paths["cefs_image_dir"],
+            mock_paths["mount_point"],
+            squashfs_config,
+            defer_cleanup=False,
+            dry_run=True,
+        )
+
+    assert result is True
+    assert nfs_path.is_symlink()  # Should still be a symlink
+    assert not (nfs_path.with_name(nfs_path.name + ".bak")).exists()
+
+
+@patch("lib.cefs.unpack.create_squashfs_image")
+@patch("lib.cefs.unpack.deploy_to_cefs_transactional")
+@patch("lib.cefs.unpack.backup_and_symlink")
+@patch("lib.cefs.unpack.get_cefs_paths")
+@patch("lib.cefs.unpack.get_cefs_filename_for_image")
+def test_repack_directory(
+    mock_get_filename,
+    mock_get_paths,
+    mock_backup_symlink,
+    mock_deploy,
+    mock_create,
+    tmp_path,
+    squashfs_config,
+    mock_paths,
+):
+    """Test repacking a directory into a new CEFS image."""
+    nfs_path = mock_paths["nfs_path"]
+    nfs_path.mkdir()
+    (nfs_path / "bin").mkdir()
+    (nfs_path / "bin" / "gcc").touch()
+
+    # Mock the CEFS paths
+    mock_cefs_paths = Mock()
+    mock_cefs_paths.image_path = mock_paths["cefs_image_dir"] / "de" / "def456_gcc.sqfs"
+    mock_cefs_paths.mount_path = Path("/cefs/de/def456")
+    mock_get_paths.return_value = mock_cefs_paths
+    mock_get_filename.return_value = "def456_gcc.sqfs"
+
+    # Mock deploy context manager
+    mock_deploy.return_value.__enter__ = Mock(return_value=mock_cefs_paths.image_path)
+    mock_deploy.return_value.__exit__ = Mock(return_value=False)
+
+    result = repack_cefs_item(
+        "compilers/c++/x86/gcc 12.3.0",
+        nfs_path,
+        mock_paths["cefs_image_dir"],
+        mock_paths["mount_point"],
+        squashfs_config,
+        mock_paths["local_temp_dir"],
+        defer_cleanup=False,
+        dry_run=False,
+    )
+
+    assert result is True
+
+    # Verify squashfs image was created
+    mock_create.assert_called_once()
+    create_args = mock_create.call_args[0]
+    assert create_args[1] == nfs_path  # Source directory
+
+    # Verify backup_and_symlink was called
+    mock_backup_symlink.assert_called_once()
+    backup_args = mock_backup_symlink.call_args[0]
+    assert backup_args[0] == nfs_path
+    assert backup_args[1] == mock_cefs_paths.mount_path
+
+
+def test_repack_not_a_directory(tmp_path, squashfs_config, mock_paths):
+    """Test that repacking a non-directory raises an error."""
+    nfs_path = mock_paths["nfs_path"]
+    nfs_path.touch()  # Create as file
+
+    with pytest.raises(RuntimeError, match="not a directory"):
+        repack_cefs_item(
+            "compilers/c++/x86/gcc 12.3.0",
+            nfs_path,
+            mock_paths["cefs_image_dir"],
+            mock_paths["mount_point"],
+            squashfs_config,
+            mock_paths["local_temp_dir"],
+            defer_cleanup=False,
+            dry_run=False,
+        )
+
+
+def test_repack_symlink(tmp_path, squashfs_config, mock_paths):
+    """Test that repacking a symlink raises an error."""
+    nfs_path = mock_paths["nfs_path"]
+    nfs_path.symlink_to("/cefs/ab/abc123")
+
+    with pytest.raises(RuntimeError, match="is a symlink"):
+        repack_cefs_item(
+            "compilers/c++/x86/gcc 12.3.0",
+            nfs_path,
+            mock_paths["cefs_image_dir"],
+            mock_paths["mount_point"],
+            squashfs_config,
+            mock_paths["local_temp_dir"],
+            defer_cleanup=False,
+            dry_run=False,
+        )
+
+
+def test_repack_dry_run(tmp_path, squashfs_config, mock_paths):
+    """Test that dry run doesn't actually repack anything."""
+    nfs_path = mock_paths["nfs_path"]
+    nfs_path.mkdir()
+
+    result = repack_cefs_item(
+        "compilers/c++/x86/gcc 12.3.0",
+        nfs_path,
+        mock_paths["cefs_image_dir"],
+        mock_paths["mount_point"],
+        squashfs_config,
+        mock_paths["local_temp_dir"],
+        defer_cleanup=False,
+        dry_run=True,
+    )
+
+    assert result is True
+    assert nfs_path.is_dir()  # Should still be a directory
+
+
+@patch("lib.cefs.unpack.create_squashfs_image")
+@patch("lib.cefs.unpack.deploy_to_cefs_transactional")
+@patch("lib.cefs.unpack.backup_and_symlink")
+@patch("lib.cefs.unpack.get_cefs_paths")
+@patch("lib.cefs.unpack.get_cefs_filename_for_image")
+@patch("lib.cefs.unpack.extract_squashfs_image")
+@patch("lib.cefs.unpack.parse_cefs_target")
+def test_unpack_repack_roundtrip(
+    mock_parse,
+    mock_extract,
+    mock_get_filename,
+    mock_get_paths,
+    mock_backup_symlink,
+    mock_deploy,
+    mock_create,
+    tmp_path,
+    squashfs_config,
+    mock_paths,
+):
+    """Test unpacking, modifying, and repacking a CEFS image."""
+    nfs_path = mock_paths["nfs_path"]
+    original_image = mock_paths["cefs_image_dir"] / "ab" / "abc123_gcc.sqfs"
+    original_image.parent.mkdir(parents=True, exist_ok=True)
+    original_image.touch()
+
+    # Step 1: Unpack
+    nfs_path.symlink_to("/cefs/ab/abc123")
+    mock_parse.return_value = (original_image, False)
+
+    def mock_extract_impl(config, image_path, output_dir, extract_path):
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "bin").mkdir()
+        (output_dir / "bin" / "gcc").touch()
+
+    mock_extract.side_effect = mock_extract_impl
+
+    unpack_result = unpack_cefs_item(
+        "compilers/c++/x86/gcc 12.3.0",
+        nfs_path,
+        mock_paths["cefs_image_dir"],
+        mock_paths["mount_point"],
+        squashfs_config,
+        defer_cleanup=False,
+        dry_run=False,
+    )
+
+    assert unpack_result is True
+    assert nfs_path.is_dir()
+
+    # Step 2: Modify (simulate user changes)
+    (nfs_path / "modified_file.txt").write_text("This file was added after unpacking")
+
+    # Step 3: Repack
+    mock_cefs_paths = Mock()
+    mock_cefs_paths.image_path = mock_paths["cefs_image_dir"] / "de" / "def456_gcc.sqfs"
+    mock_cefs_paths.mount_path = Path("/cefs/de/def456")
+    mock_get_paths.return_value = mock_cefs_paths
+    mock_get_filename.return_value = "def456_gcc.sqfs"
+    mock_deploy.return_value.__enter__ = Mock(return_value=mock_cefs_paths.image_path)
+    mock_deploy.return_value.__exit__ = Mock(return_value=False)
+
+    repack_result = repack_cefs_item(
+        "compilers/c++/x86/gcc 12.3.0",
+        nfs_path,
+        mock_paths["cefs_image_dir"],
+        mock_paths["mount_point"],
+        squashfs_config,
+        mock_paths["local_temp_dir"],
+        defer_cleanup=False,
+        dry_run=False,
+    )
+
+    assert repack_result is True
+
+    # Verify the squashfs image was created with the modified directory
+    mock_create.assert_called_once()
+    create_args = mock_create.call_args[0]
+    assert create_args[1] == nfs_path  # Should include modified_file.txt


### PR DESCRIPTION
## Summary
Implements `ce cefs unpack` and `ce cefs repack` commands to enable in-place modifications of CEFS images when reinstallation is not possible (e.g., upstream tarballs removed).

## Use Case
Fixes the Qt permission issues mentioned in #1862, but more generally provides a way to modify any CEFS image when the original tarball is no longer available.

## Workflow
```bash
# 1. Unpack CEFS image to real directory
ce cefs unpack qt-6.10

# 2. Make modifications (permissions, patches, files, etc.)
chmod -R a+rX /opt/compiler-explorer/qt-6.10.0

# 3. Repack to new CEFS image with new hash
ce cefs repack qt-6.10

# 4. Garbage collect old unreferenced image
ce cefs gc
```

## Features
- Transparent handling of consolidated images (extracts only needed subdir)
- Atomic operations with minimal race window
- Standard .bak backup mechanism for rollback
- Repack always creates single-item images (reconsolidation can optimize later)
- Uses .yaml.inprogress pattern for transactional deployment

## Testing
- 11 comprehensive unit tests covering all scenarios
- All static checks passing
- Manual testing completed successfully

## Documentation
- Updated docs/cefs.md with new commands
- Marked unpack/repack todo as complete
- Added implementation section with usage examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)