### PR TITLE
Add c++2d stdver and harden library batch builds against per-build exceptions

### DIFF
--- a/bin/lib/fortran_library_builder.py
+++ b/bin/lib/fortran_library_builder.py
@@ -894,6 +894,8 @@ class FortranLibraryBuilder:
                         else:
                             builds_failed = builds_failed + 1
                 except Exception:
+                    # Broad catch is intentional: one bad combination (e.g. conan rejecting a setting)
+                    # must not abort the rest of the batch.
                     self.logger.exception(f"Build of {compiler} {args} failed with an unexpected exception")
                     builds_failed = builds_failed + 1
 

--- a/bin/lib/fortran_library_builder.py
+++ b/bin/lib/fortran_library_builder.py
@@ -875,23 +875,27 @@ class FortranLibraryBuilder:
             for args in itertools.product(
                 build_supported_os, build_supported_buildtype, archs, stdvers, stdlibs, build_supported_flagscollection
             ):
-                with self.install_context.new_staging_dir() as staging:
-                    buildstatus = self.makebuildfor(
-                        compiler,
-                        options,
-                        exe,
-                        compilerType,
-                        toolchain,
-                        *args,
-                        self.compilerprops[compiler]["ldPath"],
-                        staging,
-                    )
-                    if buildstatus == BuildStatus.Ok:
-                        builds_succeeded = builds_succeeded + 1
-                    elif buildstatus == BuildStatus.Skipped:
-                        builds_skipped = builds_skipped + 1
-                    else:
-                        builds_failed = builds_failed + 1
+                try:
+                    with self.install_context.new_staging_dir() as staging:
+                        buildstatus = self.makebuildfor(
+                            compiler,
+                            options,
+                            exe,
+                            compilerType,
+                            toolchain,
+                            *args,
+                            self.compilerprops[compiler]["ldPath"],
+                            staging,
+                        )
+                        if buildstatus == BuildStatus.Ok:
+                            builds_succeeded = builds_succeeded + 1
+                        elif buildstatus == BuildStatus.Skipped:
+                            builds_skipped = builds_skipped + 1
+                        else:
+                            builds_failed = builds_failed + 1
+                except Exception:
+                    self.logger.exception(f"Build of {compiler} {args} failed with an unexpected exception")
+                    builds_failed = builds_failed + 1
 
             if builds_succeeded > 0:
                 self.upload_builds()

--- a/bin/lib/library_builder.py
+++ b/bin/lib/library_builder.py
@@ -1626,25 +1626,29 @@ class LibraryBuilder:
                 build_supported_os, buildtypes, archs, stdvers, stdlibs, build_supported_flagscollection
             ):
                 iteration += 1
-                with self.install_context.new_staging_dir() as staging:
-                    buildstatus = self.makebuildfor(
-                        compiler,
-                        options,
-                        exe,
-                        compilerType,
-                        toolchain,
-                        *args,
-                        self.compilerprops[compiler]["ldPath"],
-                        staging,
-                        self.compilerprops[compiler],
-                        iteration,
-                    )
-                    if buildstatus == BuildStatus.Ok:
-                        builds_succeeded = builds_succeeded + 1
-                    elif buildstatus == BuildStatus.Skipped:
-                        builds_skipped = builds_skipped + 1
-                    else:
-                        builds_failed = builds_failed + 1
+                try:
+                    with self.install_context.new_staging_dir() as staging:
+                        buildstatus = self.makebuildfor(
+                            compiler,
+                            options,
+                            exe,
+                            compilerType,
+                            toolchain,
+                            *args,
+                            self.compilerprops[compiler]["ldPath"],
+                            staging,
+                            self.compilerprops[compiler],
+                            iteration,
+                        )
+                        if buildstatus == BuildStatus.Ok:
+                            builds_succeeded = builds_succeeded + 1
+                        elif buildstatus == BuildStatus.Skipped:
+                            builds_skipped = builds_skipped + 1
+                        else:
+                            builds_failed = builds_failed + 1
+                except Exception:
+                    self.logger.exception(f"Build of {compiler} {args} failed with an unexpected exception")
+                    builds_failed = builds_failed + 1
 
             if builds_succeeded > 0:
                 self.upload_builds()

