### PR TITLE
Ignore Claude Code runtime/per-user state files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ node_modules
 /uv.lock
 /lambda/.build_site_packages
 *.egg-info
+
+# Claude Code runtime/per-user state (committed config lives in .claude/agents, .claude/commands, etc.)
+.claude/scheduled_tasks.lock
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

`scheduled_tasks.lock` and `settings.local.json` are Claude Code state that should never be committed:

- `scheduled_tasks.lock` is a runtime lock file held while a session is alive (gets cleaned up on exit, but lingers if the session crashes).
- `settings.local.json` holds per-user permission overrides.

The rest of `.claude/` (`agents/`, `commands/`, `settings.json`, `format-file.py`) stays tracked as shared project config.

## Test plan

- [x] `git check-ignore -v` confirms both patterns now match.
- [x] `git status` no longer lists `.claude/scheduled_tasks.lock` as untracked.