### PR TITLE
Replace per-iter conan info subprocess with cached /search API

### DIFF
--- a/bin/lib/fortran_library_builder.py
+++ b/bin/lib/fortran_library_builder.py
@@ -25,6 +25,7 @@ from lib.amazon import get_ssm_param
 from lib.amazon_properties import get_properties_compilers_and_libraries, get_specific_library_version_details
 from lib.installation_context import FetchFailure, PostFailure
 from lib.library_build_config import LibraryBuildConfig
+from lib.library_builder import build_target_settings, conan_search_url, match_conan_settings
 from lib.library_platform import LibraryPlatform
 from lib.staging import StagingDir
 
@@ -46,7 +47,6 @@ _propsandlibs: dict[str, Any] = defaultdict(lambda: [])
 _supports_x86: dict[str, Any] = defaultdict(lambda: [])
 
 GITCOMMITHASH_RE = re.compile(r"^(\w*)\s.*")
-CONANINFOHASH_RE = re.compile(r"\s+ID:\s(\w*)")
 
 
 def _quote(string: str) -> str:
@@ -98,7 +98,7 @@ class FortranLibraryBuilder:
         self.needs_uploading = 0
         self.libid = self.libname  # TODO: CE libid might be different from yaml libname
         self.conanserverproxy_token = None
-        self._conan_hash_cache: dict[str, str | None] = {}
+        self._possible_builds: dict[str, Any] | None = None
         self._annotations_cache: dict[str, dict] = {}
         self.http_session = requests.Session()
 
@@ -450,24 +450,46 @@ class FortranLibraryBuilder:
 
         return compiler + "_" + hasher.hexdigest()
 
+    def _get_possible_builds(self) -> dict[str, Any]:
+        if self._possible_builds is not None:
+            return self._possible_builds
+
+        url = conan_search_url(self.libname, self.target_name)
+        try:
+            request = self.http_session.get(url, timeout=_TIMEOUT)
+        except requests.RequestException as e:
+            self.logger.warning(f"Conan search failed for {self.libname}/{self.target_name}: {e}")
+            self._possible_builds = {}
+            return self._possible_builds
+
+        if not request.ok:
+            if request.status_code == 404:
+                self.logger.debug(f"No uploaded builds yet for {self.libname}/{self.target_name}")
+            else:
+                self.logger.warning(f"Conan search failed for {self.libname}/{self.target_name}: {request.status_code}")
+            self._possible_builds = {}
+            return self._possible_builds
+
+        try:
+            payload = request.json()
+        except ValueError:
+            self.logger.warning(f"Conan search returned non-JSON for {self.libname}/{self.target_name}")
+            payload = {}
+        if not isinstance(payload, dict):
+            self.logger.warning(f"Conan search returned non-object JSON for {self.libname}/{self.target_name}")
+            payload = {}
+        self._possible_builds = payload
+        return self._possible_builds
+
     def get_conan_hash(self, buildfolder: str) -> str | None:
-        if buildfolder in self._conan_hash_cache:
-            self.logger.debug(f"Using cached conan hash for {buildfolder}")
-            return self._conan_hash_cache[buildfolder]
+        if self.install_context.dry_run:
+            return None
 
-        if not self.install_context.dry_run:
-            self.logger.debug(["conan", "info", "."] + self.current_buildparameters)
-            conaninfo = subprocess.check_output(
-                ["conan", "info", "-r", "ceserver", "."] + self.current_buildparameters, cwd=buildfolder
-            ).decode("utf-8", "ignore")
-            self.logger.debug(conaninfo)
-            match = CONANINFOHASH_RE.search(conaninfo, re.MULTILINE)
-            if match:
-                result = match[1]
-                self._conan_hash_cache[buildfolder] = result
-                return result
-
-        self._conan_hash_cache[buildfolder] = None
+        target = build_target_settings(self.current_buildparameters_obj)
+        for package_id, entry in self._get_possible_builds().items():
+            settings = entry.get("settings", {}) if isinstance(entry, dict) else {}
+            if match_conan_settings(target, settings):
+                return package_id
         return None
 
     def conanproxy_login(self):
@@ -581,15 +603,17 @@ class FortranLibraryBuilder:
             return False
 
     def set_as_uploaded(self, buildfolder):
+        # Order matters: upload_builds must run before get_conan_hash. See library_builder.py
+        # set_as_uploaded for the full reasoning.
+        annotations = self.get_build_annotations(buildfolder)
+        if "commithash" not in annotations:
+            self.upload_builds()
+
         conanhash = self.get_conan_hash(buildfolder)
         if conanhash is None:
             raise RuntimeError(f"Error determining conan hash in {buildfolder}")
 
         self.logger.info(f"commithash: {conanhash}")
-
-        annotations = self.get_build_annotations(buildfolder)
-        if "commithash" not in annotations:
-            self.upload_builds()
         annotations["commithash"] = self.get_commit_hash()
 
         self.logger.info(annotations)
@@ -705,6 +729,7 @@ class FortranLibraryBuilder:
                 self.logger.debug("Clearing cache to speed up next upload")
                 subprocess.check_call(["conan", "remove", "-f", f"{self.libname}/{self.target_name}"])
             self.needs_uploading = 0
+            self._possible_builds = None
 
     def get_compiler_type(self, compiler):
         compilerType = ""

--- a/bin/lib/fortran_library_builder.py
+++ b/bin/lib/fortran_library_builder.py
@@ -25,7 +25,7 @@ from lib.amazon import get_ssm_param
 from lib.amazon_properties import get_properties_compilers_and_libraries, get_specific_library_version_details
 from lib.installation_context import FetchFailure, PostFailure
 from lib.library_build_config import LibraryBuildConfig
-from lib.library_builder import PossibleBuilds, build_target_settings, conan_search_url, match_conan_settings
+from lib.library_builder import PossibleBuilds, build_target_settings, fetch_possible_builds, find_matching_package_id
 from lib.library_platform import LibraryPlatform
 from lib.staging import StagingDir
 
@@ -451,42 +451,20 @@ class FortranLibraryBuilder:
         return compiler + "_" + hasher.hexdigest()
 
     def _get_possible_builds(self) -> PossibleBuilds:
-        # 404 means no packages have been uploaded yet for this lib/version: return empty.
-        if self._possible_builds is not None:
-            return self._possible_builds
-
-        url = conan_search_url(self.libname, self.target_name)
-        try:
-            request = self.http_session.get(url, timeout=_TIMEOUT)
-        except requests.RequestException as e:
-            raise FetchFailure(f"Conan search request failed for {self.libname}/{self.target_name}: {e}") from e
-
-        if request.status_code == 404:
-            self.logger.debug(f"No uploaded builds yet for {self.libname}/{self.target_name}")
-            self._possible_builds = {}
-            return self._possible_builds
-        if not request.ok:
-            raise FetchFailure(f"Conan search returned {request.status_code} for {self.libname}/{self.target_name}")
-
-        try:
-            payload = request.json()
-        except ValueError as e:
-            raise FetchFailure(f"Conan search returned non-JSON for {self.libname}/{self.target_name}") from e
-        if not isinstance(payload, dict):
-            raise FetchFailure(f"Conan search returned non-object JSON for {self.libname}/{self.target_name}")
-        self._possible_builds = payload
+        if self._possible_builds is None:
+            self._possible_builds = fetch_possible_builds(
+                self.libname,
+                self.target_name,
+                lambda url: self.http_session.get(url, timeout=_TIMEOUT),
+                self.logger,
+            )
         return self._possible_builds
 
     def get_conan_hash(self, buildfolder: str) -> str | None:
         if self.install_context.dry_run:
             return None
-
         target = build_target_settings(self.current_buildparameters_obj)
-        for package_id, entry in self._get_possible_builds().items():
-            settings = entry.get("settings", {}) if isinstance(entry, dict) else {}
-            if match_conan_settings(target, settings):
-                return package_id
-        return None
+        return find_matching_package_id(self._get_possible_builds(), target)
 
     def conanproxy_login(self):
         url = f"{conanserver_url}/login"

--- a/bin/lib/fortran_library_builder.py
+++ b/bin/lib/fortran_library_builder.py
@@ -599,9 +599,11 @@ class FortranLibraryBuilder:
             return False
 
     def set_as_uploaded(self, buildfolder):
-        # Upload before asking for the conan id: see library_builder.py set_as_uploaded for the
-        # full reasoning. Short version: get_conan_hash now resolves the id by querying the
-        # server's /search index, which only knows about packages already uploaded.
+        # We need the conan package_id (a deterministic SHA from compiler+version+libcxx+arch+...)
+        # to PUT annotations against /annotations/{lib}/{ver}/{package_id}. get_conan_hash now
+        # derives the id by querying the server's /search index, which only lists packages
+        # already on the server -- so for a freshly built package, we must upload first.
+        # (The previous implementation used `conan info`, which computed the id locally.)
         annotations = self.get_build_annotations(buildfolder)
         if "commithash" not in annotations:
             self.upload_builds()

--- a/bin/lib/fortran_library_builder.py
+++ b/bin/lib/fortran_library_builder.py
@@ -451,7 +451,7 @@ class FortranLibraryBuilder:
         return compiler + "_" + hasher.hexdigest()
 
     def _get_possible_builds(self) -> PossibleBuilds:
-        # 404 -> empty (no uploads yet); other failures raise rather than silently degrading.
+        # 404 means no packages have been uploaded yet for this lib/version: return empty.
         if self._possible_builds is not None:
             return self._possible_builds
 

--- a/bin/lib/fortran_library_builder.py
+++ b/bin/lib/fortran_library_builder.py
@@ -590,7 +590,7 @@ class FortranLibraryBuilder:
         if conanhash is None:
             raise RuntimeError(f"Error determining conan hash in {buildfolder}")
 
-        self.logger.info(f"commithash: {conanhash}")
+        self.logger.info(f"conanhash: {conanhash}")
         annotations["commithash"] = self.get_commit_hash()
 
         self.logger.info(annotations)

--- a/bin/lib/fortran_library_builder.py
+++ b/bin/lib/fortran_library_builder.py
@@ -581,7 +581,6 @@ class FortranLibraryBuilder:
         # to PUT annotations against /annotations/{lib}/{ver}/{package_id}. get_conan_hash now
         # derives the id by querying the server's /search index, which only lists packages
         # already on the server -- so for a freshly built package, we must upload first.
-        # (The previous implementation used `conan info`, which computed the id locally.)
         annotations = self.get_build_annotations(buildfolder)
         if "commithash" not in annotations:
             self.upload_builds()

--- a/bin/lib/fortran_library_builder.py
+++ b/bin/lib/fortran_library_builder.py
@@ -25,7 +25,7 @@ from lib.amazon import get_ssm_param
 from lib.amazon_properties import get_properties_compilers_and_libraries, get_specific_library_version_details
 from lib.installation_context import FetchFailure, PostFailure
 from lib.library_build_config import LibraryBuildConfig
-from lib.library_builder import build_target_settings, conan_search_url, match_conan_settings
+from lib.library_builder import PossibleBuilds, build_target_settings, conan_search_url, match_conan_settings
 from lib.library_platform import LibraryPlatform
 from lib.staging import StagingDir
 
