### PR TITLE
Install nightly Rust daily instead of every 2 to 3 days

### DIFF
--- a/bin/lib/installable/rust.py
+++ b/bin/lib/installable/rust.py
@@ -84,12 +84,12 @@ class RustInstallable(Installable):
             dest_dir = self.install_context.destination / self.install_path
             if os.path.exists(dest_dir):
                 dtime = datetime.fromtimestamp(dest_dir.stat().st_mtime)
-                # The fudge factor of 30m is to sort of account for the installation time. Else
+                # The fudge factor of 90m is to sort of account for the installation time. Else
                 # we start up the same time the next day and we get a 23hr58 minute old build and we
                 # don't reinstall.
-                age = datetime.now() - dtime + timedelta(minutes=30)
+                age = datetime.now() - dtime + timedelta(minutes=90)
                 self._logger.info("Nightly build %s is %s old", dest_dir, age)
-                if age.days > self.nightly_install_days:
+                if age > timedelta(days=self.nightly_install_days):
                     return True
         return super().should_install()
 


### PR DESCRIPTION
`age.days` is the count of *whole* days (i. e. floored) of the `timedelta`, so this limits Rust nightly installs to every two days.

Additionally, it seems that 30 minutes is not enough to account for the installation time, e. g. today Rust nightly was not updated because it was 1d23h (+30min) old:
```
2026-04-15T06:12:39.0211723Z 2026-04-15 06:12:39,017 compilers/rust/newer/nightly nightly INFO     Nightly build /opt/compiler-explorer/rust-nightly is 1 day, 23:28:36.017363 old
```