### PR TITLE
Add MicroPython v1.27.0

### DIFF
--- a/bin/yaml/micropython.yaml
+++ b/bin/yaml/micropython.yaml
@@ -16,6 +16,7 @@ compilers:
       - 1.25.0
       - 1.26.0
       - 1.26.1
+      - 1.27.0
     nightly:
       if: nightly
       micropython:


### PR DESCRIPTION
This release of MicroPython also includes an update to its `mpy-tool.py` disassembler designed to better integrate with Compiler Explorer, so disassembly no longer requires using the preview version of MicroPython.

https://github.com/micropython/micropython/releases/tag/v1.27.0