@@ -98,7 +98,7 @@ class FortranLibraryBuilder:
         self.needs_uploading = 0
         self.libid = self.libname  # TODO: CE libid might be different from yaml libname
         self.conanserverproxy_token = None
-        self._possible_builds: dict[str, Any] | None = None
+        self._possible_builds: PossibleBuilds | None = None
         self._annotations_cache: dict[str, dict] = {}
         self.http_session = requests.Session()
 
@@ -450,7 +450,8 @@ class FortranLibraryBuilder:
 
         return compiler + "_" + hasher.hexdigest()
 
-    def _get_possible_builds(self) -> dict[str, Any]:
+    def _get_possible_builds(self) -> PossibleBuilds:
+        # 404 -> empty (no uploads yet); other failures raise rather than silently degrading.
         if self._possible_builds is not None:
             return self._possible_builds
 
@@ -458,26 +459,21 @@ class FortranLibraryBuilder:
         try:
             request = self.http_session.get(url, timeout=_TIMEOUT)
         except requests.RequestException as e:
-            self.logger.warning(f"Conan search failed for {self.libname}/{self.target_name}: {e}")
-            self._possible_builds = {}
-            return self._possible_builds
+            raise FetchFailure(f"Conan search request failed for {self.libname}/{self.target_name}: {e}") from e
 
-        if not request.ok:
-            if request.status_code == 404:
-                self.logger.debug(f"No uploaded builds yet for {self.libname}/{self.target_name}")
-            else:
-                self.logger.warning(f"Conan search failed for {self.libname}/{self.target_name}: {request.status_code}")
+        if request.status_code == 404:
+            self.logger.debug(f"No uploaded builds yet for {self.libname}/{self.target_name}")
             self._possible_builds = {}
             return self._possible_builds
+        if not request.ok:
+            raise FetchFailure(f"Conan search returned {request.status_code} for {self.libname}/{self.target_name}")
 
         try:
             payload = request.json()
-        except ValueError:
-            self.logger.warning(f"Conan search returned non-JSON for {self.libname}/{self.target_name}")
-            payload = {}
+        except ValueError as e:
+            raise FetchFailure(f"Conan search returned non-JSON for {self.libname}/{self.target_name}") from e
         if not isinstance(payload, dict):
-            self.logger.warning(f"Conan search returned non-object JSON for {self.libname}/{self.target_name}")
-            payload = {}
+            raise FetchFailure(f"Conan search returned non-object JSON for {self.libname}/{self.target_name}")
         self._possible_builds = payload
         return self._possible_builds
 
@@ -603,8 +599,9 @@ class FortranLibraryBuilder:
             return False
 
     def set_as_uploaded(self, buildfolder):
-        # Order matters: upload_builds must run before get_conan_hash. See library_builder.py
-        # set_as_uploaded for the full reasoning.
+        # Upload before asking for the conan id: see library_builder.py set_as_uploaded for the
+        # full reasoning. Short version: get_conan_hash now resolves the id by querying the
+        # server's /search index, which only knows about packages already uploaded.
         annotations = self.get_build_annotations(buildfolder)
         if "commithash" not in annotations:
             self.upload_builds()

--- a/bin/lib/go_library_builder.py
+++ b/bin/lib/go_library_builder.py
@@ -26,9 +26,9 @@ from lib.amazon import get_ssm_param
 from lib.amazon_properties import get_properties_compilers_and_libraries
 from lib.cache_delta import CacheDeltaCapture
 from lib.golang_stdlib import go_supports_trimpath
-from lib.installation_context import FetchFailure, InstallationContext, PostFailure
+from lib.installation_context import InstallationContext, PostFailure
 from lib.library_build_config import LibraryBuildConfig
-from lib.library_builder import PossibleBuilds, build_target_settings, conan_search_url, match_conan_settings
+from lib.library_builder import PossibleBuilds, build_target_settings, fetch_possible_builds, find_matching_package_id
 from lib.library_platform import LibraryPlatform
 from lib.staging import StagingDir
 
@@ -411,43 +411,21 @@ require {self.module_path} {self.target_name}
             f.write('        self.copy("metadata.json", dst=".", keep_path=False)\n')
 
     def _get_possible_builds(self) -> PossibleBuilds:
-        # 404 means no packages have been uploaded yet for this lib/version: return empty.
-        if self._possible_builds is not None:
-            return self._possible_builds
-
-        url = conan_search_url(self.libid, self.target_name)
-        try:
-            request = self.http_session.get(url, timeout=_TIMEOUT)
-        except requests.RequestException as e:
-            raise FetchFailure(f"Conan search request failed for {self.libid}/{self.target_name}: {e}") from e
-
-        if request.status_code == 404:
-            self.logger.debug("No uploaded builds yet for %s/%s", self.libid, self.target_name)
-            self._possible_builds = {}
-            return self._possible_builds
-        if not request.ok:
-            raise FetchFailure(f"Conan search returned {request.status_code} for {self.libid}/{self.target_name}")
-
-        try:
-            payload = request.json()
-        except ValueError as e:
-            raise FetchFailure(f"Conan search returned non-JSON for {self.libid}/{self.target_name}") from e
-        if not isinstance(payload, dict):
-            raise FetchFailure(f"Conan search returned non-object JSON for {self.libid}/{self.target_name}")
-        self._possible_builds = payload
+        if self._possible_builds is None:
+            self._possible_builds = fetch_possible_builds(
+                self.libid,
+                self.target_name,
+                lambda url: self.http_session.get(url, timeout=_TIMEOUT),
+                self.logger,
+            )
         return self._possible_builds
 
     def get_conan_hash(self, buildfolder: Path) -> str | None:
         """Find the conan package_id matching the current build parameters, via the proxy search API."""
         if self.install_context.dry_run:
             return None
-
         target = build_target_settings(self.current_buildparameters_obj)
-        for package_id, entry in self._get_possible_builds().items():
-            settings = entry.get("settings", {}) if isinstance(entry, dict) else {}
-            if match_conan_settings(target, settings):
-                return package_id
-        return None
+        return find_matching_package_id(self._get_possible_builds(), target)
 
     def resil_post(self, url: str, json_data: str, headers: dict | None = None) -> requests.Response | dict:
         """Resilient POST request with retries."""

--- a/bin/lib/go_library_builder.py
+++ b/bin/lib/go_library_builder.py
@@ -571,9 +571,11 @@ require {self.module_path} {self.target_name}
 
     def set_as_uploaded(self, buildfolder: Path, build_method: str) -> None:
         """Mark build as uploaded in Conan server."""
-        # Upload before asking for the conan id: see library_builder.py set_as_uploaded for the
-        # full reasoning. Short version: get_conan_hash now resolves the id by querying the
-        # server's /search index, which only knows about packages already uploaded.
+        # We need the conan package_id (a deterministic SHA from compiler+version+libcxx+arch+...)
+        # to PUT annotations against /annotations/{lib}/{ver}/{package_id}. get_conan_hash now
+        # derives the id by querying the server's /search index, which only lists packages
+        # already on the server -- so for a freshly built package, we must upload first.
+        # (The previous implementation used `conan info`, which computed the id locally.)
         annotations = self.get_build_annotations(buildfolder)
         if "commithash" not in annotations:
             self.upload_builds()

--- a/bin/lib/go_library_builder.py
+++ b/bin/lib/go_library_builder.py
@@ -553,7 +553,6 @@ require {self.module_path} {self.target_name}
         # to PUT annotations against /annotations/{lib}/{ver}/{package_id}. get_conan_hash now
         # derives the id by querying the server's /search index, which only lists packages
         # already on the server -- so for a freshly built package, we must upload first.
-        # (The previous implementation used `conan info`, which computed the id locally.)
         annotations = self.get_build_annotations(buildfolder)
         if "commithash" not in annotations:
             self.upload_builds()

--- a/bin/lib/go_library_builder.py
+++ b/bin/lib/go_library_builder.py
@@ -11,7 +11,6 @@ import hashlib
 import json
 import logging
 import os
-import re
 import shutil
 import subprocess
 from collections import defaultdict
@@ -29,6 +28,7 @@ from lib.cache_delta import CacheDeltaCapture
 from lib.golang_stdlib import go_supports_trimpath
 from lib.installation_context import InstallationContext, PostFailure
 from lib.library_build_config import LibraryBuildConfig
+from lib.library_builder import build_target_settings, conan_search_url, match_conan_settings
 from lib.library_platform import LibraryPlatform
 from lib.staging import StagingDir
 
@@ -76,8 +76,6 @@ CONANSERVER_URL = "https://conan.compiler-explorer.com"
 
 # Cache for compiler properties
 _propsandlibs: dict[str, Any] = defaultdict(lambda: [])
-
-CONANINFOHASH_RE = re.compile(r"\s+ID:\s(\w*)")
 
 
 def clear_properties_cache() -> None:
@@ -133,7 +131,7 @@ class GoLibraryBuilder:
         # Prefix with 'go_' to avoid Conan namespace collisions with other languages
         self.libid = f"go_{self.libname}"
         self.conanserverproxy_token: str | None = None
-        self._conan_hash_cache: dict[str, str | None] = {}
+        self._possible_builds: dict[str, Any] | None = None
         self._annotations_cache: dict[str, dict] = {}
         self.http_session = requests.Session()
 
@@ -412,27 +410,49 @@ require {self.module_path} {self.target_name}
             f.write('        self.copy("module_sources/*", dst=".", keep_path=True)\n')
             f.write('        self.copy("metadata.json", dst=".", keep_path=False)\n')
 
+    def _get_possible_builds(self) -> dict[str, Any]:
+        if self._possible_builds is not None:
+            return self._possible_builds
+
+        url = conan_search_url(self.libid, self.target_name)
+        try:
+            request = self.http_session.get(url, timeout=_TIMEOUT)
+        except requests.RequestException as e:
+            self.logger.warning("Conan search failed for %s/%s: %s", self.libid, self.target_name, e)
+            self._possible_builds = {}
+            return self._possible_builds
+
+        if not request.ok:
+            if request.status_code == 404:
+                self.logger.debug("No uploaded builds yet for %s/%s", self.libid, self.target_name)
+            else:
+                self.logger.warning(
+                    "Conan search failed for %s/%s: %s", self.libid, self.target_name, request.status_code
+                )
+            self._possible_builds = {}
+            return self._possible_builds
+
+        try:
+            payload = request.json()
+        except ValueError:
+            self.logger.warning("Conan search returned non-JSON for %s/%s", self.libid, self.target_name)
+            payload = {}
+        if not isinstance(payload, dict):
+            self.logger.warning("Conan search returned non-object JSON for %s/%s", self.libid, self.target_name)
+            payload = {}
+        self._possible_builds = payload
+        return self._possible_builds
+
     def get_conan_hash(self, buildfolder: Path) -> str | None:
-        """Query Conan for package hash."""
-        if str(buildfolder) in self._conan_hash_cache:
-            return self._conan_hash_cache[str(buildfolder)]
+        """Find the conan package_id matching the current build parameters, via the proxy search API."""
+        if self.install_context.dry_run:
+            return None
 
