### PR TITLE
Add ncc-ng (Norcroft C/C++ compiler) nightly builds

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1710,6 +1710,12 @@ compilers:
         check_exe: bin/tcc -v
         targets:
           - trunk
+      ncc-ng:
+        type: nightly
+        compiler_name: ncc-ng-{{name}}
+        check_exe: bin/n++ -help
+        targets:
+          - trunk
       6502-c++:
         type: nightly
         s3_name: 6502-c%2B%2B-{{name}}


### PR DESCRIPTION
## Summary
- Adds installation support for the ncc-ng compiler nightly builds
- ncc-ng is a modernized version of the Norcroft C/C++ compiler targeting ARM platforms
- Built by the [compiler-workflows daily build action](https://github.com/compiler-explorer/compiler-workflows/actions/workflows/build-daily-ncc-ng.yml)

See compiler-explorer/compiler-explorer#8297 for the CE configuration.

## Test plan
- [x] Verified `bin/ce_install --enable nightly list` recognizes ncc-ng
- [x] Confirmed latest build (20251216) is detected from S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)