### PR TITLE
Add experimental Clang for P2561

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1652,6 +1652,7 @@ compilers:
           - rocm-trunk
           - ce-trunk
           - clangir-trunk
+          - p2561-trunk
           - bb-p2996-trunk
           - p2998-trunk
           - p3068-trunk


### PR DESCRIPTION
Adds experimental version of Clang for P2561 (with different syntax: `!?`).