### PR TITLE
Add BDE libraries

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -185,6 +185,41 @@ libraries:
       targets:
       - '1.2'
       type: github
+    bde:
+      build_type: cmake
+      check_file: Readme.md
+      repo: bloomberg/bde
+      method: clone_branch
+      lib_type: static
+      after_stage_script:
+      # Remove tests and test dependencies
+      - find . -name "*.t.*" -exec rm -f {} ";"
+      - sed -i 's/add_subdirectory(standalones)//g' CMakeLists.txt
+      prebuild_script:
+      - curl -o bde-tools.zip -L https://github.com/bloomberg/bde-tools/archive/refs/heads/main.zip
+      - unzip bde-tools.zip
+      extra_cmake_arg:
+      - -DBdeBuildSystem_ROOT:PATH=bde-tools-main/BdeBuildSystem/
+      - -DBBS_ENV_MARKER=ON
+      - -DCMAKE_INSTALL_LIBDIR=lib  # BDE CMake requires LIBDIR to be set
+      package_install: true
+      make_utility: ninja
+      staticliblink:
+      - bal
+      - bbl
+      - bbryu
+      - bdl
+      - bsl
+      - inteldfp
+      - pcre2
+      make_targets:
+      - bal
+      - bbl
+      - bdl
+      - bsl
+      targets:
+      - 4.31.0.0
+      type: github
     benchmark:
       build_type: cmake
       extra_cmake_arg:
@@ -1197,41 +1232,6 @@ libraries:
         repo: modm-io/avr-libstdcpp
         targets:
         - trunk
-        type: github
-      bde:
-        build_type: cmake
-        check_file: Readme.md
-        repo: bloomberg/bde
-        method: nightlyclone
-        lib_type: static
-        after_stage_script:
-        # Remove tests and test dependencies
-        - find . -name "*.t.*" -exec rm -f {} ";"
-        - sed -i 's/add_subdirectory(standalones)//g' CMakeLists.txt
-        prebuild_script:
-        - curl -o bde-tools.zip -L https://github.com/bloomberg/bde-tools/archive/refs/heads/main.zip
-        - unzip bde-tools.zip
-        extra_cmake_arg:
-        - -DBdeBuildSystem_ROOT:PATH=bde-tools-main/BdeBuildSystem/
-        - -DBBS_ENV_MARKER=ON
-        - -DCMAKE_INSTALL_LIBDIR=lib  # BDE CMake requires LIBDIR to be set
-        package_install: true
-        make_utility: ninja
-        staticliblink:
-        - bal
-        - bbl
-        - bbryu
-        - bdl
-        - bsl
-        - inteldfp
-        - pcre2
-        make_targets:
-        - bal
-        - bbl
-        - bdl
-        - bsl
-        targets:
-        - main
         type: github
       belleviews:
         build_type: none


### PR DESCRIPTION
Requested in https://github.com/compiler-explorer/compiler-explorer/issues/5933.

Add Bloomberg BDE libraries:
- Basic Standard Library (BSL)
- Basic Development Library (BDL)
- Basic Application Library (BAL)
- Basic Business Library (BBL)

BDE Libraries use a set of custom CMake module for build - those are brought in in a `prebuild_script`, similar to `re2`.