### PR TITLE
fix: correct check_file for libraries/c++/frozen to README.rst

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -831,7 +831,7 @@ libraries:
       - 12.0.0
       type: github
     frozen:
-      check_file: README.md
+      check_file: README.rst
       repo: serge-sans-paille/frozen
       targets:
       - 1.2.0


### PR DESCRIPTION
## Problem

`libraries/c++/frozen 1.2.0` has always been broken: `ce_install` downloads and extracts the tarball fine, but then reports:
```
installed OK, but doesn't appear as installed after
```

Root cause: the `check_file` in `libraries.yaml` is set to `README.md`, but the [frozen library](https://github.com/serge-sans-paille/frozen) ships `README.rst` (reStructuredText), not `README.md`.

```
ls ~/opt/compiler-explorer/libs/frozen/1.2.0/
AUTHORS  CMakeLists.txt  LICENSE  README.rst  benchmarks  cmake  examples  include  tests
```

## Discovery

Caught by the CEFS consolidation post-consolidation `is_installed()` check on 2026-04-10 — the check correctly detected frozen 1.2.0 wasn't properly installed and rolled back the consolidation for that library.

## Fix

Change `check_file: README.md` → `check_file: README.rst`.

Reproduced and confirmed locally: install fails before fix, install succeeds (skipped as already installed) after fix.

*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*