### PR TITLE
✨ Library YAML for phd.embed library

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -2154,6 +2154,15 @@ libraries:
         targets:
         - trunk
         type: github
+      phd-embed:
+        build_type: none
+        check_file: include/phd/embed.hpp
+        method: nightlyclone
+        path_name: libs/phd/embed
+        repo: ThePhD/embed
+        targets:
+        - main
+        type: github
       pipes:
         build_type: none
         check_file: include/pipes/pipes.hpp


### PR DESCRIPTION
This is the nightly header-only pull for the ThePhD/embed library, phd.embed!

Should be straightforward. I... think I got the folder paths right here and in conjunction with the top-level compiler-explorer properties file too.