### PR TITLE
Add glsl & slang asm compilation

### DIFF
--- a/bin/yaml/shader-explorer.yaml
+++ b/bin/yaml/shader-explorer.yaml
@@ -1,0 +1,11 @@
+compilers:
+  shader:
+    shader_explorer:
+      type: tarballs
+      dir: shader-explorer-{{name}}
+      url: https://github.com/NoNaeAbC/shader_explorer/releases/download/v{{name}}/shader_explorer-{{name}}-linux-x86_64.tar.gz
+      compression: gz
+      strip_components: 1
+      check_exe: bin/shader_explorer --version
+      targets:
+        - "0.1.0"

--- a/bin/yaml/shader-explorer.yaml
+++ b/bin/yaml/shader-explorer.yaml
@@ -8,4 +8,4 @@ compilers:
       strip_components: 1
       check_exe: bin/shader_explorer --version
       targets:
-        - "0.1.0"
+        - "0.1.2"


### PR DESCRIPTION
This is a draft because the binaries are build against Ubuntu 24.04 and require a lot of system dependencies:

```
	libLLVM.so.20.1 => /usr/lib/libLLVM.so.20.1 (0x00007f35b6000000)
	libdrm_amdgpu.so.1 => /usr/lib/libdrm_amdgpu.so.1 (0x00007f35c0c47000)
	libelf.so.1 => /usr/lib/libelf.so.1 (0x00007f35c0c2b000)
	libxcb-dri3.so.0 => /usr/lib/libxcb-dri3.so.0 (0x00007f35c0c24000)
	libwayland-client.so.0 => /usr/lib/libwayland-client.so.0 (0x00007f35c0c14000)
	libz.so.1 => /usr/lib/libz.so.1 (0x00007f35c0bf9000)
	libzstd.so.1 => /usr/lib/libzstd.so.1 (0x00007f35c0b11000)
	libunwind.so.8 => /usr/lib/libunwind.so.8 (0x00007f35c0af6000)
	libdrm.so.2 => /usr/lib/libdrm.so.2 (0x00007f35c0adf000)
	libxcb.so.1 => /usr/lib/libxcb.so.1 (0x00007f35bf7d5000)
	libX11-xcb.so.1 => /usr/lib/libX11-xcb.so.1 (0x00007f35c0ada000)
	libxcb-present.so.0 => /usr/lib/libxcb-present.so.0 (0x00007f35c0ad5000)
	libxcb-xfixes.so.0 => /usr/lib/libxcb-xfixes.so.0 (0x00007f35bf7cc000)
	libxcb-sync.so.1 => /usr/lib/libxcb-sync.so.1 (0x00007f35bf7c3000)
	libxcb-randr.so.0 => /usr/lib/libxcb-randr.so.0 (0x00007f35bf7b1000)
	libxcb-shm.so.0 => /usr/lib/libxcb-shm.so.0 (0x00007f35bf7ac000)
	libxshmfence.so.1 => /usr/lib/libxshmfence.so.1 (0x00007f35bf7a7000)
	libxcb-keysyms.so.1 => /usr/lib/libxcb-keysyms.so.1 (0x00007f35bf7a2000)
	libexpat.so.1 => /usr/lib/libexpat.so.1 (0x00007f35bf775000)
	libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007f35b5c00000)
	libm.so.6 => /usr/lib/libm.so.6 (0x00007f35b5ee2000)
	libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007f35bf748000)
	libc.so.6 => /usr/lib/libc.so.6 (0x00007f35b5a0f000)
	libffi.so.8 => /usr/lib/libffi.so.8 (0x00007f35bf73c000)
	libedit.so.0 => /usr/lib/libedit.so.0 (0x00007f35bf701000)
	libxml2.so.16 => /usr/lib/libxml2.so.16 (0x00007f35b58da000)
	/usr/lib64/ld-linux-x86-64.so.2 (0x00007f35c0ca8000)
	liblzma.so.5 => /usr/lib/liblzma.so.5 (0x00007f35bf6cc000)
	libXau.so.6 => /usr/lib/libXau.so.6 (0x00007f35bf6c7000)
	libXdmcp.so.6 => /usr/lib/libXdmcp.so.6 (0x00007f35bf6bf000)
	libncursesw.so.6 => /usr/lib/libncursesw.so.6 (0x00007f35b5869000)
	libicuuc.so.78 => /usr/lib/libicuuc.so.78 (0x00007f35b5600000)
	libicudata.so.78 => /usr/lib/libicudata.so.78 (0x00007f35b3600000)
```