-        if not self.install_context.dry_run:
-            try:
-                conaninfo = subprocess.check_output(
-                    ["conan", "info", "-r", "ceserver", "."] + self.current_buildparameters,
-                    cwd=buildfolder,
-                    timeout=_TIMEOUT,
-                ).decode("utf-8", "ignore")
-                match = CONANINFOHASH_RE.search(conaninfo)
-                if match:
-                    result = match[1]
-                    self._conan_hash_cache[str(buildfolder)] = result
-                    return result
-            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-                self.logger.debug("Conan info failed: %s", e)
-
-        self._conan_hash_cache[str(buildfolder)] = None
+        target = build_target_settings(self.current_buildparameters_obj)
+        for package_id, entry in self._get_possible_builds().items():
+            settings = entry.get("settings", {}) if isinstance(entry, dict) else {}
+            if match_conan_settings(target, settings):
+                return package_id
         return None
 
     def resil_post(self, url: str, json_data: str, headers: dict | None = None) -> requests.Response | dict:
@@ -557,15 +577,17 @@ require {self.module_path} {self.target_name}
 
     def set_as_uploaded(self, buildfolder: Path, build_method: str) -> None:
         """Mark build as uploaded in Conan server."""
+        # Order matters: upload_builds must run before get_conan_hash. See library_builder.py
+        # set_as_uploaded for the full reasoning.
+        annotations = self.get_build_annotations(buildfolder)
+        if "commithash" not in annotations:
+            self.upload_builds()
+
         conanhash = self.get_conan_hash(buildfolder)
         if conanhash is None:
             raise RuntimeError(f"Error determining conan hash in {buildfolder}")
 
         self.logger.info("conanhash: %s", conanhash)
-
-        annotations = self.get_build_annotations(buildfolder)
-        if "commithash" not in annotations:
-            self.upload_builds()
         annotations["commithash"] = self.target_name
         annotations["build_method"] = build_method
 
@@ -606,6 +628,7 @@ require {self.module_path} {self.target_name}
                 self.logger.debug("Clearing cache to speed up next upload")
                 subprocess.check_call(["conan", "remove", "-f", f"{self.libid}/{self.target_name}"])
             self.needs_uploading = 0
+            self._possible_builds = None
 
     def build_cleanup(self, buildfolder: Path) -> None:
         """Clean up build folder."""

--- a/bin/lib/go_library_builder.py
+++ b/bin/lib/go_library_builder.py
@@ -26,9 +26,9 @@ from lib.amazon import get_ssm_param
 from lib.amazon_properties import get_properties_compilers_and_libraries
 from lib.cache_delta import CacheDeltaCapture
 from lib.golang_stdlib import go_supports_trimpath
-from lib.installation_context import InstallationContext, PostFailure
+from lib.installation_context import FetchFailure, InstallationContext, PostFailure
 from lib.library_build_config import LibraryBuildConfig
-from lib.library_builder import build_target_settings, conan_search_url, match_conan_settings
+from lib.library_builder import PossibleBuilds, build_target_settings, conan_search_url, match_conan_settings
 from lib.library_platform import LibraryPlatform
 from lib.staging import StagingDir
 
@@ -131,7 +131,7 @@ class GoLibraryBuilder:
         # Prefix with 'go_' to avoid Conan namespace collisions with other languages
         self.libid = f"go_{self.libname}"
         self.conanserverproxy_token: str | None = None
-        self._possible_builds: dict[str, Any] | None = None
+        self._possible_builds: PossibleBuilds | None = None
         self._annotations_cache: dict[str, dict] = {}
         self.http_session = requests.Session()
 
@@ -410,7 +410,8 @@ require {self.module_path} {self.target_name}
             f.write('        self.copy("module_sources/*", dst=".", keep_path=True)\n')
             f.write('        self.copy("metadata.json", dst=".", keep_path=False)\n')
 
-    def _get_possible_builds(self) -> dict[str, Any]:
+    def _get_possible_builds(self) -> PossibleBuilds:
+        # 404 -> empty (no uploads yet); other failures raise rather than silently degrading.
         if self._possible_builds is not None:
             return self._possible_builds
 
@@ -418,28 +419,21 @@ require {self.module_path} {self.target_name}
         try:
             request = self.http_session.get(url, timeout=_TIMEOUT)
         except requests.RequestException as e:
-            self.logger.warning("Conan search failed for %s/%s: %s", self.libid, self.target_name, e)
-            self._possible_builds = {}
-            return self._possible_builds
+            raise FetchFailure(f"Conan search request failed for {self.libid}/{self.target_name}: {e}") from e
 
-        if not request.ok:
-            if request.status_code == 404:
-                self.logger.debug("No uploaded builds yet for %s/%s", self.libid, self.target_name)
-            else:
-                self.logger.warning(
-                    "Conan search failed for %s/%s: %s", self.libid, self.target_name, request.status_code
-                )
+        if request.status_code == 404:
+            self.logger.debug("No uploaded builds yet for %s/%s", self.libid, self.target_name)
             self._possible_builds = {}
             return self._possible_builds
+        if not request.ok:
+            raise FetchFailure(f"Conan search returned {request.status_code} for {self.libid}/{self.target_name}")
 
         try:
             payload = request.json()
-        except ValueError:
-            self.logger.warning("Conan search returned non-JSON for %s/%s", self.libid, self.target_name)
-            payload = {}
+        except ValueError as e:
+            raise FetchFailure(f"Conan search returned non-JSON for {self.libid}/{self.target_name}") from e
         if not isinstance(payload, dict):
-            self.logger.warning("Conan search returned non-object JSON for %s/%s", self.libid, self.target_name)
-            payload = {}
+            raise FetchFailure(f"Conan search returned non-object JSON for {self.libid}/{self.target_name}")
         self._possible_builds = payload
         return self._possible_builds
 
@@ -577,8 +571,9 @@ require {self.module_path} {self.target_name}
 
     def set_as_uploaded(self, buildfolder: Path, build_method: str) -> None:
         """Mark build as uploaded in Conan server."""
-        # Order matters: upload_builds must run before get_conan_hash. See library_builder.py
-        # set_as_uploaded for the full reasoning.
+        # Upload before asking for the conan id: see library_builder.py set_as_uploaded for the
+        # full reasoning. Short version: get_conan_hash now resolves the id by querying the
+        # server's /search index, which only knows about packages already uploaded.
         annotations = self.get_build_annotations(buildfolder)
         if "commithash" not in annotations:
             self.upload_builds()

--- a/bin/lib/go_library_builder.py
+++ b/bin/lib/go_library_builder.py
@@ -411,7 +411,7 @@ require {self.module_path} {self.target_name}
             f.write('        self.copy("metadata.json", dst=".", keep_path=False)\n')
 
     def _get_possible_builds(self) -> PossibleBuilds:
-        # 404 -> empty (no uploads yet); other failures raise rather than silently degrading.
+        # 404 means no packages have been uploaded yet for this lib/version: return empty.
         if self._possible_builds is not None:
             return self._possible_builds
 

--- a/bin/lib/library_builder.py
+++ b/bin/lib/library_builder.py
@@ -1143,10 +1143,8 @@ class LibraryBuilder:
         Single GET to /v1/conans/{lib}/{ver}/{lib}/{ver}/search returns all uploaded
         package_ids and their settings, replacing per-iteration `conan info` subprocess calls.
 
