### PR TITLE
[swift]: update dev-snapshot to 6.3 development branch

### DIFF
--- a/bin/yaml/swift.yaml
+++ b/bin/yaml/swift.yaml
@@ -69,4 +69,4 @@ compilers:
         dir: swift-dev-snapshot
         toolchain: swift-{{name}}-branch
         targets:
-          - '6.2'
+          - '6.3'


### PR DESCRIPTION
the 6.3 dev branch now has builds, so we can update the dev snapshot config to use them