--- a/bin/lib/library_builder.py
+++ b/bin/lib/library_builder.py
@@ -1647,6 +1647,8 @@ class LibraryBuilder:
                         else:
                             builds_failed = builds_failed + 1
                 except Exception:
+                    # Broad catch is intentional: one bad combination (e.g. conan rejecting a setting)
+                    # must not abort the rest of the batch.
                     self.logger.exception(f"Build of {compiler} {args} failed with an unexpected exception")
                     builds_failed = builds_failed + 1
 

--- a/bin/lib/rust_library_builder.py
+++ b/bin/lib/rust_library_builder.py
@@ -697,14 +697,18 @@ class RustLibraryBuilder:
                     stdlibs,
                     build_supported_flagscollection,
                 ):
-                    buildstatus = self.makebuildfor(
-                        compiler, options, exe, compilerType, toolchain, *args, ldPath, source_staging
-                    )
-                    if buildstatus == BuildStatus.Ok:
-                        builds_succeeded = builds_succeeded + 1
-                    elif buildstatus == BuildStatus.Skipped:
-                        builds_skipped = builds_skipped + 1
-                    else:
+                    try:
+                        buildstatus = self.makebuildfor(
+                            compiler, options, exe, compilerType, toolchain, *args, ldPath, source_staging
+                        )
+                        if buildstatus == BuildStatus.Ok:
+                            builds_succeeded = builds_succeeded + 1
+                        elif buildstatus == BuildStatus.Skipped:
+                            builds_skipped = builds_skipped + 1
+                        else:
+                            builds_failed = builds_failed + 1
+                    except Exception:
+                        self.logger.exception(f"Build of {compiler} {args} failed with an unexpected exception")
                         builds_failed = builds_failed + 1
 
                 if builds_succeeded > 0:

--- a/bin/lib/rust_library_builder.py
+++ b/bin/lib/rust_library_builder.py
@@ -708,6 +708,8 @@ class RustLibraryBuilder:
                         else:
                             builds_failed = builds_failed + 1
                     except Exception:
+                        # Broad catch is intentional: one bad combination (e.g. conan rejecting a setting)
+                        # must not abort the rest of the batch.
                         self.logger.exception(f"Build of {compiler} {args} failed with an unexpected exception")
                         builds_failed = builds_failed + 1
 

--- a/init/settings.yml
+++ b/init/settings.yml
@@ -82,6 +82,6 @@ flagcollection: ANY
 
 stdlib: ['', libc++]
 
-stdver: ['', c++11, c++14, c++17, c++2a, c++20, c++2b, c++23, c++2c, c++26, gnu++11, gnu++14, gnu++17, gnu++2a, gnu++2c]
+stdver: ['', c++11, c++14, c++17, c++2a, c++20, c++2b, c++23, c++2c, c++26, c++2d, gnu++11, gnu++14, gnu++17, gnu++2a, gnu++2c]
 
 toolchain: ANY


### PR DESCRIPTION
## Summary

The library build run was aborting with:

```
ERROR: Invalid setting 'c++2d' is not a valid 'settings.stdver' value.
Possible values are ['', 'c++11', ..., 'c++2c', 'c++26', ...]
```

thephd.dev (added in #2086) defaults to `-std=c++2d`, which Conan rejected because the value wasn't in `init/settings.yml`'s `stdver` allow-list. The Conan exception bubbled out of `makebuildfor` and killed the rest of the batch run, e.g. https://github.com/compiler-explorer/infra/actions/runs/25278844312/job/74113504606.

Two changes:

- Add `c++2d` to the `stdver` list in `init/settings.yml`.
- Wrap each `makebuildfor` call in the per-compiler combination loops (`library_builder.py`, `fortran_library_builder.py`, `rust_library_builder.py`) so an unexpected exception is logged and counted as a failure without aborting the other combinations.

## Test plan

- [x] `make static-checks`
- [x] `make test`
- [ ] Re-run the failing daily library build job to confirm c++2d is accepted and a single broken combination doesn't take the rest down