-        404 is treated as 'no uploads exist yet' and returns an empty dict. Any other failure
-        (5xx, connection error after retries, malformed JSON) raises FetchFailure rather than
-        silently degrading -- treating those as 'nothing uploaded' would cause spurious rebuilds
-        or downstream failures in set_as_uploaded.
+        404 means no packages have been uploaded yet for this lib/version, and is the natural
+        starting state for new libraries -- return an empty dict.
         """
         if self._possible_builds is not None:
             return self._possible_builds

--- a/bin/lib/library_builder.py
+++ b/bin/lib/library_builder.py
@@ -97,7 +97,7 @@ class ConanSearchEntry(TypedDict, total=False):
     recipe_hash: str
 
 
-PossibleBuilds = dict[str, ConanSearchEntry]
+type PossibleBuilds = dict[str, ConanSearchEntry]
 
 
 def match_conan_settings(target: dict[str, str], candidate: dict[str, str]) -> bool:

--- a/bin/lib/library_builder.py
+++ b/bin/lib/library_builder.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import tempfile
 import time
+import urllib.parse
 from collections import defaultdict
 from collections.abc import Generator
 from enum import Enum, unique
@@ -81,11 +82,67 @@ _supports_x86: dict[str, Any] = defaultdict(lambda: [])
 _compiler_support_output: dict[str, Any] = defaultdict(lambda: [])
 
 GITCOMMITHASH_RE = re.compile(r"^(\w*)\s.*")
-CONANINFOHASH_RE = re.compile(r"\s+ID:\s(\w*)")
 
 
 def _quote(string: str) -> str:
     return f'"{string}"'
+
+
+def match_conan_settings(target: dict[str, str], candidate: dict[str, str]) -> bool:
+    """Match a target settings dict against a candidate's settings.
+
+    Ported from compiler-explorer/lib/buildenvsetup/ceconan.ts findMatchingHash. Each rule
+    checks the *candidate's* value for the key under inspection, so a partially-flagged
+    headeronly entry (only some sub-settings set to 'headeronly') is matched key-by-key
+    rather than via a single up-front predicate. Behavioural rules:
+    - 'headeronly' / 'cshared' value on compiler/compiler.version matches any target value.
+    - 'headeronly' / 'cshared' value on compiler.libcxx (only when the candidate's
+      `settings.compiler` is itself 'headeronly' or 'cshared') matches any target libcxx;
+      'headeronly' also matches any arch.
+    - stdver is treated as a wildcard: pre-c++11 ABI breakage aside, compiler.version
+      already discriminates incompatible cases.
+    - All other keys must compare equal.
+    """
+    candidate_compiler = candidate.get("compiler", "")
+    parent_is_placeholder = candidate_compiler in ("headeronly", "cshared")
+
+    for key, val in target.items():
+        if key in ("compiler", "compiler.version") and candidate.get(key) in ("headeronly", "cshared"):
+            continue
+        if key == "compiler.libcxx" and parent_is_placeholder:
+            continue
+        if key == "arch" and candidate_compiler == "headeronly":
+            continue
+        if key == "stdver":
+            continue
+        if val != candidate.get(key, ""):
+            return False
+    return True
+
+
+def conan_search_url(libname: str, target_name: str) -> str:
+    encoded_lib = urllib.parse.quote(libname, safe="")
+    encoded_ver = urllib.parse.quote(target_name, safe="")
+    return f"{conanserver_url}/v1/conans/{encoded_lib}/{encoded_ver}/{encoded_lib}/{encoded_ver}/search"
+
+
+def build_target_settings(buildparams: dict[str, Any]) -> dict[str, str]:
+    """Translate current_buildparameters_obj keys into conan settings dotted form.
+
+    Uses .get(key, "") rather than indexing because the source object may be a defaultdict
+    with a list factory; a missing key would otherwise mutate the dict and produce a
+    non-string value that breaks equality matching.
+    """
+    return {
+        "os": buildparams.get("os", ""),
+        "build_type": buildparams.get("buildtype", ""),
+        "compiler": buildparams.get("compiler", ""),
+        "compiler.version": buildparams.get("compiler_version", ""),
+        "compiler.libcxx": buildparams.get("libcxx", ""),
+        "arch": buildparams.get("arch", ""),
+        "stdver": buildparams.get("stdver", ""),
+        "flagcollection": buildparams.get("flagcollection", ""),
+    }
 
 
 @unique
@@ -136,7 +193,7 @@ class LibraryBuilder:
         self.conanserverproxy_token = None
         self.current_commit_hash = ""
         self.platform = platform
-        self._conan_hash_cache: dict[str, str | None] = {}
+        self._possible_builds: dict[str, Any] | None = None
         self._annotations_cache: dict[str, dict] = {}
         self.http_session = requests.Session()
 
@@ -1068,24 +1125,47 @@ class LibraryBuilder:
 
         return compiler + "_" + str(iteration)
 
+    def _get_possible_builds(self) -> dict[str, Any]:
+        """Return the conan-server search response for this (libname, target_name), cached.
+
+        Single GET to /v1/conans/{lib}/{ver}/{lib}/{ver}/search returns all uploaded
+        package_ids and their settings, replacing per-iteration `conan info` subprocess calls.
+        """
+        if self._possible_builds is not None:
+            return self._possible_builds
+
+        url = conan_search_url(self.libname, self.target_name)
+        request = self.resil_get(url, stream=False, timeout=_TIMEOUT)
+        if request is None or not request.ok:
+            status = request.status_code if request is not None else "no-response"
+            if request is not None and request.status_code == 404:
+                self.logger.debug(f"No uploaded builds yet for {self.libname}/{self.target_name}")
+            else:
+                self.logger.warning(f"Conan search failed for {self.libname}/{self.target_name}: {status}")
+            self._possible_builds = {}
+            return self._possible_builds
+
+        try:
+            payload = request.json()
+        except ValueError:
+            self.logger.warning(f"Conan search returned non-JSON for {self.libname}/{self.target_name}")
+            payload = {}
+        if not isinstance(payload, dict):
+            self.logger.warning(f"Conan search returned non-object JSON for {self.libname}/{self.target_name}")
+            payload = {}
+        self._possible_builds = payload
+        return self._possible_builds
+
     def get_conan_hash(self, buildfolder: str) -> str | None:
-        if buildfolder in self._conan_hash_cache:
-            self.logger.debug(f"Using cached conan hash for {buildfolder}")
-            return self._conan_hash_cache[buildfolder]
+        if self.install_context.dry_run:
+            return None
 
-        if not self.install_context.dry_run:
-            self.logger.debug(["conan", "info", "."] + self.current_buildparameters)
-            conaninfo = subprocess.check_output(
-                ["conan", "info", "-r", "ceserver", "."] + self.current_buildparameters, cwd=buildfolder
-            ).decode("utf-8", "ignore")
-            self.logger.debug(conaninfo)
-            match = CONANINFOHASH_RE.search(conaninfo, re.MULTILINE)
-            if match:
-                result = match[1]
-                self._conan_hash_cache[buildfolder] = result
-                return result
+        target = build_target_settings(self.current_buildparameters_obj)
+        for package_id, entry in self._get_possible_builds().items():
+            settings = entry.get("settings", {}) if isinstance(entry, dict) else {}
+            if match_conan_settings(target, settings):
+                return package_id
 
-        self._conan_hash_cache[buildfolder] = None
         return None
 
     def conanproxy_login(self):
@@ -1223,15 +1303,19 @@ class LibraryBuilder:
             return False
 
     def set_as_uploaded(self, buildfolder):
+        # Order matters: upload_builds must run before get_conan_hash, because the new search-API
+        # path can only see packages already on the remote. When upload_builds runs (i.e.
+        # needs_uploading > 0), it invalidates _possible_builds so the next get_conan_hash call
+        # refetches and finds the just-uploaded package.
+        annotations = self.get_build_annotations(buildfolder)
+        if "commithash" not in annotations:
+            self.upload_builds()
+
         conanhash = self.get_conan_hash(buildfolder)
         if conanhash is None:
             raise RuntimeError(f"Error determining conan hash in {buildfolder}")
 
         self.logger.info(f"commithash: {conanhash}")
-
-        annotations = self.get_build_annotations(buildfolder)
-        if "commithash" not in annotations:
-            self.upload_builds()
         annotations["commithash"] = self.get_commit_hash()
 
         for lib in itertools.chain(self.buildconfig.staticliblink, self.buildconfig.sharedliblink):
@@ -1392,6 +1476,8 @@ class LibraryBuilder:
                 self.logger.debug("Clearing cache to speed up next upload")
                 subprocess.check_call(["conan", "remove", "-f", f"{self.libname}/{self.target_name}"])
             self.needs_uploading = 0
+            # Force re-fetch on next get_conan_hash so post-upload set_as_uploaded sees the new package.
+            self._possible_builds = None
 
     def get_compiler_type(self, compiler):
         compilerType = ""

--- a/bin/lib/library_builder.py
+++ b/bin/lib/library_builder.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 from collections.abc import Generator
 from enum import Enum, unique
 from pathlib import Path
-from typing import Any, TextIO
+from typing import Any, TextIO, TypedDict
 
 import botocore
 import requests
@@ -86,6 +86,18 @@ GITCOMMITHASH_RE = re.compile(r"^(\w*)\s.*")
 
 def _quote(string: str) -> str:
     return f'"{string}"'
+
+
+class ConanSearchEntry(TypedDict, total=False):
+    """A single entry in a Conan /v1/.../search response, keyed by package_id at the top level."""
+
+    settings: dict[str, str]
+    options: dict[str, str]
+    full_requires: list[str]
+    recipe_hash: str
+
+
+PossibleBuilds = dict[str, ConanSearchEntry]
 
 
 def match_conan_settings(target: dict[str, str], candidate: dict[str, str]) -> bool:
@@ -193,7 +205,7 @@ class LibraryBuilder:
         self.conanserverproxy_token = None
         self.current_commit_hash = ""
         self.platform = platform
-        self._possible_builds: dict[str, Any] | None = None
+        self._possible_builds: PossibleBuilds | None = None
         self._annotations_cache: dict[str, dict] = {}
         self.http_session = requests.Session()
 
@@ -1125,34 +1137,37 @@ class LibraryBuilder:
 
         return compiler + "_" + str(iteration)
 
-    def _get_possible_builds(self) -> dict[str, Any]:
+    def _get_possible_builds(self) -> PossibleBuilds:
         """Return the conan-server search response for this (libname, target_name), cached.
 
         Single GET to /v1/conans/{lib}/{ver}/{lib}/{ver}/search returns all uploaded
         package_ids and their settings, replacing per-iteration `conan info` subprocess calls.
