### PR TITLE
Fix consolidated image extraction and deduplicate with helper

### DIFF
--- a/bin/lib/cefs/unpack.py
+++ b/bin/lib/cefs/unpack.py
@@ -13,7 +13,7 @@ from lib.cefs.deployment import backup_and_symlink, deploy_to_cefs_transactional
 from lib.cefs.paths import get_cefs_filename_for_image, get_cefs_paths, parse_cefs_target
 from lib.cefs_manifest import create_installable_manifest_entry, create_manifest
 from lib.config import SquashfsConfig
-from lib.squashfs import create_squashfs_image, extract_squashfs_image
+from lib.squashfs import create_squashfs_image, extract_squashfs_relocating_subdir
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -93,7 +93,7 @@ def unpack_cefs_item(
     try:
         # Extract to temp directory
         _LOGGER.info("Extracting to temporary location: %s", temp_path)
-        extract_squashfs_image(squashfs_config, cefs_image_path, temp_path, extraction_path)
+        extract_squashfs_relocating_subdir(squashfs_config, cefs_image_path, temp_path, extraction_path)
 
         backup_path = nfs_path.with_name(nfs_path.name + ".bak")
 


### PR DESCRIPTION
## Summary
Fixes bug where unpacking from consolidated images resulted in nested subdirectories. For example, unpacking `libraries/c++/qt 6.5.2` created `/opt/compiler-explorer/libs/qt/6.5.2/libraries_c++_qt_6.5.2/` instead of contents directly in `/opt/compiler-explorer/libs/qt/6.5.2/`.

## Root Cause
When `unsquashfs` extracts a specific path from an archive, it creates that path as a subdirectory in the output location. The unpack code wasn't handling this correctly.

## Solution
Created `extract_squashfs_relocating_subdir()` helper function in `squashfs.py` that:
1. Extracts to a temporary location
2. Moves the extracted subdirectory contents to the final destination
3. Cleans up the temp directory

This helper is now used by both:
- `unpack.py` - for unpacking consolidated images
- `consolidation.py` - for extracting items during consolidation

## Changes
- Added `extract_squashfs_relocating_subdir()` to squashfs.py with proper documentation
- Simplified unpack.py to use new helper
- Updated consolidation.py to use new helper (deduplicated ~20 lines of similar code)
- Updated all tests to mock the new helper function
- Added test assertion to verify contents are not nested

## Testing
- All 11 unpack tests passing
- All 18 consolidation tests passing
- Manually tested by user on real Qt installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)