### PR TITLE
Add Helion language support

### DIFF
--- a/bin/yaml/helion.yaml
+++ b/bin/yaml/helion.yaml
@@ -1,0 +1,15 @@
+compilers:
+  helion:
+    depends:
+      - compilers/python 3.12.1
+    type: pip
+    dir: helion/v{{name}}
+    python: "%DEP0%/bin/python3.12"
+    package:
+      - helion=={{name}}
+      - triton==3.5.0
+      - torch==2.9.0
+      - numpy
+    check_exe: [ "bin/python3.12", "-c", "import helion; print(helion.__name__)" ]
+    targets:
+      - 0.2.0


### PR DESCRIPTION
Helion is a Python-embedded domain-specific language (DSL) for authoring machine learning kernels, designed to compile down to Triton.

https://github.com/pytorch/helion

I mostly followed the Triton example, please let me know if there's more I need to do or anything I missed.

compiler-explorer PR: https://github.com/compiler-explorer/compiler-explorer/pull/8206