+
+        404 is treated as 'no uploads exist yet' and returns an empty dict. Any other failure
+        (5xx, connection error after retries, malformed JSON) raises FetchFailure rather than
+        silently degrading -- treating those as 'nothing uploaded' would cause spurious rebuilds
+        or downstream failures in set_as_uploaded.
         """
         if self._possible_builds is not None:
             return self._possible_builds
 
         url = conan_search_url(self.libname, self.target_name)
         request = self.resil_get(url, stream=False, timeout=_TIMEOUT)
-        if request is None or not request.ok:
-            status = request.status_code if request is not None else "no-response"
-            if request is not None and request.status_code == 404:
-                self.logger.debug(f"No uploaded builds yet for {self.libname}/{self.target_name}")
-            else:
-                self.logger.warning(f"Conan search failed for {self.libname}/{self.target_name}: {status}")
+        if request is None:
+            raise FetchFailure(f"Conan search request failed for {self.libname}/{self.target_name}")
+        if request.status_code == 404:
+            self.logger.debug(f"No uploaded builds yet for {self.libname}/{self.target_name}")
             self._possible_builds = {}
             return self._possible_builds
+        if not request.ok:
+            raise FetchFailure(f"Conan search returned {request.status_code} for {self.libname}/{self.target_name}")
 
         try:
             payload = request.json()
-        except ValueError:
-            self.logger.warning(f"Conan search returned non-JSON for {self.libname}/{self.target_name}")
-            payload = {}
+        except ValueError as e:
+            raise FetchFailure(f"Conan search returned non-JSON for {self.libname}/{self.target_name}") from e
         if not isinstance(payload, dict):
-            self.logger.warning(f"Conan search returned non-object JSON for {self.libname}/{self.target_name}")
-            payload = {}
+            raise FetchFailure(f"Conan search returned non-object JSON for {self.libname}/{self.target_name}")
         self._possible_builds = payload
         return self._possible_builds
 
@@ -1303,10 +1318,14 @@ class LibraryBuilder:
             return False
 
     def set_as_uploaded(self, buildfolder):
-        # Order matters: upload_builds must run before get_conan_hash, because the new search-API
-        # path can only see packages already on the remote. When upload_builds runs (i.e.
-        # needs_uploading > 0), it invalidates _possible_builds so the next get_conan_hash call
-        # refetches and finds the just-uploaded package.
+        # We need the conan package_id (a deterministic SHA from compiler+version+libcxx+arch+...)
+        # to PUT annotations against /annotations/{lib}/{ver}/{package_id}.
+        #
+        # get_conan_hash now derives the id by querying the server's /search index, which only
+        # lists packages already on the server. So for a freshly built package that hasn't been
+        # uploaded yet, we must upload first, then ask for the id. (The previous implementation
+        # used `conan info`, which computed the id locally from the recipe and didn't care
+        # whether the package was on the server -- the order did not matter then.)
         annotations = self.get_build_annotations(buildfolder)
         if "commithash" not in annotations:
             self.upload_builds()

--- a/bin/lib/library_builder.py
+++ b/bin/lib/library_builder.py
@@ -1338,13 +1338,9 @@ class LibraryBuilder:
 
     def set_as_uploaded(self, buildfolder):
         # We need the conan package_id (a deterministic SHA from compiler+version+libcxx+arch+...)
-        # to PUT annotations against /annotations/{lib}/{ver}/{package_id}.
-        #
-        # get_conan_hash now derives the id by querying the server's /search index, which only
-        # lists packages already on the server. So for a freshly built package that hasn't been
-        # uploaded yet, we must upload first, then ask for the id. (The previous implementation
-        # used `conan info`, which computed the id locally from the recipe and didn't care
-        # whether the package was on the server -- the order did not matter then.)
+        # to PUT annotations against /annotations/{lib}/{ver}/{package_id}. get_conan_hash
+        # derives the id by querying the server's /search index, which only lists packages
+        # already on the server -- so for a freshly built package, we must upload first.
         annotations = self.get_build_annotations(buildfolder)
         if "commithash" not in annotations:
             self.upload_builds()

--- a/bin/lib/library_builder.py
+++ b/bin/lib/library_builder.py
@@ -1353,7 +1353,7 @@ class LibraryBuilder:
         if conanhash is None:
             raise RuntimeError(f"Error determining conan hash in {buildfolder}")
 
-        self.logger.info(f"commithash: {conanhash}")
+        self.logger.info(f"conanhash: {conanhash}")
         annotations["commithash"] = self.get_commit_hash()
 
         for lib in itertools.chain(self.buildconfig.staticliblink, self.buildconfig.sharedliblink):

--- a/bin/lib/library_builder.py
+++ b/bin/lib/library_builder.py
@@ -13,8 +13,9 @@ import tempfile
 import time
 import urllib.parse
 from collections import defaultdict
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from enum import Enum, unique
+from logging import Logger
 from pathlib import Path
 from typing import Any, TextIO, TypedDict
 
@@ -136,6 +137,53 @@ def conan_search_url(libname: str, target_name: str) -> str:
     encoded_lib = urllib.parse.quote(libname, safe="")
     encoded_ver = urllib.parse.quote(target_name, safe="")
     return f"{conanserver_url}/v1/conans/{encoded_lib}/{encoded_ver}/{encoded_lib}/{encoded_ver}/search"
+
+
+def fetch_possible_builds(
+    libname: str,
+    target_name: str,
+    fetcher: Callable[[str], requests.Response | None],
+    logger: Logger,
+) -> PossibleBuilds:
+    """Fetch and parse the conan-server /search response for a (libname, target_name).
+
+    `fetcher` is a one-argument callable taking the URL and returning a Response (or None to
+    signal a request that failed all retries). Each builder class supplies its own fetcher
+    so it can pick its retry strategy (resil_get vs raw http_session.get).
+
+    404 means no packages have been uploaded yet for this lib/version, and is the natural
+    starting state for new libraries -- return an empty dict.
+    """
+    url = conan_search_url(libname, target_name)
+    try:
+        response = fetcher(url)
+    except requests.RequestException as e:
+        raise FetchFailure(f"Conan search request failed for {libname}/{target_name}: {e}") from e
+
+    if response is None:
+        raise FetchFailure(f"Conan search request failed for {libname}/{target_name}")
+    if response.status_code == 404:
+        logger.debug("No uploaded builds yet for %s/%s", libname, target_name)
+        return {}
+    if not response.ok:
+        raise FetchFailure(f"Conan search returned {response.status_code} for {libname}/{target_name}")
+
+    try:
+        payload = response.json()
+    except ValueError as e:
+        raise FetchFailure(f"Conan search returned non-JSON for {libname}/{target_name}") from e
+    if not isinstance(payload, dict):
+        raise FetchFailure(f"Conan search returned non-object JSON for {libname}/{target_name}")
+    return payload
+
+
+def find_matching_package_id(possible_builds: PossibleBuilds, target: dict[str, str]) -> str | None:
+    """Return the first package_id in `possible_builds` whose settings match `target`."""
+    for package_id, entry in possible_builds.items():
+        settings = entry.get("settings", {}) if isinstance(entry, dict) else {}
+        if match_conan_settings(target, settings):
+            return package_id
+    return None
 
 
 def build_target_settings(buildparams: dict[str, Any]) -> dict[str, str]:
@@ -1138,48 +1186,21 @@ class LibraryBuilder:
         return compiler + "_" + str(iteration)
 
     def _get_possible_builds(self) -> PossibleBuilds:
-        """Return the conan-server search response for this (libname, target_name), cached.
-
-        Single GET to /v1/conans/{lib}/{ver}/{lib}/{ver}/search returns all uploaded
-        package_ids and their settings, replacing per-iteration `conan info` subprocess calls.
-
-        404 means no packages have been uploaded yet for this lib/version, and is the natural
-        starting state for new libraries -- return an empty dict.
-        """
-        if self._possible_builds is not None:
-            return self._possible_builds
-
-        url = conan_search_url(self.libname, self.target_name)
-        request = self.resil_get(url, stream=False, timeout=_TIMEOUT)
-        if request is None:
-            raise FetchFailure(f"Conan search request failed for {self.libname}/{self.target_name}")
-        if request.status_code == 404:
-            self.logger.debug(f"No uploaded builds yet for {self.libname}/{self.target_name}")
-            self._possible_builds = {}
-            return self._possible_builds
-        if not request.ok:
-            raise FetchFailure(f"Conan search returned {request.status_code} for {self.libname}/{self.target_name}")
-
-        try:
-            payload = request.json()
-        except ValueError as e:
-            raise FetchFailure(f"Conan search returned non-JSON for {self.libname}/{self.target_name}") from e
-        if not isinstance(payload, dict):
-            raise FetchFailure(f"Conan search returned non-object JSON for {self.libname}/{self.target_name}")
-        self._possible_builds = payload
+        """Return the conan-server /search response for this (libname, target_name), cached."""
+        if self._possible_builds is None:
+            self._possible_builds = fetch_possible_builds(
+                self.libname,
+                self.target_name,
+                lambda url: self.resil_get(url, stream=False, timeout=_TIMEOUT),
+                self.logger,
+            )
         return self._possible_builds
 
     def get_conan_hash(self, buildfolder: str) -> str | None:
         if self.install_context.dry_run:
             return None
-
         target = build_target_settings(self.current_buildparameters_obj)
-        for package_id, entry in self._get_possible_builds().items():
-            settings = entry.get("settings", {}) if isinstance(entry, dict) else {}
-            if match_conan_settings(target, settings):
-                return package_id
-
-        return None
+        return find_matching_package_id(self._get_possible_builds(), target)
 
     def conanproxy_login(self):
         url = f"{conanserver_url}/login"

--- a/bin/lib/rust_library_builder.py
+++ b/bin/lib/rust_library_builder.py
@@ -425,9 +425,11 @@ class RustLibraryBuilder:
             return False
 
     def set_as_uploaded(self, buildfolder, source_folder, build_method):
-        # Upload before asking for the conan id: see library_builder.py set_as_uploaded for the
-        # full reasoning. Short version: get_conan_hash now resolves the id by querying the
-        # server's /search index, which only knows about packages already uploaded.
+        # We need the conan package_id (a deterministic SHA from compiler+version+libcxx+arch+...)
+        # to PUT annotations against /annotations/{lib}/{ver}/{package_id}. get_conan_hash now
+        # derives the id by querying the server's /search index, which only lists packages
+        # already on the server -- so for a freshly built package, we must upload first.
+        # (The previous implementation used `conan info`, which computed the id locally.)
         annotations = self.get_build_annotations(buildfolder)
         if "commithash" not in annotations:
             self.upload_builds()

--- a/bin/lib/rust_library_builder.py
+++ b/bin/lib/rust_library_builder.py
@@ -23,7 +23,7 @@ from lib.amazon import get_ssm_param
 from lib.amazon_properties import get_properties_compilers_and_libraries
 from lib.installation_context import FetchFailure, InstallationContext, PostFailure
 from lib.library_build_config import LibraryBuildConfig
-from lib.library_builder import PossibleBuilds, build_target_settings, conan_search_url, match_conan_settings
+from lib.library_builder import PossibleBuilds, build_target_settings, fetch_possible_builds, find_matching_package_id
 from lib.library_platform import LibraryPlatform
 from lib.rust_crates import RustCrate, get_builder_user_agent_id
 from lib.staging import StagingDir
@@ -260,42 +260,20 @@ class RustLibraryBuilder:
         return compiler + "_" + hasher.hexdigest()
 
     def _get_possible_builds(self) -> PossibleBuilds:
-        # 404 means no packages have been uploaded yet for this lib/version: return empty.
-        if self._possible_builds is not None:
-            return self._possible_builds
-
-        url = conan_search_url(self.libname, self.target_name)
-        try:
-            request = self.http_session.get(url, timeout=_TIMEOUT)
-        except requests.RequestException as e:
-            raise FetchFailure(f"Conan search request failed for {self.libname}/{self.target_name}: {e}") from e
-
-        if request.status_code == 404:
-            self.logger.debug(f"No uploaded builds yet for {self.libname}/{self.target_name}")
-            self._possible_builds = {}
-            return self._possible_builds
-        if not request.ok:
-            raise FetchFailure(f"Conan search returned {request.status_code} for {self.libname}/{self.target_name}")
-
-        try:
-            payload = request.json()
-        except ValueError as e:
-            raise FetchFailure(f"Conan search returned non-JSON for {self.libname}/{self.target_name}") from e
-        if not isinstance(payload, dict):
-            raise FetchFailure(f"Conan search returned non-object JSON for {self.libname}/{self.target_name}")
-        self._possible_builds = payload
+        if self._possible_builds is None:
+            self._possible_builds = fetch_possible_builds(
+                self.libname,
+                self.target_name,
+                lambda url: self.http_session.get(url, timeout=_TIMEOUT),
+                self.logger,
+            )
         return self._possible_builds
 
     def get_conan_hash(self, buildfolder: str) -> str | None:
         if self.install_context.dry_run:
             return None
-
         target = build_target_settings(self.current_buildparameters_obj)
-        for package_id, entry in self._get_possible_builds().items():
-            settings = entry.get("settings", {}) if isinstance(entry, dict) else {}
-            if match_conan_settings(target, settings):
-                return package_id
-        return None
+        return find_matching_package_id(self._get_possible_builds(), target)
 
     def resil_post(self, url, json_data, headers=None):
         request = None

--- a/bin/lib/rust_library_builder.py
+++ b/bin/lib/rust_library_builder.py
@@ -23,7 +23,7 @@ from lib.amazon import get_ssm_param
 from lib.amazon_properties import get_properties_compilers_and_libraries
 from lib.installation_context import FetchFailure, InstallationContext, PostFailure
 from lib.library_build_config import LibraryBuildConfig
-from lib.library_builder import build_target_settings, conan_search_url, match_conan_settings
+from lib.library_builder import PossibleBuilds, build_target_settings, conan_search_url, match_conan_settings
 from lib.library_platform import LibraryPlatform
 from lib.rust_crates import RustCrate, get_builder_user_agent_id
 from lib.staging import StagingDir
@@ -86,7 +86,7 @@ class RustLibraryBuilder:
         self.needs_uploading = 0
         self.libid = self.libname  # TODO: CE libid might be different from yaml libname
         self.conanserverproxy_token = None
-        self._possible_builds: dict[str, Any] | None = None
+        self._possible_builds: PossibleBuilds | None = None
         self._annotations_cache: dict[str, dict] = {}
         self.http_session = requests.Session()
 
@@ -259,7 +259,8 @@ class RustLibraryBuilder:
 
         return compiler + "_" + hasher.hexdigest()
 
-    def _get_possible_builds(self) -> dict[str, Any]:
+    def _get_possible_builds(self) -> PossibleBuilds:
+        # 404 -> empty (no uploads yet); other failures raise rather than silently degrading.
         if self._possible_builds is not None:
             return self._possible_builds
 
@@ -267,26 +268,21 @@ class RustLibraryBuilder:
         try:
             request = self.http_session.get(url, timeout=_TIMEOUT)
         except requests.RequestException as e:
-            self.logger.warning(f"Conan search failed for {self.libname}/{self.target_name}: {e}")
-            self._possible_builds = {}
-            return self._possible_builds
+            raise FetchFailure(f"Conan search request failed for {self.libname}/{self.target_name}: {e}") from e
 
-        if not request.ok:
-            if request.status_code == 404:
-                self.logger.debug(f"No uploaded builds yet for {self.libname}/{self.target_name}")
-            else:
-                self.logger.warning(f"Conan search failed for {self.libname}/{self.target_name}: {request.status_code}")
+        if request.status_code == 404:
+            self.logger.debug(f"No uploaded builds yet for {self.libname}/{self.target_name}")
             self._possible_builds = {}
             return self._possible_builds
+        if not request.ok:
+            raise FetchFailure(f"Conan search returned {request.status_code} for {self.libname}/{self.target_name}")
 
         try:
             payload = request.json()
-        except ValueError:
-            self.logger.warning(f"Conan search returned non-JSON for {self.libname}/{self.target_name}")
-            payload = {}
+        except ValueError as e:
+            raise FetchFailure(f"Conan search returned non-JSON for {self.libname}/{self.target_name}") from e
         if not isinstance(payload, dict):
-            self.logger.warning(f"Conan search returned non-object JSON for {self.libname}/{self.target_name}")
-            payload = {}
+            raise FetchFailure(f"Conan search returned non-object JSON for {self.libname}/{self.target_name}")
         self._possible_builds = payload
         return self._possible_builds
 
@@ -429,8 +425,9 @@ class RustLibraryBuilder:
             return False
 
     def set_as_uploaded(self, buildfolder, source_folder, build_method):
-        # Order matters: upload_builds must run before get_conan_hash. See library_builder.py
-        # set_as_uploaded for the full reasoning.
+        # Upload before asking for the conan id: see library_builder.py set_as_uploaded for the
+        # full reasoning. Short version: get_conan_hash now resolves the id by querying the
+        # server's /search index, which only knows about packages already uploaded.
         annotations = self.get_build_annotations(buildfolder)
         if "commithash" not in annotations:
             self.upload_builds()

--- a/bin/lib/rust_library_builder.py
+++ b/bin/lib/rust_library_builder.py
@@ -407,7 +407,6 @@ class RustLibraryBuilder:
         # to PUT annotations against /annotations/{lib}/{ver}/{package_id}. get_conan_hash now
         # derives the id by querying the server's /search index, which only lists packages
         # already on the server -- so for a freshly built package, we must upload first.
-        # (The previous implementation used `conan info`, which computed the id locally.)
         annotations = self.get_build_annotations(buildfolder)
         if "commithash" not in annotations:
             self.upload_builds()

--- a/bin/lib/rust_library_builder.py
+++ b/bin/lib/rust_library_builder.py
@@ -260,7 +260,7 @@ class RustLibraryBuilder:
         return compiler + "_" + hasher.hexdigest()
 
     def _get_possible_builds(self) -> PossibleBuilds:
-        # 404 -> empty (no uploads yet); other failures raise rather than silently degrading.
+        # 404 means no packages have been uploaded yet for this lib/version: return empty.
         if self._possible_builds is not None:
             return self._possible_builds
 

--- a/bin/lib/rust_library_builder.py
+++ b/bin/lib/rust_library_builder.py
@@ -23,6 +23,7 @@ from lib.amazon import get_ssm_param
 from lib.amazon_properties import get_properties_compilers_and_libraries
 from lib.installation_context import FetchFailure, InstallationContext, PostFailure
 from lib.library_build_config import LibraryBuildConfig
+from lib.library_builder import build_target_settings, conan_search_url, match_conan_settings
 from lib.library_platform import LibraryPlatform
 from lib.rust_crates import RustCrate, get_builder_user_agent_id
 from lib.staging import StagingDir
@@ -41,7 +42,6 @@ build_supported_flagscollection = [[""]]
 _propsandlibs: dict[str, Any] = defaultdict(lambda: [])
 
 GITCOMMITHASH_RE = re.compile(r"^(\w*)\s.*")
-CONANINFOHASH_RE = re.compile(r"\s+ID:\s(\w*)")
 
 
 @unique
@@ -86,7 +86,7 @@ class RustLibraryBuilder:
         self.needs_uploading = 0
         self.libid = self.libname  # TODO: CE libid might be different from yaml libname
         self.conanserverproxy_token = None
-        self._conan_hash_cache: dict[str, str | None] = {}
+        self._possible_builds: dict[str, Any] | None = None
         self._annotations_cache: dict[str, dict] = {}
         self.http_session = requests.Session()
 
@@ -259,24 +259,46 @@ class RustLibraryBuilder:
 
         return compiler + "_" + hasher.hexdigest()
 
+    def _get_possible_builds(self) -> dict[str, Any]:
+        if self._possible_builds is not None:
+            return self._possible_builds
+
+        url = conan_search_url(self.libname, self.target_name)
+        try:
+            request = self.http_session.get(url, timeout=_TIMEOUT)
+        except requests.RequestException as e:
+            self.logger.warning(f"Conan search failed for {self.libname}/{self.target_name}: {e}")
+            self._possible_builds = {}
+            return self._possible_builds
+
+        if not request.ok:
+            if request.status_code == 404:
+                self.logger.debug(f"No uploaded builds yet for {self.libname}/{self.target_name}")
+            else:
+                self.logger.warning(f"Conan search failed for {self.libname}/{self.target_name}: {request.status_code}")
+            self._possible_builds = {}
+            return self._possible_builds
+
+        try:
+            payload = request.json()
+        except ValueError:
+            self.logger.warning(f"Conan search returned non-JSON for {self.libname}/{self.target_name}")
+            payload = {}
+        if not isinstance(payload, dict):
+            self.logger.warning(f"Conan search returned non-object JSON for {self.libname}/{self.target_name}")
+            payload = {}
+        self._possible_builds = payload
+        return self._possible_builds
+
     def get_conan_hash(self, buildfolder: str) -> str | None:
-        if buildfolder in self._conan_hash_cache:
-            self.logger.debug(f"Using cached conan hash for {buildfolder}")
-            return self._conan_hash_cache[buildfolder]
+        if self.install_context.dry_run:
+            return None
 
-        if not self.install_context.dry_run:
-            self.logger.debug(["conan", "info", "."] + self.current_buildparameters)
-            conaninfo = subprocess.check_output(
-                ["conan", "info", "-r", "ceserver", "."] + self.current_buildparameters, cwd=buildfolder
-            ).decode("utf-8", "ignore")
-            self.logger.debug(conaninfo)
-            match = CONANINFOHASH_RE.search(conaninfo, re.MULTILINE)
-            if match:
-                result = match[1]
-                self._conan_hash_cache[buildfolder] = result
-                return result
-
-        self._conan_hash_cache[buildfolder] = None
+        target = build_target_settings(self.current_buildparameters_obj)
+        for package_id, entry in self._get_possible_builds().items():
+            settings = entry.get("settings", {}) if isinstance(entry, dict) else {}
+            if match_conan_settings(target, settings):
+                return package_id
         return None
 
     def resil_post(self, url, json_data, headers=None):
@@ -407,15 +429,17 @@ class RustLibraryBuilder:
             return False
 
     def set_as_uploaded(self, buildfolder, source_folder, build_method):
+        # Order matters: upload_builds must run before get_conan_hash. See library_builder.py
+        # set_as_uploaded for the full reasoning.
+        annotations = self.get_build_annotations(buildfolder)
+        if "commithash" not in annotations:
+            self.upload_builds()
+
         conanhash = self.get_conan_hash(buildfolder)
         if conanhash is None:
             raise RuntimeError(f"Error determining conan hash in {buildfolder}")
 
         self.logger.info(f"conanhash: {conanhash}")
-
-        annotations = self.get_build_annotations(buildfolder)
-        if "commithash" not in annotations:
-            self.upload_builds()
         annotations["commithash"] = self.get_commit_hash()
 
         for key in build_method:
@@ -640,6 +664,7 @@ class RustLibraryBuilder:
                 self.logger.debug("Clearing cache to speed up next upload")
                 subprocess.check_call(["conan", "remove", "-f", f"{self.libname}/{self.target_name}"])
             self.needs_uploading = 0
+            self._possible_builds = None
 
     def makebuild(self, buildfor):
         builds_failed = 0

--- a/bin/test/fortran_library_builder_test.py
+++ b/bin/test/fortran_library_builder_test.py
@@ -163,8 +163,7 @@ def test_expand_make_arg(requests_mock):
     assert result == "--arch=x86_64 --build=Debug --std=f2018"
 
 
-@patch("subprocess.check_output")
-def test_get_conan_hash_success(mock_subprocess, requests_mock):
+def test_get_conan_hash_success(requests_mock):
     requests_mock.get(f"{BASE}fortran.amazon.properties", text="")
     logger = mock.Mock(spec_set=Logger)
     install_context = mock.Mock()
@@ -174,15 +173,36 @@ def test_get_conan_hash_success(mock_subprocess, requests_mock):
         logger, "fortran", "fortranlib", "2.0.0", "/tmp/source", install_context, build_config, False
     )
 
-    mock_subprocess.return_value = b"conanfile.py: ID: fortran123456\nOther output"
-    builder.current_buildparameters = ["-s", "os=Linux"]
+    builder.current_buildparameters_obj["os"] = "Linux"
+    builder.current_buildparameters_obj["buildtype"] = "Debug"
+    builder.current_buildparameters_obj["compiler"] = "fortran"
+    builder.current_buildparameters_obj["compiler_version"] = "f2018"
+    builder.current_buildparameters_obj["libcxx"] = "libgfortran"
+    builder.current_buildparameters_obj["arch"] = "x86_64"
+    builder.current_buildparameters_obj["stdver"] = ""
+    builder.current_buildparameters_obj["flagcollection"] = ""
+
+    requests_mock.get(
+        "https://conan.compiler-explorer.com/v1/conans/fortranlib/2.0.0/fortranlib/2.0.0/search",
+        json={
+            "fortran123456": {
+                "settings": {
+                    "os": "Linux",
+                    "build_type": "Debug",
+                    "compiler": "fortran",
+                    "compiler.version": "f2018",
+                    "compiler.libcxx": "libgfortran",
+                    "arch": "x86_64",
+                    "stdver": "",
+                    "flagcollection": "",
+                }
+            }
+        },
+    )
 
     result = builder.get_conan_hash("/tmp/buildfolder")
 
     assert result == "fortran123456"
-    mock_subprocess.assert_called_once_with(
-        ["conan", "info", "-r", "ceserver", "."] + builder.current_buildparameters, cwd="/tmp/buildfolder"
-    )
 
 
 @patch("subprocess.call")

--- a/bin/test/go_library_builder_test.py
+++ b/bin/test/go_library_builder_test.py
@@ -287,6 +287,45 @@ class TestGoLibraryBuilderConanHelpers:
         assert 'name = "go_uuid"' in content
         assert 'version = "v1.6.0"' in content
 
+    @patch("lib.go_library_builder.get_properties_compilers_and_libraries")
+    def test_get_conan_hash_via_search(self, mock_get_props, requests_mock):
+        """get_conan_hash should match the search response settings rather than shelling out."""
+        mock_get_props.return_value = ({"gl1238": {"exe": "/opt/go/bin/go"}}, {})
+        logger = MagicMock()
+        install_context = MagicMock()
+        install_context.dry_run = False
+        buildconfig = create_go_test_build_config()
+
+        builder = GoLibraryBuilder(
+            logger=logger,
+            language="go",
+            libname="uuid",
+            target_name="v1.6.0",
+            install_context=install_context,
+            buildconfig=buildconfig,
+        )
+        builder.set_current_conan_build_parameters("Linux", "Debug", "gl1238", "x86_64")
+
+        requests_mock.get(
+            "https://conan.compiler-explorer.com/v1/conans/go_uuid/v1.6.0/go_uuid/v1.6.0/search",
+            json={
+                "go_hash": {
+                    "settings": {
+                        "os": "Linux",
+                        "build_type": "Debug",
+                        "compiler": "golang",
+                        "compiler.version": "gl1238",
+                        "compiler.libcxx": "",
+                        "arch": "x86_64",
+                        "stdver": "",
+                        "flagcollection": "",
+                    }
+                }
+            },
+        )
+
+        assert builder.get_conan_hash(Path("/tmp/build")) == "go_hash"
+
 
 class TestGoLibraryBuilderBuildStatus:
     """Tests for BuildStatus enum."""

--- a/bin/test/library_builder_test.py
+++ b/bin/test/library_builder_test.py
@@ -9,7 +9,8 @@ from subprocess import TimeoutExpired
 from unittest import mock
 from unittest.mock import patch
 
-from lib.installation_context import InstallationContext
+import pytest
+from lib.installation_context import FetchFailure, InstallationContext
 from lib.library_build_config import LibraryBuildConfig
 from lib.library_builder import BuildStatus, LibraryBuilder, build_timeout
 from lib.library_platform import LibraryPlatform
@@ -299,6 +300,22 @@ def test_get_conan_hash_404_returns_none(requests_mock):
     builder = _make_builder_with_params(requests_mock)
     requests_mock.get(SEARCH_URL, status_code=404)
     assert builder.get_conan_hash("/tmp/buildfolder") is None
+
+
+def test_get_conan_hash_500_raises(requests_mock):
+    """Non-404 server errors should propagate, not silently degrade."""
+    builder = _make_builder_with_params(requests_mock)
+    requests_mock.get(SEARCH_URL, status_code=500)
+    with pytest.raises(FetchFailure):
+        builder.get_conan_hash("/tmp/buildfolder")
+
+
+def test_get_conan_hash_non_dict_json_raises(requests_mock):
+    """Search responses that aren't a JSON object should propagate, not silently degrade."""
+    builder = _make_builder_with_params(requests_mock)
+    requests_mock.get(SEARCH_URL, json=["not", "an", "object"])
+    with pytest.raises(FetchFailure):
+        builder.get_conan_hash("/tmp/buildfolder")
 
 
 def test_get_conan_hash_headeronly_matches_any_compiler(requests_mock):

