### PR TITLE
Add Go 1.25.4

### DIFF
--- a/bin/yaml/go.yaml
+++ b/bin/yaml/go.yaml
@@ -33,6 +33,7 @@ compilers:
         - "1.22.12"
         - "1.23.8"
         - "1.24.2"
+        - "1.25.4"
     tinygo:
       type: tarballs
       compression: gz


### PR DESCRIPTION
Added Go v1.25.4 (latest 1.25 minor version right now) to the target list