### PR TITLE
Add Overt

### DIFF
--- a/bin/yaml/overt.yaml
+++ b/bin/yaml/overt.yaml
@@ -1,0 +1,32 @@
+# Compiler Explorer infra install recipe for Overt.
+#
+# Destination: compiler-explorer/infra:bin/yaml/overt.yaml
+# Docs: https://github.com/compiler-explorer/infra/blob/main/docs/adding_a_compiler.md
+#
+# This file tells CE's build farm where to download each released Overt
+# version and how to lay it out under /opt/compiler-explorer/overt-<version>/.
+#
+# The release tarball produced by .github/workflows/release.yml has shape:
+#     overt-<version>/
+#       bin/overt              <- single-file self-contained binary
+#       runtime/Overt.Runtime.dll
+#       LICENSE
+#       README.md
+#       VERSION
+#
+# strip_components: 0 keeps the overt-<version>/ prefix so the install path
+# ends up at /opt/compiler-explorer/overt-<version>/bin/overt — matching
+# compiler.overt010.exe in ../config/overt.defaults.properties.
+
+installers:
+  overt:
+    type: tarballs
+    compression: xz
+    url_pattern: https://github.com/paulmooreparks/Overt/releases/download/v{0}/overt-{0}-linux-x64.tar.xz
+    dir_pattern: overt-{0}
+    strip_components: 0
+    check_exe: bin/overt --version
+    targets:
+      # Add each tagged release here as it ships. CE's install farm re-runs
+      # this recipe whenever the list changes.
+      - 0.1.0-preview

--- a/bin/yaml/overt.yaml
+++ b/bin/yaml/overt.yaml
@@ -1,32 +1,9 @@
-# Compiler Explorer infra install recipe for Overt.
-#
-# Destination: compiler-explorer/infra:bin/yaml/overt.yaml
-# Docs: https://github.com/compiler-explorer/infra/blob/main/docs/adding_a_compiler.md
-#
-# This file tells CE's build farm where to download each released Overt
-# version and how to lay it out under /opt/compiler-explorer/overt-<version>/.
-#
-# The release tarball produced by .github/workflows/release.yml has shape:
-#     overt-<version>/
-#       bin/overt              <- single-file self-contained binary
-#       runtime/Overt.Runtime.dll
-#       LICENSE
-#       README.md
-#       VERSION
-#
-# strip_components: 0 keeps the overt-<version>/ prefix so the install path
-# ends up at /opt/compiler-explorer/overt-<version>/bin/overt — matching
-# compiler.overt010.exe in ../config/overt.defaults.properties.
-
-installers:
+compilers:
   overt:
     type: tarballs
     compression: xz
-    url_pattern: https://github.com/paulmooreparks/Overt/releases/download/v{0}/overt-{0}-linux-x64.tar.xz
-    dir_pattern: overt-{0}
-    strip_components: 0
+    url: https://github.com/paulmooreparks/Overt/releases/download/v{{name}}/overt-{{name}}-linux-x64.tar.xz
     check_exe: bin/overt --version
+    dir: overt-{{name}}
     targets:
-      # Add each tagged release here as it ships. CE's install farm re-runs
-      # this recipe whenever the list changes.
-      - 0.1.0-preview
+      - 0.2.0-preview.1


### PR DESCRIPTION
Adds an install recipe for Overt, an agent-first programming language that transpiles to C#.

- **Repo:** https://github.com/paulmooreparks/Overt
- **License:** Apache-2.0
- **Release artifact:** https://github.com/paulmooreparks/Overt/releases/download/v0.2.0-preview.1/overt-0.2.0-preview.1-linux-x64.tar.xz
- **Tarball layout:**

```
overt-0.2.0-preview.1/
    bin/
        overt (single-file self-contained Linux x64 CLI, built on Ubuntu 22.04 / glibc 2.35)
    runtime/
        Overt.Runtime.dll (consumed downstream when compiling the emitted C#; not loaded by the CLI itself)
    LICENSE
    README.md
    VERSION
```

`check_exe`: `bin/overt --version`. Binary is self-sufficient; no runtime installation needed on the host.