### PR TITLE
✨ C++ YAML for gcc.thephd.dev/clang.thephd.dev compilers (separated)

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1700,6 +1700,7 @@ compilers:
           - contracts-GNUext-trunk
           - thomas-healy-trunk
           - trivial-relocation-trunk
+          - gcc.thephd.dev
       clang:
         type: nightly
         check_exe: bin/clang++ --version
@@ -1712,7 +1713,7 @@ compilers:
           - concepts-trunk
           - embed-trunk
           - dang-main
-          - thephd.dev
+          - clang.thephd.dev
           - widberg-main
           - mizvekov-resugar
           - relocatable-trunk

--- a/init/settings.yml
+++ b/init/settings.yml
@@ -82,6 +82,6 @@ flagcollection: ANY
 
 stdlib: ['', libc++]
 
-stdver: ['', c++11, c++14, c++17, c++2a, c++20, c++2b, c++23, c++2c, c++26, c++2d, gnu++11, gnu++14, gnu++17, gnu++2a, gnu++2c]
+stdver: ['', c++11, c++14, c++17, c++2a, c++20, c++2b, c++23, c++2c, c++26, c++2d, gnu++11, gnu++14, gnu++17, gnu++2a, gnu++2c, gnu++2d]
 
 toolchain: ANY


### PR DESCRIPTION
As per https://github.com/compiler-explorer/compiler-workflows/pull/63 -- separate out the two builds for the two different compilers, so that both can be used.

Also add `gnu++2d` as a valid standard flag, as that's a flag supported by the GCC build (has not hit trunk yet, I don't think).