### PR TITLE
fix: prevent fresh+reconsolidation item name collision in CEFS consolidation

### DIFF
--- a/bin/lib/cefs/consolidation.py
+++ b/bin/lib/cefs/consolidation.py
@@ -683,10 +683,24 @@ def prepare_consolidation_items(
     """
     items_for_consolidation = []
     subdir_mapping = {}
+    seen_subdir_names: dict[str, str] = {}  # subdir_name -> item.name, for duplicate detection
 
     for item in group:
         # Use the installable name as subdirectory name (sanitized for filesystem)
         subdir_name = sanitize_path_for_filename(Path(item.name))
+
+        # Guard against duplicate subdir names within the same group. This can happen when a
+        # fresh item and a reconsolidation item have the same installable name — both produce
+        # the same sanitized subdir_name and parallel workers would race to write to the same
+        # extraction directory (OSError: Directory not empty).
+        if subdir_name in seen_subdir_names:
+            raise ValueError(
+                f"Duplicate subdir name '{subdir_name}' in consolidation group: "
+                f"'{item.name}' (from_reconsolidation={item.from_reconsolidation}) conflicts with "
+                f"'{seen_subdir_names[subdir_name]}'. "
+                f"Fresh items and reconsolidation items with the same name must not appear in the same group."
+            )
+        seen_subdir_names[subdir_name] = item.name
 
         # For reconsolidation items, we already have the extraction path
         if item.from_reconsolidation:

--- a/bin/lib/cli/cefs.py
+++ b/bin/lib/cli/cefs.py
@@ -596,8 +596,18 @@ def consolidate(
 
         if recon_candidates:
             _LOGGER.info("Found %d items from consolidated images for reconsolidation", len(recon_candidates))
-            # Reconsolidation candidates are already in the right format
-            cefs_items.extend(recon_candidates)
+            # Filter out reconsolidation candidates whose name already appears as a fresh item.
+            # If both a fresh item and a reconsolidation item have the same name they would
+            # produce the same sanitized subdir_name and race when extracted in parallel.
+            fresh_names = {item.name for item in cefs_items}
+            filtered_recon = [c for c in recon_candidates if c.name not in fresh_names]
+            skipped = len(recon_candidates) - len(filtered_recon)
+            if skipped:
+                _LOGGER.info(
+                    "Skipping %d reconsolidation candidate(s) whose name already appears as a fresh item",
+                    skipped,
+                )
+            cefs_items.extend(filtered_recon)
 
     if not cefs_items:
         _LOGGER.warning("No CEFS items found matching filter: %s", " ".join(filter_) if filter_ else "all")

--- a/bin/test/cefs/consolidation_test.py
+++ b/bin/test/cefs/consolidation_test.py
@@ -862,3 +862,51 @@ def test_gather_reconsolidation_candidates(tmp_path):
     assert len(candidates_filtered) == 2
     filtered_names = {c.name for c in candidates_filtered}
     assert filtered_names == {"tools/small 1.0.0", "tools/small 2.0.0"}
+
+
+def test_prepare_consolidation_items_rejects_duplicate_names(tmp_path):
+    """Test that prepare_consolidation_items raises when a fresh item and reconsolidation item
+    produce the same sanitized subdir_name within the same group.
+
+    This is the root cause of the CEFS consolidation failure where two parallel workers both
+    tried to extract to the same directory:
+      compilers_swift_static-sdk_sdk-0-1-0_6.2.4
+    One was a fresh item 'compilers/swift/static-sdk/sdk-0-1-0 6.2.4', the other a
+    reconsolidation item with the same name from an existing consolidated image.
+    """
+    mount_point = Path("/cefs")
+
+    # Fresh item: compilers/swift/static-sdk/sdk-0-1-0 6.2.4
+    # Sanitized: compilers_swift_static-sdk_sdk-0-1-0_6.2.4
+    fresh_path = tmp_path / "swift-static-sdk-6.2.4"
+    cefs_target = mount_point / "7e" / "7e37bea4f759832456d69f12_swift-6.2.4-static-sdk"
+    fresh_path.symlink_to(cefs_target)
+
+    # Reconsolidation item with the same name (from an existing consolidated image)
+    # Its extraction_path is the sanitized subdir name used when it was originally consolidated
+    recon_path = tmp_path / "swift-static-sdk-6.2.4-recon"  # different nfs_path, same name
+
+    group = [
+        ConsolidationCandidate(
+            name="compilers/swift/static-sdk/sdk-0-1-0 6.2.4",
+            nfs_path=fresh_path,
+            squashfs_path=Path("/efs/cefs-images/7e/7e37bea4f759832456d69f12_swift-6.2.4-static-sdk.sqfs"),
+            size=238_000_000,
+            from_reconsolidation=False,
+        ),
+        ConsolidationCandidate(
+            name="compilers/swift/static-sdk/sdk-0-1-0 6.2.4",  # same name!
+            nfs_path=recon_path,
+            squashfs_path=Path("/efs/cefs-images/26/26ccf7a2fd1f9d4667de2307_consolidated.sqfs"),
+            size=50_000_000,
+            extraction_path=Path("compilers_swift_static-sdk_sdk-0-1-0_6.2.4"),
+            from_reconsolidation=True,
+        ),
+    ]
+
+    # Both items produce the same sanitized subdir_name: 'compilers_swift_static-sdk_sdk-0-1-0_6.2.4'
+    # prepare_consolidation_items should detect this and raise, OR
+    # pack_items_into_groups should prevent duplicate names from being in the same group.
+    # Either way, two items with the same name must not appear in the same consolidation group.
+    with pytest.raises((ValueError, AssertionError)):
+        prepare_consolidation_items(group, mount_point)

--- a/bin/test/cefs/consolidation_test.py
+++ b/bin/test/cefs/consolidation_test.py
@@ -864,27 +864,27 @@ def test_gather_reconsolidation_candidates(tmp_path):
     assert filtered_names == {"tools/small 1.0.0", "tools/small 2.0.0"}
 
 
-def test_prepare_consolidation_items_rejects_duplicate_names(tmp_path):
-    """Test that prepare_consolidation_items raises when a fresh item and reconsolidation item
-    produce the same sanitized subdir_name within the same group.
+def test_duplicate_subdir_names_in_consolidation_group_are_rejected(tmp_path):
+    """Regression test: fresh item + reconsolidation item with the same name must not appear
+    in the same consolidation group.
 
-    This is the root cause of the CEFS consolidation failure where two parallel workers both
-    tried to extract to the same directory:
-      compilers_swift_static-sdk_sdk-0-1-0_6.2.4
-    One was a fresh item 'compilers/swift/static-sdk/sdk-0-1-0 6.2.4', the other a
-    reconsolidation item with the same name from an existing consolidated image.
+    Production failure (2026-04-10, run #24232582644):
+      OSError: [Errno 39] Directory not empty:
+        .tmp_extract_2d3e5ffc/compilers_swift_static-sdk_sdk-0-1-0_6.2.4
+        -> compilers_swift_static-sdk_sdk-0-1-0_6.2.4
+
+    Both 'compilers/swift/static-sdk/sdk-0-1-0 6.2.4' (fresh install) and a
+    reconsolidation candidate from an existing consolidated image produced the
+    same sanitized subdir_name. Parallel workers raced to write the same
+    directory, and the second found it non-empty.
     """
     mount_point = Path("/cefs")
 
-    # Fresh item: compilers/swift/static-sdk/sdk-0-1-0 6.2.4
-    # Sanitized: compilers_swift_static-sdk_sdk-0-1-0_6.2.4
     fresh_path = tmp_path / "swift-static-sdk-6.2.4"
     cefs_target = mount_point / "7e" / "7e37bea4f759832456d69f12_swift-6.2.4-static-sdk"
     fresh_path.symlink_to(cefs_target)
 
-    # Reconsolidation item with the same name (from an existing consolidated image)
-    # Its extraction_path is the sanitized subdir name used when it was originally consolidated
-    recon_path = tmp_path / "swift-static-sdk-6.2.4-recon"  # different nfs_path, same name
+    recon_path = tmp_path / "swift-static-sdk-6.2.4-recon"
 
     group = [
         ConsolidationCandidate(
@@ -895,7 +895,7 @@ def test_prepare_consolidation_items_rejects_duplicate_names(tmp_path):
             from_reconsolidation=False,
         ),
         ConsolidationCandidate(
-            name="compilers/swift/static-sdk/sdk-0-1-0 6.2.4",  # same name!
+            name="compilers/swift/static-sdk/sdk-0-1-0 6.2.4",  # same name as above
             nfs_path=recon_path,
             squashfs_path=Path("/efs/cefs-images/26/26ccf7a2fd1f9d4667de2307_consolidated.sqfs"),
             size=50_000_000,
@@ -904,9 +904,8 @@ def test_prepare_consolidation_items_rejects_duplicate_names(tmp_path):
         ),
     ]
 
-    # Both items produce the same sanitized subdir_name: 'compilers_swift_static-sdk_sdk-0-1-0_6.2.4'
-    # prepare_consolidation_items should detect this and raise, OR
-    # pack_items_into_groups should prevent duplicate names from being in the same group.
-    # Either way, two items with the same name must not appear in the same consolidation group.
-    with pytest.raises((ValueError, AssertionError)):
+    # Both items sanitize to the same subdir_name: 'compilers_swift_static-sdk_sdk-0-1-0_6.2.4'.
+    # prepare_consolidation_items must detect this and raise ValueError — if it silently
+    # returned both, parallel workers would race to extract to the same directory.
+    with pytest.raises(ValueError, match="Duplicate subdir name"):
         prepare_consolidation_items(group, mount_point)


### PR DESCRIPTION
## Problem

CEFS consolidation was failing with:
```
OSError: [Errno 39] Directory not empty:
  .tmp_extract_2d3e5ffc/compilers_swift_static-sdk_sdk-0-1-0_6.2.4
  -> compilers_swift_static-sdk_sdk-0-1-0_6.2.4
```
(from run https://github.com/compiler-explorer/infra/actions/runs/24232582644)

**Root cause:** A fresh item (`compilers/swift/static-sdk/sdk-0-1-0 6.2.4`) and a reconsolidation item with the same name (pulled from an existing consolidated image) were both placed in the same consolidation group. Both sanitize to the same subdir name (`compilers_swift_static-sdk_sdk-0-1-0_6.2.4`). When parallel workers extracted them, the second found the directory already written by the first.

## Fix

Two-layer defence:

**1. `cli/cefs.py` (prevent):** When assembling candidates, filter out reconsolidation items whose name already appears as a fresh item. The fresh item supersedes — it represents the current installed state; the reconsolidation item would just duplicate it.

**2. `consolidation.py` (detect):** Add a duplicate subdir_name guard in `prepare_consolidation_items` that raises `ValueError` if two items in the same group would produce the same extraction directory. Safety net for any future code path that assembles a bad group.

## Test

New test `test_prepare_consolidation_items_rejects_duplicate_names` reproduces the exact production scenario: a fresh Swift static SDK item and a reconsolidation item with the same name in the same group.

- Before fix: test **fails** (no exception raised — bug confirmed)
- After fix: test **passes** (ValueError raised — bug prevented)

*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*