### PR TITLE
Download Clojure dependencies into versioned repo

### DIFF
--- a/bin/yaml/clojure.yaml
+++ b/bin/yaml/clojure.yaml
@@ -7,8 +7,9 @@ compilers:
     script_filename: "clojure-{{name}}.sh"
     script: |
       chmod +x {{script_filename}}
-      export JAVA_HOME=%DEP0%
       ./{{script_filename}} --prefix $(pwd)/clojure/{{name}}
+      export JAVA_HOME=%DEP0%
+      export CLJ_CONFIG=$(pwd)/clojure/{{name}}/.config
       $(pwd)/clojure/{{name}}/bin/clojure -Sdeps "{:mvn/local-repo \"$(pwd)/clojure/{{name}}/.m2/repository\"}" -Spath
     relocate_paths:
       - bin


### PR DESCRIPTION
The Clojure build script needs to trigger the download of jars into a compiler-version-local repository to ensure correct deployment.