--- a/bin/test/library_builder_test.py
+++ b/bin/test/library_builder_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import io
 import os
@@ -225,8 +227,11 @@ def test_expand_make_arg(requests_mock):
     assert result == "-DARCH=x86_64 -DBUILD=Debug -DSTD=c++17"
 
 
-@patch("subprocess.check_output")
-def test_get_conan_hash_success(mock_subprocess, requests_mock):
+SEARCH_URL = "https://conan.compiler-explorer.com/v1/conans/testlib/1.0.0/testlib/1.0.0/search"
+
+
+def _make_builder_with_params(requests_mock, params_overrides=None):
+    """Build a LibraryBuilder with current_buildparameters_obj populated for hash matching."""
     requests_mock.get(f"{BASE}cpp.amazon.properties", text="")
     logger = mock.Mock(spec_set=Logger)
     install_context = mock.Mock()
@@ -235,16 +240,244 @@ def test_get_conan_hash_success(mock_subprocess, requests_mock):
     builder = LibraryBuilder(
         logger, "cpp", "testlib", "1.0.0", "/tmp/source", install_context, build_config, False, LibraryPlatform.Linux
     )
+    params = {
+        "os": "Linux",
+        "buildtype": "Debug",
+        "compiler": "gcc",
+        "compiler_version": "g141",
+        "libcxx": "libstdc++",
+        "arch": "x86_64",
+        "stdver": "",
+        "flagcollection": "",
+    }
+    if params_overrides:
+        params.update(params_overrides)
+    for k, v in params.items():
+        builder.current_buildparameters_obj[k] = v
+    return builder
 
