### PR TITLE
C3: Use static builds for 0.7.10 and 0.7.11

### DIFF
--- a/bin/yaml/c3.yaml
+++ b/bin/yaml/c3.yaml
@@ -44,5 +44,8 @@ compilers:
       os_suffix: linux
       targets:
         - 0.7.9
+    linux_static:
+      os_suffix: linux-static
+      targets:
         - 0.7.10
         - 0.7.11


### PR DESCRIPTION
This fixes "GLIBC_2.38 not found" errors by switching to the -linux-static tarballs for version 0.7.10 and 0.7.11.

previous PR: https://github.com/compiler-explorer/infra/pull/2061