### PR TITLE
Bypass enable-check when loading installables for CEFS GC display

### DIFF
--- a/bin/lib/cli/cefs.py
+++ b/bin/lib/cli/cefs.py
@@ -821,7 +821,9 @@ def gc(context: CliContext, force: bool, min_age: str, include_broken: bool, cle
             raise click.ClickException(f"GC completed with {error_count} errors during analysis")
         return
 
-    installables_by_name = {installable.name: installable for installable in context.get_installables([])}
+    installables_by_name = {
+        installable.name: installable for installable in context.get_installables([], bypass_enable_check=True)
+    }
     destination_root = context.installation_context.destination
 
     _LOGGER.info("Unreferenced CEFS images to delete:")


### PR DESCRIPTION
## Summary

- The superseded-nightly display added in #2053 looks installables up by name to find their un-dated symlink, but nightlies are gated behind `--enable=nightly`. The `gc` command doesn't pass `bypass_enable_check`, so every nightly in the GC report fell back to `NOT INSTALLED`.
- Observed on `arm64-gcc-trunk`: the image at `arm64/gcc-trunk-20260329` was reported `NOT INSTALLED` despite `/opt/compiler-explorer/arm64/gcc-trunk` pointing at `gcc-trunk-20260409`. Passing `bypass_enable_check=True` makes the lookup see the nightly installable and report "superseded" correctly. Safe here because GC only needs these entries for display — it's not installing anything.

## Test plan

- [x] `uv run pytest bin/test/cefs/` (136 passed — existing coverage of `get_installable_current_locations` already validates the superseded path once the lookup works)
- [ ] Watch next scheduled `cefs-gc` run for nightly images reporting "superseded" instead of "NOT INSTALLED"