-    mock_subprocess.return_value = b"conanfile.py: ID: abc123def456\nOther output"
-    builder.current_buildparameters = ["-s", "os=Linux"]
+
+def test_get_conan_hash_success(requests_mock):
+    builder = _make_builder_with_params(requests_mock)
+    requests_mock.get(
+        SEARCH_URL,
+        json={
+            "abc123def456": {
+                "settings": {
+                    "os": "Linux",
+                    "build_type": "Debug",
+                    "compiler": "gcc",
+                    "compiler.version": "g141",
+                    "compiler.libcxx": "libstdc++",
+                    "arch": "x86_64",
+                    "stdver": "",
+                    "flagcollection": "",
+                }
+            },
+            "other_hash": {"settings": {"compiler": "clang", "compiler.version": "clang1400"}},
+        },
+    )
 
     result = builder.get_conan_hash("/tmp/buildfolder")
 
     assert result == "abc123def456"
-    mock_subprocess.assert_called_once_with(
-        ["conan", "info", "-r", "ceserver", "."] + builder.current_buildparameters, cwd="/tmp/buildfolder"
+
+
+def test_get_conan_hash_dry_run_returns_none(requests_mock):
+    builder = _make_builder_with_params(requests_mock)
+    builder.install_context.dry_run = True
+    assert builder.get_conan_hash("/tmp/buildfolder") is None
+
+
+def test_get_conan_hash_empty_search_returns_none(requests_mock):
+    builder = _make_builder_with_params(requests_mock)
+    requests_mock.get(SEARCH_URL, json={})
+    assert builder.get_conan_hash("/tmp/buildfolder") is None
+
+
+def test_get_conan_hash_404_returns_none(requests_mock):
+    builder = _make_builder_with_params(requests_mock)
+    requests_mock.get(SEARCH_URL, status_code=404)
+    assert builder.get_conan_hash("/tmp/buildfolder") is None
+
+
+def test_get_conan_hash_headeronly_matches_any_compiler(requests_mock):
+    builder = _make_builder_with_params(requests_mock)
+    requests_mock.get(
+        SEARCH_URL,
+        json={
+            "headeronly_hash": {
+                "settings": {
+                    "os": "Linux",
+                    "build_type": "Debug",
+                    "compiler": "headeronly",
+                    "compiler.version": "headeronly",
+                    "compiler.libcxx": "",
+                    "arch": "",
+                    "stdver": "",
+                    "flagcollection": "",
+                }
+            }
+        },
     )
+    assert builder.get_conan_hash("/tmp/buildfolder") == "headeronly_hash"
+
+
+def test_get_conan_hash_cshared_matches_any_compiler(requests_mock):
+    builder = _make_builder_with_params(requests_mock)
+    requests_mock.get(
+        SEARCH_URL,
+        json={
+            "cshared_hash": {
+                "settings": {
+                    "os": "Linux",
+                    "build_type": "Debug",
+                    "compiler": "cshared",
+                    "compiler.version": "cshared",
+                    "compiler.libcxx": "",
+                    "arch": "x86_64",
+                    "stdver": "",
+                    "flagcollection": "",
+                }
+            }
+        },
+    )
+    assert builder.get_conan_hash("/tmp/buildfolder") == "cshared_hash"
+
+
+def test_get_conan_hash_stdver_is_wildcard(requests_mock):
+    builder = _make_builder_with_params(requests_mock, {"stdver": "c++23"})
+    requests_mock.get(
+        SEARCH_URL,
+        json={
+            "h": {
+                "settings": {
+                    "os": "Linux",
+                    "build_type": "Debug",
+                    "compiler": "gcc",
+                    "compiler.version": "g141",
+                    "compiler.libcxx": "libstdc++",
+                    "arch": "x86_64",
+                    "stdver": "",
+                    "flagcollection": "",
+                }
+            }
+        },
+    )
+    assert builder.get_conan_hash("/tmp/buildfolder") == "h"
+
+
+def test_get_conan_hash_libcxx_mismatch_returns_none(requests_mock):
+    builder = _make_builder_with_params(requests_mock, {"libcxx": "libstdc++"})
+    requests_mock.get(
+        SEARCH_URL,
+        json={
+            "h": {
+                "settings": {
+                    "os": "Linux",
+                    "build_type": "Debug",
+                    "compiler": "gcc",
+                    "compiler.version": "g141",
+                    "compiler.libcxx": "libc++",
+                    "arch": "x86_64",
+                    "stdver": "",
+                    "flagcollection": "",
+                }
+            }
+        },
+    )
+    assert builder.get_conan_hash("/tmp/buildfolder") is None
+
+
+def test_get_conan_hash_caches_search_response(requests_mock):
+    builder = _make_builder_with_params(requests_mock)
+    matcher = requests_mock.get(
+        SEARCH_URL,
+        json={
+            "h": {
+                "settings": {
+                    "os": "Linux",
+                    "build_type": "Debug",
+                    "compiler": "gcc",
+                    "compiler.version": "g141",
+                    "compiler.libcxx": "libstdc++",
+                    "arch": "x86_64",
+                    "stdver": "",
+                    "flagcollection": "",
+                }
+            }
+        },
+    )
+
+    builder.get_conan_hash("/tmp/build1")
+    builder.get_conan_hash("/tmp/build2")
+
+    assert matcher.call_count == 1
+
+
+@patch("subprocess.check_call")
+def test_upload_builds_invalidates_search_cache(mock_subprocess, requests_mock):
+    builder = _make_builder_with_params(requests_mock)
+    matcher = requests_mock.get(
+        SEARCH_URL,
+        json={
+            "h": {
+                "settings": {
+                    "os": "Linux",
+                    "build_type": "Debug",
+                    "compiler": "gcc",
+                    "compiler.version": "g141",
+                    "compiler.libcxx": "libstdc++",
+                    "arch": "x86_64",
+                    "stdver": "",
+                    "flagcollection": "",
+                }
+            }
+        },
+    )
+    builder.needs_uploading = 1
+
+    builder.get_conan_hash("/tmp/build1")
+    builder.upload_builds()
+    builder.get_conan_hash("/tmp/build2")
+
+    assert matcher.call_count == 2
+
+
+@patch("subprocess.check_call")
+def test_set_as_uploaded_first_time_does_not_raise(mock_subprocess, requests_mock):
+    """Regression test: set_as_uploaded must not raise on a never-before-uploaded build.
+
+    Reproduces the bug where get_conan_hash was called BEFORE upload_builds, so the
+    search response (which only includes already-uploaded packages) returned None.
+    """
+    builder = _make_builder_with_params(requests_mock)
+    builder.conanserverproxy_token = "test-token"
+
+    matched_settings = {
+        "os": "Linux",
+        "build_type": "Debug",
+        "compiler": "gcc",
+        "compiler.version": "g141",
+        "compiler.libcxx": "libstdc++",
+        "arch": "x86_64",
+        "stdver": "",
+        "flagcollection": "",
+    }
+    # First search call (from get_build_annotations) returns empty: package not yet uploaded.
+    # After upload_builds invalidates the cache, the second search call returns our package.
+    requests_mock.get(SEARCH_URL, [{"json": {}}, {"json": {"freshly_uploaded_hash": {"settings": matched_settings}}}])
+    requests_mock.post(
+        "https://conan.compiler-explorer.com/annotations/testlib/1.0.0/freshly_uploaded_hash",
+        json={"ok": True},
+    )
+
+    builder.needs_uploading = 1
+    builder.current_commit_hash = "abc123"
+
+    builder.set_as_uploaded("/tmp/buildfolder")
+
+    mock_subprocess.assert_called()
 
 
 @patch("subprocess.call")

--- a/bin/test/library_builder_test.py
+++ b/bin/test/library_builder_test.py
@@ -12,10 +12,100 @@ from unittest.mock import patch
 import pytest
 from lib.installation_context import FetchFailure, InstallationContext
 from lib.library_build_config import LibraryBuildConfig
-from lib.library_builder import BuildStatus, LibraryBuilder, build_timeout
+from lib.library_builder import BuildStatus, LibraryBuilder, build_timeout, match_conan_settings
 from lib.library_platform import LibraryPlatform
 
 BASE = "https://raw.githubusercontent.com/compiler-explorer/compiler-explorer/main/etc/config/"
+
+
+# Direct unit tests for match_conan_settings -- the matcher logic ported from ceconan.ts.
+# These exercise the function in isolation, without the LibraryBuilder/HTTP scaffolding used
+# by the get_conan_hash tests further down.
+
+_TARGET_GCC = {
+    "os": "Linux",
+    "build_type": "Debug",
+    "compiler": "gcc",
+    "compiler.version": "g141",
+    "compiler.libcxx": "libstdc++",
+    "arch": "x86_64",
+    "stdver": "",
+    "flagcollection": "",
+}
+
+
+def _candidate(**overrides):
+    base = {**_TARGET_GCC}
+    base.update(overrides)
+    return base
+
+
+def test_match_conan_settings_exact():
+    assert match_conan_settings(_TARGET_GCC, _candidate()) is True
+
+
+def test_match_conan_settings_compiler_mismatch():
+    assert match_conan_settings(_TARGET_GCC, _candidate(compiler="clang", **{"compiler.version": "clang19"})) is False
+
+
+def test_match_conan_settings_libcxx_mismatch_real_compiler():
+    assert match_conan_settings(_TARGET_GCC, _candidate(**{"compiler.libcxx": "libc++"})) is False
+
+
+def test_match_conan_settings_arch_mismatch():
+    assert match_conan_settings(_TARGET_GCC, _candidate(arch="x86")) is False
+
+
+def test_match_conan_settings_os_mismatch():
+    assert match_conan_settings(_TARGET_GCC, _candidate(os="Windows")) is False
+
+
+def test_match_conan_settings_stdver_is_wildcard():
+    target = {**_TARGET_GCC, "stdver": "c++23"}
+    assert match_conan_settings(target, _candidate(stdver="")) is True
+    assert match_conan_settings(target, _candidate(stdver="c++17")) is True
+
+
+def test_match_conan_settings_headeronly_compiler_wildcard():
+    headeronly = _candidate(compiler="headeronly", **{"compiler.version": "headeronly"})
+    assert match_conan_settings(_TARGET_GCC, headeronly) is True
+
+
+def test_match_conan_settings_headeronly_bypasses_libcxx_and_arch():
+    headeronly = _candidate(
+        compiler="headeronly",
+        **{"compiler.version": "headeronly", "compiler.libcxx": "", "arch": ""},
+    )
+    target = {**_TARGET_GCC, "compiler.libcxx": "libc++", "arch": "x86"}
+    assert match_conan_settings(target, headeronly) is True
+
+
+def test_match_conan_settings_cshared_compiler_wildcard():
+    cshared = _candidate(compiler="cshared", **{"compiler.version": "cshared"})
+    assert match_conan_settings(_TARGET_GCC, cshared) is True
+
+
+def test_match_conan_settings_cshared_bypasses_libcxx_but_not_arch():
+    """Per the TS source: cshared wildcards libcxx; only headeronly wildcards arch."""
+    cshared = _candidate(
+        compiler="cshared",
+        **{"compiler.version": "cshared", "compiler.libcxx": "", "arch": "x86_64"},
+    )
+    # libcxx mismatch is allowed for cshared
+    target_diff_libcxx = {**_TARGET_GCC, "compiler.libcxx": "libc++"}
+    assert match_conan_settings(target_diff_libcxx, cshared) is True
+    # arch mismatch is NOT allowed for cshared
+    target_diff_arch = {**_TARGET_GCC, "arch": "x86"}
+    assert match_conan_settings(target_diff_arch, cshared) is False
+
+
+def test_match_conan_settings_missing_candidate_key_compares_to_empty():
+    """A missing key on the candidate side compares as empty string."""
+    target = {**_TARGET_GCC, "compiler.libcxx": "libstdc++"}
+    candidate = {k: v for k, v in _candidate().items() if k != "compiler.libcxx"}
+    assert match_conan_settings(target, candidate) is False
+    target_empty = {**_TARGET_GCC, "compiler.libcxx": ""}
+    assert match_conan_settings(target_empty, candidate) is True
 
 
 def create_test_build_config():

--- a/bin/test/rust_library_builder_test.py
+++ b/bin/test/rust_library_builder_test.py
@@ -54,8 +54,7 @@ def test_makebuildhash(requests_mock):
     assert len(result) > len("rustc-1.70_")
 
 
-@patch("subprocess.check_output")
-def test_get_conan_hash_success(mock_subprocess, requests_mock):
+def test_get_conan_hash_success(requests_mock):
     requests_mock.get(f"{BASE}rust.amazon.properties", text="")
     logger = mock.Mock(spec_set=Logger)
     install_context = mock.Mock()
@@ -63,15 +62,36 @@ def test_get_conan_hash_success(mock_subprocess, requests_mock):
     build_config = create_rust_test_build_config()
     builder = RustLibraryBuilder(logger, "rust", "rustlib", "1.0.0", install_context, build_config)
 
-    mock_subprocess.return_value = b"conanfile.py: ID: rust123456\nOther output"
-    builder.current_buildparameters = ["-s", "os=Linux"]
+    builder.current_buildparameters_obj["os"] = "Linux"
+    builder.current_buildparameters_obj["buildtype"] = "Debug"
+    builder.current_buildparameters_obj["compiler"] = "rustc"
+    builder.current_buildparameters_obj["compiler_version"] = "rustc-1.70"
+    builder.current_buildparameters_obj["libcxx"] = ""
+    builder.current_buildparameters_obj["arch"] = "x86_64"
+    builder.current_buildparameters_obj["stdver"] = ""
+    builder.current_buildparameters_obj["flagcollection"] = ""
+
+    requests_mock.get(
+        "https://conan.compiler-explorer.com/v1/conans/rustlib/1.0.0/rustlib/1.0.0/search",
+        json={
+            "rust123456": {
+                "settings": {
+                    "os": "Linux",
+                    "build_type": "Debug",
+                    "compiler": "rustc",
+                    "compiler.version": "rustc-1.70",
+                    "compiler.libcxx": "",
+                    "arch": "x86_64",
+                    "stdver": "",
+                    "flagcollection": "",
+                }
+            }
+        },
+    )
 
     result = builder.get_conan_hash("/tmp/buildfolder")
 
     assert result == "rust123456"
-    mock_subprocess.assert_called_once_with(
-        ["conan", "info", "-r", "ceserver", "."] + builder.current_buildparameters, cwd="/tmp/buildfolder"
-    )
 
 
 @patch("subprocess.call")


### PR DESCRIPTION
## Summary

Library-builder hot path was shelling out to `conan info -r ceserver .` once per build combination to derive the conan package_id. Replaced with a single `GET /v1/conans/{lib}/{ver}/{lib}/{ver}/search` cached on the builder instance, with client-side settings matching.

Pattern ported from `compiler-explorer/lib/buildenvsetup/ceconan.ts` (@partouf's existing rewrite on the Node.js side). Match rules - headeronly / cshared compiler wildcards, libcxx and arch wildcards under those, stdver always-match - extracted as module-level helpers (`match_conan_settings`, `conan_search_url`, `build_target_settings` in `library_builder.py`) and shared across all four builder classes (c++, rust, fortran, go) to avoid drift.

Refs #1342.

## Performance

Measured locally with conan 1.66 against the live conan proxy:

| | per-iteration cost |
|---|---|
| old (`conan info` subprocess) | ~335ms |
| new (cached `/search` + dict scan) | ~0.5ms after a one-off ~1s search |

| iterations | old | new | speedup |
|--:|--:|--:|--:|
| 20 | 6.7s | 1.0s | 7x |
| 40 | 13.4s | 1.0s | 13x |
| 200 | 67s | 1.1s | 60x |

End-to-end timing on a real lin-builder is the natural follow-up; couldn't run that locally because CE customises conan's `settings.yml` with non-standard values (e.g. `compiler.version=g141`, the `flagcollection` setting) that only exist on the builder bootstrap.

## Subtle bits

- **`set_as_uploaded` ordering.** The new search endpoint can only see packages already on the remote, so the original ordering (`get_conan_hash` -> conditional `upload_builds`) would have crashed every first-time upload with `RuntimeError: Error determining conan hash`. Reordered to `get_build_annotations` -> conditional `upload_builds` -> `get_conan_hash`. `upload_builds` invalidates `_possible_builds`, so the post-upload `get_conan_hash` sees the fresh search response. `test_set_as_uploaded_first_time_does_not_raise` is the regression test for this path; it fails on the un-reordered version.
- **TS port faithfulness.** Match rules check the candidate's specific key (e.g. `candidate.get("compiler.version") in ("headeronly", "cshared")`) rather than a single up-front predicate, mirroring the TS implementation. Worth comparing to `ceconan.ts:249-275` if reviewing the matcher.
- **URL encoding** uses `urllib.parse.quote(s, safe="")` to match `encodeURIComponent` semantics for lib/version path segments.
- **Cache-invalidation point.** All four `upload_builds` set `self._possible_builds = None` after a successful upload, so the next `get_conan_hash` in the same builder instance refetches.

## Out of scope

- TTL on `hasFailedBefore` (the trunk-poisoning aspect of #1342). Separate, server-side concern.
- Consolidating `resil_get` / HTTP-retry into a shared helper across the four builders. Pre-existing drift, not made worse by this PR.

## Test plan

- [x] `make test` (636 passed, 1 skipped)
- [x] `make static-checks` clean
- [x] Two passes of code review by an LLM agent
- [x] Live validation against `conan.compiler-explorer.com`: real boost_bin/clang_barry hash returned by the matcher resolves to a real annotation; libcxx mismatch returns None; eigen/3.4.0 headeronly matches across compiler/libcxx/arch but rejects on os mismatch
- [x] Regression test for fresh-upload path verified to fail when the ordering fix is reverted
- [ ] End-to-end timing on a real lin-builder (follow-up; needs CE's customised conan settings)