### PR TITLE
Add C3 compilers up to 0.7.11

### DIFF
--- a/bin/yaml/c3.yaml
+++ b/bin/yaml/c3.yaml
@@ -7,7 +7,7 @@ compilers:
     strip_components: 1
     create_untar_dir: true
     check_exe: c3c --version
-    url: https://github.com/c3lang/c3c/releases/download/v{{name}}/c3-{{ubuntu}}.tar.gz
+    url: https://github.com/c3lang/c3c/releases/download/v{{name}}/c3-{{os_suffix}}.tar.gz
     older:
       targets:
         - name: 0.4
@@ -17,7 +17,7 @@ compilers:
         - name: 0.5.5
           url: https://github.com/c3lang/c3c/releases/download/v0.5.5/c3-ubuntu-20-0.5.5.tar.gz
     ubuntu20:
-      ubuntu: ubuntu-20
+      os_suffix: ubuntu-20
       targets:
         - 0.6.0
         - 0.6.1
@@ -30,9 +30,19 @@ compilers:
         - 0.6.8
         - 0.7.0
     ubuntu22:
-      ubuntu: ubuntu-22
+      os_suffix: ubuntu-22
       targets:
         - 0.7.1
         - 0.7.2
         - 0.7.3
         - 0.7.4
+        - 0.7.5
+        - 0.7.6
+        - 0.7.7
+        - 0.7.8
+    linux:
+      os_suffix: linux
+      targets:
+        - 0.7.9
+        - 0.7.10
+        - 0.7.11


### PR DESCRIPTION
Adds targets for C3 versions 0.7.5 through 0.7.11 and updates the config to support the new c3-linux.tar.gz release artifact name format

https://github.com/compiler-explorer/compiler-explorer/pull/8619