### PR TITLE
Add nightly build for wasmtime

### DIFF
--- a/bin/yaml/wasm.yaml
+++ b/bin/yaml/wasm.yaml
@@ -16,6 +16,17 @@ compilers:
         - 41.0.0
         - 42.0.2
         - 43.0.1
+    nightly:
+      if: nightly
+      wasmtime:
+        type: nightlytarballs
+        compression: xz
+        url: https://github.com/bytecodealliance/wasmtime/releases/download/{{name}}/wasmtime-{{name}}-x86_64-linux.tar.xz
+        check_exe: wasmtime --version
+        dir: wasmtime-{{name}}
+        untar_dir: wasmtime-{{name}}-x86_64-linux
+        targets:
+          - dev
     wasi:
       type: tarballs
       compression: gz

--- a/update_compilers/install_libraries.sh
+++ b/update_compilers/install_libraries.sh
@@ -10,6 +10,7 @@ export PATH=$PATH:/opt/compiler-explorer/cmake/bin
 
 if install_nightly; then
     echo "Installing trunk versions"
+    ce_install 'wasmtime dev'
 else
     echo "Skipping install of trunk versions"
 fi

--- a/update_compilers/install_libraries.sh
+++ b/update_compilers/install_libraries.sh
@@ -10,7 +10,6 @@ export PATH=$PATH:/opt/compiler-explorer/cmake/bin
 
 if install_nightly; then
     echo "Installing trunk versions"
-    ce_install 'wasmtime dev'
 else
     echo "Skipping install of trunk versions"
 fi


### PR DESCRIPTION
The wasmtime nightly (dev) release already includes tarball artifacts, so it seems we can define everything declaratively