### PR TITLE
Add UvInstallable for uv-based Python tools

### DIFF
--- a/bin/lib/installation.py
+++ b/bin/lib/installation.py
@@ -17,7 +17,7 @@ from lib.installable.archives import (
 from lib.installable.edg import EdgCompilerInstallable
 from lib.installable.git import BitbucketInstallable, GitHubInstallable, GitLabInstallable
 from lib.installable.installable import SingleFileInstallable
-from lib.installable.python import PipInstallable
+from lib.installable.python import PipInstallable, UvInstallable
 from lib.installable.rust import CratesIOInstallable, RustInstallable
 from lib.installable.script import ScriptInstallable
 from lib.installable.solidity import SolidityInstallable
@@ -95,6 +95,7 @@ _INSTALLER_TYPES = {
     "bitbucket": BitbucketInstallable,
     "rust": RustInstallable,
     "pip": PipInstallable,
+    "uv": UvInstallable,
     "ziparchive": ZipArchiveInstallable,
     "cratesio": CratesIOInstallable,
     "non-free-s3tarballs": NonFreeS3TarballInstallable,

--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -116,6 +116,16 @@ tools:
     check_exe: bin/osaca --version
     targets:
       - 0.7.1
+  uica:
+    type: uv
+    dir: uica-{{name}}
+    script:
+      - git clone --branch {{name}} --recursive https://github.com/compiler-explorer/uiCA.git uica-src
+      - cd uica-src && uv run --with setuptools python build.py
+    package: ./uica-src
+    check_exe: bin/uica --help
+    targets:
+      - ce
   rustfmt:
     type: tarballs
     dir: rustfmt-{{name}}


### PR DESCRIPTION
Adds support for installing Python tools using the uv package manager. UvInstallable creates a venv, runs an optional script for build steps, and installs packages. Supports local paths with ./ prefix for staging- relative package installation.

Uses UV_BIN environment variable to ensure the same uv executable that runs ce_install is used for package operations.

Includes uiCA tool configuration which clones the repo, builds XED, and installs the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)