### PR TITLE
Use curl -fsL for conan-proxy prebuild downloads

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -429,7 +429,7 @@ libraries:
       postbuild_script_pwsh:
       - echo "skipping zlib check"
       prebuild_script:
-      - curl -sL -o zlib.tgz https://conan.compiler-explorer.com/downloadpkg/zlib/1.3.1/%compiler%/%arch%/%libcxx%
+      - curl -fsL -o zlib.tgz https://conan.compiler-explorer.com/downloadpkg/zlib/1.3.1/%compiler%/%arch%/%libcxx%
       - mkdir -p /tmp/zlib
       - tar xzf zlib.tgz -C /tmp/zlib
       prebuild_script_pwsh:
@@ -2687,7 +2687,7 @@ libraries:
       - echo "postbuild not using abseil"
       prebuild_script:
       - mkdir -p /tmp/abseil-cpp
-      - curl -sL https://conan.compiler-explorer.com/downloadpkg/abseil/20250127.0/%compiler%/%arch%/%libcxx%
+      - curl -fsL https://conan.compiler-explorer.com/downloadpkg/abseil/20250127.0/%compiler%/%arch%/%libcxx%
         -o abseil-cpp-20250127.0.tar.gz
       - tar xzf abseil-cpp-20250127.0.tar.gz -C /tmp/abseil-cpp
       prebuild_script_pwsh:
@@ -3299,7 +3299,7 @@ libraries:
       build_type: fpm
       check_file: fpm.toml
       prebuild_script:
-      - curl -sL -o curl.tgz https://conan.compiler-explorer.com/downloadcshared/curl/7.83.1
+      - curl -fsL -o curl.tgz https://conan.compiler-explorer.com/downloadcshared/curl/7.83.1
       - tar -xzf curl.tgz
       - cp lib/libcurl-d.so lib/libcurl.so
       - export FPM_CFLAGS="-I/opt/compiler-explorer/libs/curl/7.83.1/include"
@@ -3332,7 +3332,7 @@ libraries:
         check_file: fpm.toml
         method: nightlyclone
         prebuild_script:
-        - curl -sL -o curl.tgz https://conan.compiler-explorer.com/downloadcshared/curl/7.83.1
+        - curl -fsL -o curl.tgz https://conan.compiler-explorer.com/downloadcshared/curl/7.83.1
         - tar -xzf curl.tgz
         - cp lib/libcurl-d.so lib/libcurl.so
         - export FPM_CFLAGS="-I/opt/compiler-explorer/libs/curl/7.83.1/include"


### PR DESCRIPTION
## Summary

Four library prebuild scripts in `libraries.yaml` use `curl -sL` to pull pre-built dependencies from the conan proxy. `curl -sL` happily writes the response body to disk on 4xx/5xx — so a 404 (e.g. when the dependency hasn't been built for the requesting compiler yet) ends up as the literal bytes `Not Found` in the target tarball. The downstream `tar xzf` then fails with `gzip: stdin: not in gzip format`, several seconds and three layers of cascade away from the actual cause.

`-f` makes curl exit non-zero on 4xx/5xx so the build aborts cleanly at the download step. The downloads themselves don't get any easier — but the failure mode does.

Touched scripts:
- `boost_bin` → zlib
- `re2` → abseil
- `http_client` → curl
- `forcompile/nightly` → curl

## Context

Surfaced today while debugging clang_barry × boost_bin (run [25341996247](https://github.com/compiler-explorer/infra/actions/runs/25341996247)). The actual root cause was that zlib hasn't been built for clang_barry — that's tracked in #2092 and **is not** fixed by this PR. This PR only makes that class of failure surface as the right error instead of `gzip: stdin: not in gzip format`.

## Test plan

- [x] `make static-checks`
- [x] **Failure case** — curl against a known-missing dep (clang_barry, no zlib built):
  ```
  $ curl -fsL -o /tmp/zlib.tgz "https://conan.compiler-explorer.com/downloadpkg/zlib/1.3.1/clang_barry/x86_64/libc++"
  $ echo $?
  22
  $ ls /tmp/zlib.tgz
  ls: cannot access '/tmp/zlib.tgz': No such file or directory
  ```
  Curl exits 22 and writes nothing — the build will abort here with a clear message instead of cascading into tar/readelf.
- [x] **Success case** — curl against an existing dep (g141, libstdc++):
  ```
  $ curl -fsL -o /tmp/zlib.tgz "https://conan.compiler-explorer.com/downloadpkg/zlib/1.3.1/g141/x86_64/libstdc++"
  $ echo $?
  0
  $ file /tmp/zlib.tgz
  /tmp/zlib.tgz: gzip compressed data, was "conan_package.tgz", max compression, ...
  ```
  Curl exits 0, downloads ~277KB, valid gzip — happy path still works.
- [ ] End-to-end exercise via `workflow_dispatch` requires merge first: `lin-lib-build.yaml` hardcodes `refs/heads/main` for `start-builder.sh` and that script clones infra from main, so PR-branch builds run against main's YAML regardless of `--ref`. Will tick after merge by triggering a small targeted run.