### PR TITLE
Show superseded nightlies in CEFS GC instead of NOT INSTALLED

### DIFF
--- a/.github/workflows/cefs-gc.yml
+++ b/.github/workflows/cefs-gc.yml
@@ -25,10 +25,10 @@ jobs:
       - uses: actions/checkout@v5
       - name: Set up environment
         run: make ce
-#      - name: Run CEFS garbage collection
-#        run: >-
-#          sudo bin/ce_install cefs gc
-#          --force
-#          --cleanup-bak
-#          --min-age ${{ github.event.inputs.min-age || '2d' }}
-#          ${{ github.event.inputs.include-broken == 'true' && '--include-broken' || '' }}
+      - name: Run CEFS garbage collection
+        run: >-
+          sudo bin/ce_install cefs gc
+          --force
+          --cleanup-bak
+          --min-age ${{ github.event.inputs.min-age || '2d' }}
+          ${{ github.event.inputs.include-broken == 'true' && '--include-broken' || '' }}

--- a/bin/lib/cefs/formatting.py
+++ b/bin/lib/cefs/formatting.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import humanfriendly
 import yaml
@@ -17,6 +18,9 @@ from lib.cefs.consolidation import (
 from lib.cefs.paths import describe_cefs_image, get_current_symlink_targets
 from lib.cefs.state import CEFSState
 from lib.cefs_manifest import read_manifest_from_alongside
+
+if TYPE_CHECKING:
+    from lib.installable.installable import Installable
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -195,24 +199,84 @@ def format_usage_statistics(stats, state: CEFSState, verbose: bool, cefs_mount_p
     return lines
 
 
-def get_installable_current_locations(image_path: Path) -> list[str]:
-    """Get information about where each Installable in an image is currently installed."""
+def _classify_destination(path: Path) -> str:
+    if path.is_symlink():
+        try:
+            return f"{path} -> {path.readlink()}"
+        except OSError as e:
+            return f"{path} -> [unreadable: {e}]"
+    if path.is_dir():
+        return f"{path} [directory]"
+    if path.exists():
+        return f"{path} [file]"
+    return "NOT INSTALLED"
+
+
+def classify_installable_location(destination: Path, symlink: Path | None) -> str:
+    """Describe where an installable's content currently lives on disk.
+
+    For nightlies, the manifest stores a dated destination (e.g. gcc-trunk-20250916)
+    while the installable also has a stable un-dated symlink path (e.g. gcc-trunk).
+    If the dated directory is no longer present but the un-dated symlink exists,
+    the image has been superseded by a newer nightly rather than being "not installed".
+    """
+    if symlink is None:
+        return _classify_destination(destination)
+
+    if not symlink.is_symlink():
+        if destination.exists() or destination.is_symlink():
+            return _classify_destination(destination)
+        return "NOT INSTALLED"
+
+    try:
+        symlink_target = symlink.readlink()
+    except OSError as e:
+        return f"{symlink} -> [unreadable: {e}]"
+
+    resolved_target = symlink_target if symlink_target.is_absolute() else (symlink.parent / symlink_target)
+    try:
+        points_to_this = resolved_target.resolve(strict=False) == destination.resolve(strict=False)
+    except OSError:
+        points_to_this = str(resolved_target) == str(destination)
+
+    if points_to_this:
+        return f"{symlink} -> {symlink_target}"
+
+    return f"{symlink} -> {symlink_target} (this image: {destination.name}, superseded)"
+
+
+def _symlink_for_installable(installable: Installable, destination_root: Path) -> Path | None:
+    """Resolve the un-dated symlink path for an installable, if it has one."""
+    install_path_symlink = getattr(installable, "install_path_symlink", None)
+    if install_path_symlink:
+        return destination_root / install_path_symlink
+    path_name_symlink = getattr(installable, "path_name_symlink", None)
+    if path_name_symlink:
+        return destination_root / path_name_symlink
+    return None
+
+
+def get_installable_current_locations(
+    image_path: Path,
+    installables_by_name: dict[str, Installable] | None = None,
+    destination_root: Path | None = None,
+) -> list[str]:
+    """Get information about where each Installable in an image is currently installed.
+
+    When ``installables_by_name`` and ``destination_root`` are provided, looks up the
+    Installable for each manifest entry to discover its un-dated symlink path. This
+    lets us report "superseded" for stale nightly images instead of "NOT INSTALLED".
+    """
     if not (manifest := read_manifest_from_alongside(image_path)):
         return []
 
-    def _classify(path: Path) -> str:
-        if path.is_symlink():
-            try:
-                return f"{path} -> {path.readlink()}"
-            except OSError as e:
-                return f"{path} -> [unreadable: {e}]"
-        if path.is_dir():
-            return f"{path} [directory]"
-        if path.exists():
-            return f"{path} [file]"
-        return "NOT INSTALLED"
-
-    return [
-        f"    └─ {content['name']} → currently: {_classify(Path(content['destination']))}"
-        for content in manifest["contents"]
-    ]
+    lines = []
+    for content in manifest["contents"]:
+        destination = Path(content["destination"])
+        symlink: Path | None = None
+        if installables_by_name is not None and destination_root is not None:
+            installable = installables_by_name.get(content["name"])
+            if installable is not None:
+                symlink = _symlink_for_installable(installable, destination_root)
+        lines.append(f"    └─ {content['name']} → currently: {classify_installable_location(destination, symlink)}")
+    return lines

--- a/bin/lib/cli/cefs.py
+++ b/bin/lib/cli/cefs.py
@@ -821,6 +821,9 @@ def gc(context: CliContext, force: bool, min_age: str, include_broken: bool, cle
             raise click.ClickException(f"GC completed with {error_count} errors during analysis")
         return
 
+    installables_by_name = {installable.name: installable for installable in context.get_installables([])}
+    destination_root = context.installation_context.destination
+
     _LOGGER.info("Unreferenced CEFS images to delete:")
     for image_path in unreferenced:
         try:
@@ -838,7 +841,7 @@ def gc(context: CliContext, force: bool, min_age: str, include_broken: bool, cle
         )
 
         # Show where each Installable in this image is currently installed
-        for line in get_installable_current_locations(image_path):
+        for line in get_installable_current_locations(image_path, installables_by_name, destination_root):
             _LOGGER.info(line)
 
     if context.installation_context.dry_run:

--- a/bin/test/cefs/formatting_test.py
+++ b/bin/test/cefs/formatting_test.py
@@ -3,13 +3,16 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
 from lib.cefs.formatting import (
+    classify_installable_location,
     format_image_contents_string,
     get_image_description,
     get_image_description_from_manifest,
+    get_installable_current_locations,
 )
 
 from test.cefs.test_helpers import make_test_manifest
@@ -83,3 +86,100 @@ def test_get_image_description_integration(tmp_path):
     # Test without manifest (will try to mount, which will fail)
     manifest_path.unlink()
     assert get_image_description(image_path, cefs_mount) is None  # Falls back to mounting which fails in test
+
+
+def test_classify_installable_location_no_symlink_directory_exists(tmp_path):
+    dest = tmp_path / "gcc-11"
+    dest.mkdir()
+    assert classify_installable_location(dest, None) == f"{dest} [directory]"
+
+
+def test_classify_installable_location_no_symlink_missing(tmp_path):
+    dest = tmp_path / "gcc-11"
+    assert classify_installable_location(dest, None) == "NOT INSTALLED"
+
+
+def test_classify_installable_location_symlink_missing_and_dest_missing(tmp_path):
+    dest = tmp_path / "gcc-trunk-20250916"
+    symlink = tmp_path / "gcc-trunk"
+    assert classify_installable_location(dest, symlink) == "NOT INSTALLED"
+
+
+def test_classify_installable_location_symlink_points_to_this(tmp_path):
+    dest = tmp_path / "gcc-trunk-20250916"
+    dest.mkdir()
+    symlink = tmp_path / "gcc-trunk"
+    symlink.symlink_to("gcc-trunk-20250916")
+    result = classify_installable_location(dest, symlink)
+    assert result == f"{symlink} -> gcc-trunk-20250916"
+
+
+def test_classify_installable_location_symlink_superseded(tmp_path):
+    # Old dated destination no longer on disk
+    dest = tmp_path / "gcc-trunk-20250916"
+    # A newer dated dir exists and the un-dated symlink points at it
+    newer = tmp_path / "gcc-trunk-20260407"
+    newer.mkdir()
+    symlink = tmp_path / "gcc-trunk"
+    symlink.symlink_to("gcc-trunk-20260407")
+    result = classify_installable_location(dest, symlink)
+    assert result == f"{symlink} -> gcc-trunk-20260407 (this image: gcc-trunk-20250916, superseded)"
+
+
+@dataclass
+class _FakeInstallable:
+    name: str
+    path_name_symlink: str | None = None
+    install_path_symlink: str | None = None
+
+
+def test_get_installable_current_locations_uses_installable_lookup(tmp_path):
+    image_path = tmp_path / "test.sqfs"
+    manifest_path = image_path.with_suffix(".yaml")
+
+    dest = tmp_path / "gcc-trunk-20250916"
+    newer = tmp_path / "gcc-trunk-20260407"
+    newer.mkdir()
+    symlink = tmp_path / "gcc-trunk"
+    symlink.symlink_to("gcc-trunk-20260407")
+
+    manifest_path.write_text(
+        yaml.dump(make_test_manifest(contents=[{"name": "compilers/c++/x86/gcc trunk", "destination": str(dest)}]))
+    )
+
+    installables = {"compilers/c++/x86/gcc trunk": _FakeInstallable("compilers/c++/x86/gcc trunk", "gcc-trunk")}
+    lines = get_installable_current_locations(image_path, installables, tmp_path)
+    assert len(lines) == 1
+    assert "superseded" in lines[0]
+    assert "NOT INSTALLED" not in lines[0]
+
+
+def test_get_installable_current_locations_unknown_installable(tmp_path):
+    image_path = tmp_path / "test.sqfs"
+    manifest_path = image_path.with_suffix(".yaml")
+    manifest_path.write_text(
+        yaml.dump(
+            make_test_manifest(
+                contents=[{"name": "compilers/c++/x86/gcc 11.0.0", "destination": str(tmp_path / "gcc-11")}]
+            )
+        )
+    )
+    # Lookup map is empty: falls back to destination check, which is NOT INSTALLED.
+    lines = get_installable_current_locations(image_path, {}, tmp_path)
+    assert len(lines) == 1
+    assert "NOT INSTALLED" in lines[0]
+
+
+def test_get_installable_current_locations_no_lookup(tmp_path):
+    image_path = tmp_path / "test.sqfs"
+    manifest_path = image_path.with_suffix(".yaml")
+    manifest_path.write_text(
+        yaml.dump(
+            make_test_manifest(
+                contents=[{"name": "compilers/c++/x86/gcc 11.0.0", "destination": str(tmp_path / "gcc-11")}]
+            )
+        )
+    )
+    lines = get_installable_current_locations(image_path)
+    assert len(lines) == 1
+    assert "NOT INSTALLED" in lines[0]


### PR DESCRIPTION
## Summary

- The CEFS GC listing for unreferenced images called dated nightly destinations `NOT INSTALLED` once the dated directory was pruned, even though the un-dated symlink (e.g. `gcc-trunk`) was still alive and just pointing at a newer build.
- Fix entirely on the GC display side: `get_installable_current_locations` now takes the loaded installables map and looks each manifest entry up by name, reading the un-dated symlink (`path_name_symlink` / `install_path_symlink`) directly off the `Installable`. No install-time plumbing or manifest schema changes — works on every existing image immediately.
- `classify_installable_location` reports e.g. `gcc-trunk -> gcc-trunk-20260407 (this image: gcc-trunk-20250916, superseded)` instead of `NOT INSTALLED`. Falls back to the previous behaviour when there's no installable / no symlink.
- Re-enables the periodic `cefs-gc` workflow now that its output is no longer misleading (was disabled in be9ebcea).

## Test plan

- [x] `uv run pytest bin/test/cefs/` (136 passed)
- [x] `make pre-commit` (Python checks clean; terraform hooks skipped — no terraform installed locally)
- [ ] Watch first scheduled `cefs-gc` run for sane output