### PR TITLE
Use blue-green deploy for Start Staging workflow

### DIFF
--- a/.github/workflows/start_staging.yml
+++ b/.github/workflows/start_staging.yml
@@ -18,8 +18,6 @@ jobs:
 
     steps:
     - name: Update infra
-      run: cd /home/ubuntu/infra && git pull
-    - name: Set build number
-      run: ce builds set_current ${{ github.event.inputs.buildnumber }} --branch ${{ github.event.inputs.branch }} --confirm
-    - name: Start environment
-      run: ce environment start
+      run: cd /home/ubuntu/infra && git pull && make ce
+    - name: Blue-green deploy to staging
+      run: ce --env staging blue-green deploy --branch ${{ github.event.inputs.branch }} --skip-confirmation --no-notify ${{ github.event.inputs.buildnumber }}


### PR DESCRIPTION
## Summary
- Replace deprecated `builds set_current` + `environment start` pair with a single `ce --env staging blue-green deploy` call.
- Pass `--skip-confirmation` and `--no-notify` so the workflow stays non-interactive.
- Add `make ce` to the update step to match the pattern used in other admin-runner workflows.

Fixes #1930

## Test plan
- [ ] Trigger the workflow from GitHub Actions against staging with the default `latest`/`main` inputs and confirm the deploy completes without prompting.
- [ ] Re-run with an explicit `buildnumber` and non-default `branch` to confirm arguments are forwarded correctly.