### PR TITLE
Add resolc Solidity compiler v0.5.0 

### DIFF
--- a/bin/yaml/solidity.yaml
+++ b/bin/yaml/solidity.yaml
@@ -66,3 +66,4 @@ compilers:
     check_exe: resolc --version
     targets:
       - 0.4.0
+      - 0.5.0


### PR DESCRIPTION
This PR adds the newest version `v0.5.0` of the `resolc` Solidity compiler.