### PR TITLE
✨ C++ YAML for thephd.dev compiler

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1710,8 +1710,9 @@ compilers:
           - cppx-ext-trunk
           - cppx-p2320-trunk
           - concepts-trunk
-          - embed-trunk
-          - dang-main
+          #- embed-trunk
+          #- dang-main
+          - thephd.dev
           - widberg-main
           - mizvekov-resugar
           - relocatable-trunk


### PR DESCRIPTION
We only need to add it to the C++ YAML, we can reference the clang and clang++ executables from the c++ and c amazon.properties in the compiler-explorer.