### PR TITLE
Upload clang crash dumps and build logs as artifact on lib-build failure

### DIFF
--- a/.github/workflows/lin-lib-build.yaml
+++ b/.github/workflows/lin-lib-build.yaml
@@ -63,3 +63,22 @@ jobs:
 
       - name: Build libraries
         run: cd /tmp && chmod +x start-builder.sh && ./start-builder.sh "${{ secrets.CONAN_PASSWORD }}" "${{ steps.extract.outputs.language }}" "${{ steps.extract.outputs.library_name }}" "${{ inputs.compiler }}"
+
+      - name: Upload build failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-failure-${{ inputs.compiler }}-${{ steps.extract.outputs.library_name }}-${{ github.run_id }}
+          path: |
+            /tmp/*.cpp
+            /tmp/*.ii
+            /tmp/*.c
+            /tmp/*.s
+            /tmp/*.sh
+            /tmp/ce-cefs-temp/staging/**/cemakelog*.txt
+            /tmp/ce-cefs-temp/staging/**/cecmakelog.txt
+            /tmp/ce-cefs-temp/staging/**/ceconfiglog.txt
+            /tmp/ce-cefs-temp/staging/**/cemakeclean.txt
+            /tmp/ce-cefs-temp/staging/**/ceinstall_*.txt
+          if-no-files-found: warn
+          retention-days: 14


### PR DESCRIPTION
## Summary

When a Linux library build fails, capture and upload the diagnostic files we'd otherwise have to SSH a runner to retrieve:

- `/tmp/*.{cpp,ii,c,s,sh}` — clang's crash-dump files (preprocessed source + run script) when the compiler asserts or otherwise SIGABRTs.
- `ce*log*.txt` from the build's staging dir — cmake configure/build/install logs, configure log, make-clean log.

Retention 14 days, artifact named after compiler / library / run id.

## Why

Surfaced while debugging boost_bin × clang_barry: the actual clang frontend assertion crash (`Assertion '!isValueDependent()' failed.`) is buried in the middle of a parallel build's output and got squeezed out of the `tail -200` dump from #2094. Having the full logs and the preprocessed-source crash dumps as artifacts means we can hand them to upstream compiler authors directly without re-running anything.

## Test plan

- [x] `make static-checks` passes
- [ ] Trigger a known-failing build (boost_bin × clang_barry) and confirm the artifact appears, contains the expected crash dump and log files, and is downloadable. (Will verify post-merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)