### PR TITLE
fix: ensure V lang VMODULES cache is world-writable after install

### DIFF
--- a/bin/yaml/v.yaml
+++ b/bin/yaml/v.yaml
@@ -6,6 +6,18 @@ compilers:
     folder: v
     check_exe: v --version
     check_env:
+      # V always initialises its module cache ($VMODULES/cache/) on startup, even for
+      # `v --version`. The install runs as root, which creates /tmp/.vmodules/cache/
+      # owned by root with drwx------ permissions. Subsequent check_exe runs as a
+      # non-root user then panic with "Permission denied".
+      #
+      # The after_stage_script (below) runs as root immediately after extraction and
+      # ensures the cache directory is world-writable so non-root checks succeed.
       - VMODULES=/tmp/.vmodules
+    after_stage_script:
+      # Ensure V's module cache directory is accessible by all users.
+      # Without this, the root-owned cache from the install blocks non-root check_exe.
+      - mkdir -p /tmp/.vmodules/cache
+      - chmod 777 /tmp/.vmodules /tmp/.vmodules/cache
     targets:
       - '2023.30'


### PR DESCRIPTION
## Problem

`compilers/v 2023.30` has been failing every nightly install since 2026-03-12 with:

```
V panic: folder: /tmp/.vmodules/cache/, error: Permission denied
```

V always initialises its module cache (`$VMODULES/cache/`) on startup — even for `v --version`. The install runs as root, creating `/tmp/.vmodules/cache/` owned by root with `drwx------` permissions. Subsequent `check_exe` calls (which run as non-root) then panic.

Confirmed on the admin node:
```
$ sudo ls -l /tmp/.vmodules/
total 4
drwx------ 2 root root 4096 Mar 12 19:37 cache
```

## Fix

Add an `after_stage_script` (which runs as root, immediately after extraction) that creates the cache directory and sets world-writable permissions so non-root users can access it.

Closes #2065

*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*