### PR TITLE
[swift]: keep existing directory naming convention per feedback

### DIFF
--- a/bin/yaml/swift.yaml
+++ b/bin/yaml/swift.yaml
@@ -41,10 +41,8 @@ compilers:
       url: https://download.swift.org/{{build}}/ubuntu2204/{{toolchain}}/{{toolchain}}-ubuntu22.04.tar.gz
       targets:
           - '6.2'
-          - name: '6.2.4'
-            dir: swift-6.2.x
-          - name: '6.3'
-            dir: swift-6.3.x
+          - '6.2.4'
+          - '6.3'
 
     static-sdk:
       url: https://download.swift.org/{{build}}/static-sdk/{{toolchain}}/{{toolchain}}_static-linux-{{sdk_version}}.artifactbundle.tar.gz
@@ -62,10 +60,8 @@ compilers:
       sdk-0-1-0:
         sdk_version: '0.1.0'
         targets:
-          - name: '6.2.4'
-            dir: swift-6.2.x-static-sdk
-          - name: '6.3'
-            dir: swift-6.3.x-static-sdk
+          - '6.2.4'
+          - '6.3'
     nightly:
       if: nightly
       type: restQueryTarballs


### PR DESCRIPTION
Per discussion in https://github.com/compiler-explorer/infra/pull/2045, keep the existing directory naming convention because the reason I had for changing it doesn't seem like it makes sense.