### PR TITLE
Bulk-fetch /failedbuilds, replace per-iteration hasFailedBefore POSTs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ node_modules
 /uv.lock
 /lambda/.build_site_packages
 *.egg-info
+
+# Claude Code runtime/per-user state (committed config lives in .claude/agents, .claude/commands, etc.)
+.claude/scheduled_tasks.lock
+.claude/settings.local.json

--- a/bin/lib/fortran_library_builder.py
+++ b/bin/lib/fortran_library_builder.py
@@ -25,7 +25,15 @@ from lib.amazon import get_ssm_param
 from lib.amazon_properties import get_properties_compilers_and_libraries, get_specific_library_version_details
 from lib.installation_context import FetchFailure, PostFailure
 from lib.library_build_config import LibraryBuildConfig
-from lib.library_builder import PossibleBuilds, build_target_settings, fetch_possible_builds, find_matching_package_id
+from lib.library_builder import (
+    FailedBuilds,
+    PossibleBuilds,
+    build_target_settings,
+    fetch_failed_builds,
+    fetch_possible_builds,
+    find_matching_package_id,
+    match_failed_build,
+)
 from lib.library_platform import LibraryPlatform
 from lib.staging import StagingDir
 
@@ -99,6 +107,7 @@ class FortranLibraryBuilder:
         self.libid = self.libname  # TODO: CE libid might be different from yaml libname
         self.conanserverproxy_token = None
         self._possible_builds: PossibleBuilds | None = None
+        self._failed_builds: FailedBuilds | None = None
         self._annotations_cache: dict[str, dict] = {}
         self.http_session = requests.Session()
 
@@ -506,7 +515,12 @@ class FortranLibraryBuilder:
 
         headers = {"Content-Type": "application/json", "Authorization": "Bearer " + self.conanserverproxy_token}
 
-        return self.resil_post(url, json_data=json.dumps(buildparameters_copy), headers=headers)
+        result = self.resil_post(url, json_data=json.dumps(buildparameters_copy), headers=headers)
+
+        if builtok in (BuildStatus.Failed, BuildStatus.TimedOut):
+            self._failed_builds = None
+
+        return result
 
     def get_build_annotations(self, buildfolder):
         if buildfolder in self._annotations_cache:
@@ -553,18 +567,18 @@ class FortranLibraryBuilder:
         else:
             return self.target_name
 
+    def _get_failed_builds(self) -> FailedBuilds:
+        if self._failed_builds is None:
+            self._failed_builds = fetch_failed_builds(
+                self.libname,
+                self.target_name,
+                lambda url: self.http_session.get(url, timeout=_TIMEOUT),
+                self.logger,
+            )
+        return self._failed_builds
+
     def has_failed_before(self):
-        url = f"{conanserver_url}/whathasfailedbefore"
-        request = self.resil_post(url, json_data=json.dumps(self.current_buildparameters_obj))
-        if not request.ok:
-            raise PostFailure(f"Post failure for {url}: {request}")
-        else:
-            response = json.loads(request.content)
-            current_commit = self.get_commit_hash()
-            if response["commithash"] == current_commit:
-                return response["response"]
-            else:
-                return False
+        return match_failed_build(self._get_failed_builds(), self.current_buildparameters_obj, self.get_commit_hash())
 
     def is_already_uploaded(self, buildfolder):
         annotations = self.get_build_annotations(buildfolder)

--- a/bin/lib/fortran_library_builder.py
+++ b/bin/lib/fortran_library_builder.py
@@ -517,8 +517,8 @@ class FortranLibraryBuilder:
 
         result = self.resil_post(url, json_data=json.dumps(buildparameters_copy), headers=headers)
 
-        if builtok in (BuildStatus.Failed, BuildStatus.TimedOut):
-            self._failed_builds = None
+        # Failed/TimedOut add a failure row server-side; Ok deletes one. Either way the cache is stale.
+        self._failed_builds = None
 
         return result
 

--- a/bin/lib/go_library_builder.py
+++ b/bin/lib/go_library_builder.py
@@ -28,7 +28,15 @@ from lib.cache_delta import CacheDeltaCapture
 from lib.golang_stdlib import go_supports_trimpath
 from lib.installation_context import InstallationContext, PostFailure
 from lib.library_build_config import LibraryBuildConfig
-from lib.library_builder import PossibleBuilds, build_target_settings, fetch_possible_builds, find_matching_package_id
+from lib.library_builder import (
+    FailedBuilds,
+    PossibleBuilds,
+    build_target_settings,
+    fetch_failed_builds,
+    fetch_possible_builds,
+    find_matching_package_id,
+    match_failed_build,
+)
 from lib.library_platform import LibraryPlatform
 from lib.staging import StagingDir
 
@@ -132,6 +140,7 @@ class GoLibraryBuilder:
         self.libid = f"go_{self.libname}"
         self.conanserverproxy_token: str | None = None
         self._possible_builds: PossibleBuilds | None = None
+        self._failed_builds: FailedBuilds | None = None
         self._annotations_cache: dict[str, dict] = {}
         self.http_session = requests.Session()
 
@@ -502,18 +511,24 @@ require {self.module_path} {self.target_name}
             error_text = request.get("text", "") if isinstance(request, dict) else request.text
             raise PostFailure(f"Post failure for {url}: {error_text}")
 
+        if builtok in (BuildStatus.Failed, BuildStatus.TimedOut):
+            self._failed_builds = None
+
+    def _get_failed_builds(self) -> FailedBuilds:
+        if self._failed_builds is None:
+            self._failed_builds = fetch_failed_builds(
+                self.libid,
+                self.target_name,
+                lambda url: self.http_session.get(url, timeout=_TIMEOUT),
+                self.logger,
+            )
+        return self._failed_builds
+
     def has_failed_before(self, build_method: str) -> bool:
         """Check if this build has failed before."""
-        url = f"{CONANSERVER_URL}/hasfailedbefore"
-        data = dict(self.current_buildparameters_obj)
-        data["flagcollection"] = build_method
-
-        request = self.resil_post(url, json.dumps(data))
-        if isinstance(request, dict) or not request.ok:
-            return False
-
-        response = json.loads(request.content)
-        return response.get("response", False)
+        params = dict(self.current_buildparameters_obj)
+        params["flagcollection"] = build_method
+        return match_failed_build(self._get_failed_builds(), params, None)
 
     def get_build_annotations(self, buildfolder: Path) -> dict:
         """Get build annotations from Conan server."""

--- a/bin/lib/go_library_builder.py
+++ b/bin/lib/go_library_builder.py
@@ -511,8 +511,8 @@ require {self.module_path} {self.target_name}
             error_text = request.get("text", "") if isinstance(request, dict) else request.text
             raise PostFailure(f"Post failure for {url}: {error_text}")
 
-        if builtok in (BuildStatus.Failed, BuildStatus.TimedOut):
-            self._failed_builds = None
+        # Failed/TimedOut add a failure row server-side; Ok deletes one. Either way the cache is stale.
+        self._failed_builds = None
 
     def _get_failed_builds(self) -> FailedBuilds:
         if self._failed_builds is None:

--- a/bin/lib/library_builder.py
+++ b/bin/lib/library_builder.py
@@ -186,6 +186,94 @@ def find_matching_package_id(possible_builds: PossibleBuilds, target: dict[str, 
     return None
 
 
+class FailedBuildRecord(TypedDict, total=False):
+    """A single row from /failedbuilds: a known-failed (compiler, ...) tuple for some lib/version."""
+
+    compiler: str
+    compiler_version: str
+    arch: str
+    libcxx: str
+    compiler_flags: str
+    commithash: str
+
+
+type FailedBuilds = list[FailedBuildRecord]
+
+
+def failed_builds_url(libname: str, target_name: str) -> str:
+    encoded_lib = urllib.parse.quote(libname, safe="")
+    encoded_ver = urllib.parse.quote(target_name, safe="")
+    return f"{conanserver_url}/failedbuilds/{encoded_lib}/{encoded_ver}"
+
+
+def fetch_failed_builds(
+    libname: str,
+    target_name: str,
+    fetcher: Callable[[str], requests.Response | None],
+    logger: Logger,
+) -> FailedBuilds:
+    """Fetch and parse the conan-proxy /failedbuilds response for a (libname, target_name).
+
+    Mirrors fetch_possible_builds: 404 means no failures recorded yet (legitimate empty
+    state), other failure modes raise FetchFailure so the builder surfaces them rather
+    than silently treating real outages as "nothing failed".
+    """
+    url = failed_builds_url(libname, target_name)
+    try:
+        response = fetcher(url)
+    except requests.RequestException as e:
+        raise FetchFailure(f"Failed-builds request failed for {libname}/{target_name}: {e}") from e
+
+    if response is None:
+        raise FetchFailure(f"Failed-builds request failed for {libname}/{target_name}")
+    if response.status_code == 404:
+        logger.debug("No recorded failures for %s/%s", libname, target_name)
+        return []
+    if not response.ok:
+        raise FetchFailure(f"Failed-builds returned {response.status_code} for {libname}/{target_name}")
+
+    try:
+        payload = response.json()
+    except ValueError as e:
+        raise FetchFailure(f"Failed-builds returned non-JSON for {libname}/{target_name}") from e
+    if not isinstance(payload, list):
+        raise FetchFailure(f"Failed-builds returned non-array JSON for {libname}/{target_name}")
+    return payload
+
+
+def match_failed_build(
+    records: FailedBuilds,
+    build_params: dict[str, Any],
+    current_commit_hash: str | None,
+) -> bool:
+    """Return True iff some record matches build_params on the discriminator columns.
+
+    Discriminators: compiler, compiler_version, arch, libcxx, flagcollection. When
+    `current_commit_hash` is given (C++/Fortran callers), the matching record must also
+    carry that commithash; older records are treated as stale, preserving the existing
+    trunk-recovery behaviour from /whathasfailedbefore. When None (Go/Rust callers,
+    matching /hasfailedbefore semantics), any matching record counts.
+    """
+    target_compiler = build_params.get("compiler", "")
+    target_version = build_params.get("compiler_version", "")
+    target_arch = build_params.get("arch", "")
+    target_libcxx = build_params.get("libcxx", "")
+    target_flags = build_params.get("flagcollection", "")
+
+    for r in records:
+        if (
+            r.get("compiler", "") == target_compiler
+            and r.get("compiler_version", "") == target_version
+            and r.get("arch", "") == target_arch
+            and r.get("libcxx", "") == target_libcxx
+            and r.get("compiler_flags", "") == target_flags
+        ):
+            if current_commit_hash is None:
+                return True
+            return r.get("commithash", "") == current_commit_hash
+    return False
+
+
 def build_target_settings(buildparams: dict[str, Any]) -> dict[str, str]:
     """Translate current_buildparameters_obj keys into conan settings dotted form.
 
@@ -254,6 +342,7 @@ class LibraryBuilder:
         self.current_commit_hash = ""
         self.platform = platform
         self._possible_builds: PossibleBuilds | None = None
+        self._failed_builds: FailedBuilds | None = None
         self._annotations_cache: dict[str, dict] = {}
         self.http_session = requests.Session()
 
@@ -1260,7 +1349,12 @@ class LibraryBuilder:
 
         headers = {"Content-Type": "application/json", "Authorization": "Bearer " + self.conanserverproxy_token}
 
-        return self.resil_post(url, json_data=json.dumps(buildparameters_copy), headers=headers)
+        result = self.resil_post(url, json_data=json.dumps(buildparameters_copy), headers=headers)
+
+        if builtok in (BuildStatus.Failed, BuildStatus.TimedOut):
+            self._failed_builds = None
+
+        return result
 
     def get_build_annotations(self, buildfolder):
         if buildfolder in self._annotations_cache:
@@ -1313,18 +1407,18 @@ class LibraryBuilder:
 
         return self.current_commit_hash
 
+    def _get_failed_builds(self) -> FailedBuilds:
+        if self._failed_builds is None:
+            self._failed_builds = fetch_failed_builds(
+                self.libname,
+                self.target_name,
+                lambda url: self.resil_get(url, stream=False, timeout=_TIMEOUT),
+                self.logger,
+            )
+        return self._failed_builds
+
     def has_failed_before(self):
-        url = f"{conanserver_url}/whathasfailedbefore"
-        request = self.resil_post(url, json_data=json.dumps(self.current_buildparameters_obj))
-        if not request.ok:
-            raise PostFailure(f"Post failure for {url}: {request}")
-        else:
-            response = json.loads(request.content)
-            current_commit = self.get_commit_hash()
-            if response["commithash"] == current_commit:
-                return response["response"]
-            else:
-                return False
+        return match_failed_build(self._get_failed_builds(), self.current_buildparameters_obj, self.get_commit_hash())
 
     def is_already_uploaded(self, buildfolder):
         annotations = self.get_build_annotations(buildfolder)

--- a/bin/lib/library_builder.py
+++ b/bin/lib/library_builder.py
@@ -214,9 +214,7 @@ def fetch_failed_builds(
 ) -> FailedBuilds:
     """Fetch and parse the conan-proxy /failedbuilds response for a (libname, target_name).
 
-    Mirrors fetch_possible_builds: 404 means no failures recorded yet (legitimate empty
-    state), other failure modes raise FetchFailure so the builder surfaces them rather
-    than silently treating real outages as "nothing failed".
+    404 means no failures recorded yet; non-2xx and malformed payloads raise FetchFailure.
     """
     url = failed_builds_url(libname, target_name)
     try:
@@ -249,10 +247,8 @@ def match_failed_build(
     """Return True iff some record matches build_params on the discriminator columns.
 
     Discriminators: compiler, compiler_version, arch, libcxx, flagcollection. When
-    `current_commit_hash` is given (C++/Fortran callers), the matching record must also
-    carry that commithash; older records are treated as stale, preserving the existing
-    trunk-recovery behaviour from /whathasfailedbefore. When None (Go/Rust callers,
-    matching /hasfailedbefore semantics), any matching record counts.
+    `current_commit_hash` is given, the record's commithash must match too -- a failure
+    against a different commit is treated as stale so the next build can retry.
     """
     target_compiler = build_params.get("compiler", "")
     target_version = build_params.get("compiler_version", "")
@@ -1351,8 +1347,8 @@ class LibraryBuilder:
 
         result = self.resil_post(url, json_data=json.dumps(buildparameters_copy), headers=headers)
 
-        if builtok in (BuildStatus.Failed, BuildStatus.TimedOut):
-            self._failed_builds = None
+        # Failed/TimedOut add a failure row server-side; Ok deletes one. Either way the cache is stale.
+        self._failed_builds = None
 
         return result
 

--- a/bin/lib/rust_library_builder.py
+++ b/bin/lib/rust_library_builder.py
@@ -357,8 +357,8 @@ class RustLibraryBuilder:
         if not request.ok:
             raise PostFailure(f"Post failure for {url}: {request}")
 
-        if builtok in (BuildStatus.Failed, BuildStatus.TimedOut):
-            self._failed_builds = None
+        # Failed/TimedOut add a failure row server-side; Ok deletes one. Either way the cache is stale.
+        self._failed_builds = None
 
     def get_build_annotations(self, buildfolder):
         if buildfolder in self._annotations_cache:

--- a/bin/lib/rust_library_builder.py
+++ b/bin/lib/rust_library_builder.py
@@ -23,7 +23,15 @@ from lib.amazon import get_ssm_param
 from lib.amazon_properties import get_properties_compilers_and_libraries
 from lib.installation_context import FetchFailure, InstallationContext, PostFailure
 from lib.library_build_config import LibraryBuildConfig
-from lib.library_builder import PossibleBuilds, build_target_settings, fetch_possible_builds, find_matching_package_id
+from lib.library_builder import (
+    FailedBuilds,
+    PossibleBuilds,
+    build_target_settings,
+    fetch_failed_builds,
+    fetch_possible_builds,
+    find_matching_package_id,
+    match_failed_build,
+)
 from lib.library_platform import LibraryPlatform
 from lib.rust_crates import RustCrate, get_builder_user_agent_id
 from lib.staging import StagingDir
@@ -87,6 +95,7 @@ class RustLibraryBuilder:
         self.libid = self.libname  # TODO: CE libid might be different from yaml libname
         self.conanserverproxy_token = None
         self._possible_builds: PossibleBuilds | None = None
+        self._failed_builds: FailedBuilds | None = None
         self._annotations_cache: dict[str, dict] = {}
         self.http_session = requests.Session()
 
@@ -348,6 +357,9 @@ class RustLibraryBuilder:
         if not request.ok:
             raise PostFailure(f"Post failure for {url}: {request}")
 
+        if builtok in (BuildStatus.Failed, BuildStatus.TimedOut):
+            self._failed_builds = None
+
     def get_build_annotations(self, buildfolder):
         if buildfolder in self._annotations_cache:
             self.logger.debug(f"Using cached annotations for {buildfolder}")
@@ -376,20 +388,20 @@ class RustLibraryBuilder:
     def get_commit_hash(self) -> str:
         return self.target_name
 
+    def _get_failed_builds(self) -> FailedBuilds:
+        if self._failed_builds is None:
+            self._failed_builds = fetch_failed_builds(
+                self.libname,
+                self.target_name,
+                lambda url: self.http_session.get(url, timeout=_TIMEOUT),
+                self.logger,
+            )
+        return self._failed_builds
+
     def has_failed_before(self, build_method):
-        url = f"{conanserver_url}/hasfailedbefore"
-
-        data = self.current_buildparameters_obj.copy()
-        data["flagcollection"] = build_method["build_method"]
-
-        req_data = json.dumps(data)
-
-        request = self.resil_post(url, req_data)
-        if not request.ok:
-            raise PostFailure(f"Post failure for {url}: {request}")
-        else:
-            response = json.loads(request.content)
-            return response["response"]
+        params = self.current_buildparameters_obj.copy()
+        params["flagcollection"] = build_method["build_method"]
+        return match_failed_build(self._get_failed_builds(), params, None)
 
     def is_already_uploaded(self, buildfolder, source_folder):
         annotations = self.get_build_annotations(buildfolder)

--- a/bin/test/fortran_library_builder_test.py
+++ b/bin/test/fortran_library_builder_test.py
@@ -205,6 +205,53 @@ def test_get_conan_hash_success(requests_mock):
     assert result == "fortran123456"
 
 
+def _make_fortran_builder_with_buildparams(requests_mock):
+    requests_mock.get(f"{BASE}fortran.amazon.properties", text="")
+    logger = mock.Mock(spec_set=Logger)
+    install_context = mock.Mock()
+    install_context.dry_run = False
+    build_config = create_fortran_test_build_config()
+    builder = FortranLibraryBuilder(
+        logger, "fortran", "fortranlib", "2.0.0", "/tmp/source", install_context, build_config, False
+    )
+    builder.current_buildparameters_obj["compiler"] = "fortran"
+    builder.current_buildparameters_obj["compiler_version"] = "f2018"
+    builder.current_buildparameters_obj["arch"] = "x86_64"
+    builder.current_buildparameters_obj["libcxx"] = "libgfortran"
+    builder.current_buildparameters_obj["flagcollection"] = ""
+    return builder
+
+
+_FORTRAN_FAILED_URL = "https://conan.compiler-explorer.com/failedbuilds/fortranlib/2.0.0"
+
+
+def _fortran_failed_record(**overrides):
+    base = {
+        "compiler": "fortran",
+        "compiler_version": "f2018",
+        "arch": "x86_64",
+        "libcxx": "libgfortran",
+        "compiler_flags": "",
+        "commithash": "2.0.0",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_fortran_has_failed_before_caches_response(requests_mock):
+    builder = _make_fortran_builder_with_buildparams(requests_mock)
+    matcher = requests_mock.get(_FORTRAN_FAILED_URL, json=[_fortran_failed_record()])
+    assert builder.has_failed_before() is True
+    assert builder.has_failed_before() is True
+    assert matcher.call_count == 1
+
+
+def test_fortran_has_failed_before_stale_commit_returns_false(requests_mock):
+    builder = _make_fortran_builder_with_buildparams(requests_mock)
+    requests_mock.get(_FORTRAN_FAILED_URL, json=[_fortran_failed_record(commithash="prev")])
+    assert builder.has_failed_before() is False
+
+
 @patch("subprocess.call")
 def test_execute_build_script_success(mock_subprocess, requests_mock):
     requests_mock.get(f"{BASE}fortran.amazon.properties", text="")

--- a/bin/test/go_library_builder_test.py
+++ b/bin/test/go_library_builder_test.py
@@ -326,6 +326,45 @@ class TestGoLibraryBuilderConanHelpers:
 
         assert builder.get_conan_hash(Path("/tmp/build")) == "go_hash"
 
+    @patch("lib.go_library_builder.get_properties_compilers_and_libraries")
+    def test_has_failed_before_via_failedbuilds(self, mock_get_props, requests_mock):
+        """has_failed_before should hit /failedbuilds/<libid>/<ver> and match in-memory."""
+        mock_get_props.return_value = ({"gl1238": {"exe": "/opt/go/bin/go"}}, {})
+        logger = MagicMock()
+        install_context = MagicMock()
+        install_context.dry_run = False
+        buildconfig = create_go_test_build_config()
+
+        builder = GoLibraryBuilder(
+            logger=logger,
+            language="go",
+            libname="uuid",
+            target_name="v1.6.0",
+            install_context=install_context,
+            buildconfig=buildconfig,
+        )
+        builder.set_current_conan_build_parameters("Linux", "Debug", "gl1238", "x86_64")
+
+        # libid is go_uuid (Go always prefixes with go_); endpoint must use that, not bare libname.
+        matcher = requests_mock.get(
+            "https://conan.compiler-explorer.com/failedbuilds/go_uuid/v1.6.0",
+            json=[
+                {
+                    "compiler": "golang",
+                    "compiler_version": "gl1238",
+                    "arch": "x86_64",
+                    "libcxx": "",
+                    "compiler_flags": "gomod",
+                    "commithash": "ignored",
+                }
+            ],
+        )
+
+        assert builder.has_failed_before("gomod") is True
+        assert builder.has_failed_before("gccgo") is False
+        # one fetch shared across calls -- the match logic runs in-memory
+        assert matcher.call_count == 1
+
 
 class TestGoLibraryBuilderBuildStatus:
     """Tests for BuildStatus enum."""

--- a/bin/test/library_builder_test.py
+++ b/bin/test/library_builder_test.py
@@ -809,22 +809,21 @@ def test_match_failed_build_finds_match_among_many():
 _FAILED_URL = "https://conan.compiler-explorer.com/failedbuilds/testlib/1.0.0"
 
 
-def _direct_fetcher(requests_mock):
-    session = requests.Session()
-    return lambda url: session.get(url, timeout=5)
+def _fetch(url):
+    return requests.get(url, timeout=5)
 
 
 def test_fetch_failed_builds_returns_list(requests_mock):
     requests_mock.get(_FAILED_URL, json=[_failed_record()])
     logger = mock.Mock(spec_set=Logger)
-    result = fetch_failed_builds("testlib", "1.0.0", _direct_fetcher(requests_mock), logger)
+    result = fetch_failed_builds("testlib", "1.0.0", _fetch, logger)
     assert result == [_failed_record()]
 
 
 def test_fetch_failed_builds_404_returns_empty(requests_mock):
     requests_mock.get(_FAILED_URL, status_code=404)
     logger = mock.Mock(spec_set=Logger)
-    result = fetch_failed_builds("testlib", "1.0.0", _direct_fetcher(requests_mock), logger)
+    result = fetch_failed_builds("testlib", "1.0.0", _fetch, logger)
     assert result == []
 
 
@@ -832,14 +831,14 @@ def test_fetch_failed_builds_500_raises(requests_mock):
     requests_mock.get(_FAILED_URL, status_code=500)
     logger = mock.Mock(spec_set=Logger)
     with pytest.raises(FetchFailure):
-        fetch_failed_builds("testlib", "1.0.0", _direct_fetcher(requests_mock), logger)
+        fetch_failed_builds("testlib", "1.0.0", _fetch, logger)
 
 
 def test_fetch_failed_builds_non_list_json_raises(requests_mock):
     requests_mock.get(_FAILED_URL, json={"not": "a list"})
     logger = mock.Mock(spec_set=Logger)
     with pytest.raises(FetchFailure):
-        fetch_failed_builds("testlib", "1.0.0", _direct_fetcher(requests_mock), logger)
+        fetch_failed_builds("testlib", "1.0.0", _fetch, logger)
 
 
 # Behavioural tests on LibraryBuilder.has_failed_before.

--- a/bin/test/library_builder_test.py
+++ b/bin/test/library_builder_test.py
@@ -10,9 +10,17 @@ from unittest import mock
 from unittest.mock import patch
 
 import pytest
+import requests
 from lib.installation_context import FetchFailure, InstallationContext
 from lib.library_build_config import LibraryBuildConfig
-from lib.library_builder import BuildStatus, LibraryBuilder, build_timeout, match_conan_settings
+from lib.library_builder import (
+    BuildStatus,
+    LibraryBuilder,
+    build_timeout,
+    fetch_failed_builds,
+    match_conan_settings,
+    match_failed_build,
+)
 from lib.library_platform import LibraryPlatform
 
 BASE = "https://raw.githubusercontent.com/compiler-explorer/compiler-explorer/main/etc/config/"
@@ -725,3 +733,136 @@ def test_count_headers(mock_glob, requests_mock):
 
     assert result == 3
     assert mock_glob.call_count == 2
+
+
+# Direct unit tests for match_failed_build.
+
+_FAILED_PARAMS = {
+    "compiler": "gcc",
+    "compiler_version": "g141",
+    "arch": "x86_64",
+    "libcxx": "libstdc++",
+    "flagcollection": "",
+}
+
+
+def _failed_record(**overrides):
+    base = {
+        "compiler": "gcc",
+        "compiler_version": "g141",
+        "arch": "x86_64",
+        "libcxx": "libstdc++",
+        "compiler_flags": "",
+        "commithash": "abc123",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_match_failed_build_exact_match_with_commit_filter():
+    assert match_failed_build([_failed_record()], _FAILED_PARAMS, "abc123") is True
+
+
+def test_match_failed_build_stale_commit_returns_false():
+    assert match_failed_build([_failed_record(commithash="old")], _FAILED_PARAMS, "abc123") is False
+
+
+def test_match_failed_build_no_commit_filter_matches_any_commit():
+    assert match_failed_build([_failed_record(commithash="old")], _FAILED_PARAMS, None) is True
+
+
+def test_match_failed_build_compiler_mismatch():
+    assert match_failed_build([_failed_record(compiler="clang")], _FAILED_PARAMS, "abc123") is False
+
+
+def test_match_failed_build_version_mismatch():
+    assert match_failed_build([_failed_record(compiler_version="g131")], _FAILED_PARAMS, "abc123") is False
+
+
+def test_match_failed_build_arch_mismatch():
+    assert match_failed_build([_failed_record(arch="x86")], _FAILED_PARAMS, "abc123") is False
+
+
+def test_match_failed_build_libcxx_mismatch():
+    assert match_failed_build([_failed_record(libcxx="libc++")], _FAILED_PARAMS, "abc123") is False
+
+
+def test_match_failed_build_flagcollection_mismatch():
+    assert match_failed_build([_failed_record(compiler_flags="-std=c++23")], _FAILED_PARAMS, "abc123") is False
+
+
+def test_match_failed_build_empty_records_returns_false():
+    assert match_failed_build([], _FAILED_PARAMS, "abc123") is False
+
+
+def test_match_failed_build_finds_match_among_many():
+    records = [
+        _failed_record(compiler="clang", compiler_version="c1700"),
+        _failed_record(),
+        _failed_record(compiler="gcc", compiler_version="g131"),
+    ]
+    assert match_failed_build(records, _FAILED_PARAMS, "abc123") is True
+
+
+# Direct unit tests for fetch_failed_builds.
+
+_FAILED_URL = "https://conan.compiler-explorer.com/failedbuilds/testlib/1.0.0"
+
+
+def _direct_fetcher(requests_mock):
+    session = requests.Session()
+    return lambda url: session.get(url, timeout=5)
+
+
+def test_fetch_failed_builds_returns_list(requests_mock):
+    requests_mock.get(_FAILED_URL, json=[_failed_record()])
+    logger = mock.Mock(spec_set=Logger)
+    result = fetch_failed_builds("testlib", "1.0.0", _direct_fetcher(requests_mock), logger)
+    assert result == [_failed_record()]
+
+
+def test_fetch_failed_builds_404_returns_empty(requests_mock):
+    requests_mock.get(_FAILED_URL, status_code=404)
+    logger = mock.Mock(spec_set=Logger)
+    result = fetch_failed_builds("testlib", "1.0.0", _direct_fetcher(requests_mock), logger)
+    assert result == []
+
+
+def test_fetch_failed_builds_500_raises(requests_mock):
+    requests_mock.get(_FAILED_URL, status_code=500)
+    logger = mock.Mock(spec_set=Logger)
+    with pytest.raises(FetchFailure):
+        fetch_failed_builds("testlib", "1.0.0", _direct_fetcher(requests_mock), logger)
+
+
+def test_fetch_failed_builds_non_list_json_raises(requests_mock):
+    requests_mock.get(_FAILED_URL, json={"not": "a list"})
+    logger = mock.Mock(spec_set=Logger)
+    with pytest.raises(FetchFailure):
+        fetch_failed_builds("testlib", "1.0.0", _direct_fetcher(requests_mock), logger)
+
+
+# Behavioural tests on LibraryBuilder.has_failed_before.
+
+
+def test_has_failed_before_caches_endpoint_response(requests_mock):
+    builder = _make_builder_with_params(requests_mock)
+    builder.current_commit_hash = "abc123"
+    matcher = requests_mock.get(_FAILED_URL, json=[_failed_record()])
+    assert builder.has_failed_before() is True
+    assert builder.has_failed_before() is True
+    assert matcher.call_count == 1
+
+
+def test_has_failed_before_stale_commit_returns_false(requests_mock):
+    builder = _make_builder_with_params(requests_mock)
+    builder.current_commit_hash = "abc123"
+    requests_mock.get(_FAILED_URL, json=[_failed_record(commithash="prev")])
+    assert builder.has_failed_before() is False
+
+
+def test_has_failed_before_no_records_returns_false(requests_mock):
+    builder = _make_builder_with_params(requests_mock)
+    builder.current_commit_hash = "abc123"
+    requests_mock.get(_FAILED_URL, json=[])
+    assert builder.has_failed_before() is False

--- a/bin/test/rust_library_builder_test.py
+++ b/bin/test/rust_library_builder_test.py
@@ -139,8 +139,7 @@ def test_rust_has_failed_before_caches_response(requests_mock):
     assert matcher.call_count == 1
 
 
-def test_rust_has_failed_before_ignores_commithash(requests_mock):
-    """Rust has no commit-hash filter today; preserve that semantics."""
+def test_rust_has_failed_before_matches_regardless_of_commithash(requests_mock):
     builder = _make_rust_builder(requests_mock)
     requests_mock.get(_RUST_FAILED_URL, json=[_rust_failed_record(compiler_flags="release", commithash="ancient")])
     assert builder.has_failed_before({"build_method": "release"}) is True

--- a/bin/test/rust_library_builder_test.py
+++ b/bin/test/rust_library_builder_test.py
@@ -94,6 +94,58 @@ def test_get_conan_hash_success(requests_mock):
     assert result == "rust123456"
 
 
+_RUST_FAILED_URL = "https://conan.compiler-explorer.com/failedbuilds/rustlib/1.0.0"
+
+
+def _make_rust_builder(requests_mock):
+    requests_mock.get(f"{BASE}rust.amazon.properties", text="")
+    logger = mock.Mock(spec_set=Logger)
+    install_context = mock.Mock()
+    install_context.dry_run = False
+    build_config = create_rust_test_build_config()
+    builder = RustLibraryBuilder(logger, "rust", "rustlib", "1.0.0", install_context, build_config)
+    builder.current_buildparameters_obj["compiler"] = "rustc"
+    builder.current_buildparameters_obj["compiler_version"] = "rustc-1.70"
+    builder.current_buildparameters_obj["arch"] = "x86_64"
+    builder.current_buildparameters_obj["libcxx"] = ""
+    return builder
+
+
+def _rust_failed_record(**overrides):
+    base = {
+        "compiler": "rustc",
+        "compiler_version": "rustc-1.70",
+        "arch": "x86_64",
+        "libcxx": "",
+        "compiler_flags": "release",
+        "commithash": "any",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_rust_has_failed_before_overrides_flagcollection_from_build_method(requests_mock):
+    builder = _make_rust_builder(requests_mock)
+    requests_mock.get(_RUST_FAILED_URL, json=[_rust_failed_record(compiler_flags="release")])
+    assert builder.has_failed_before({"build_method": "release"}) is True
+    assert builder.has_failed_before({"build_method": "debug"}) is False
+
+
+def test_rust_has_failed_before_caches_response(requests_mock):
+    builder = _make_rust_builder(requests_mock)
+    matcher = requests_mock.get(_RUST_FAILED_URL, json=[_rust_failed_record(compiler_flags="release")])
+    builder.has_failed_before({"build_method": "release"})
+    builder.has_failed_before({"build_method": "release"})
+    assert matcher.call_count == 1
+
+
+def test_rust_has_failed_before_ignores_commithash(requests_mock):
+    """Rust has no commit-hash filter today; preserve that semantics."""
+    builder = _make_rust_builder(requests_mock)
+    requests_mock.get(_RUST_FAILED_URL, json=[_rust_failed_record(compiler_flags="release", commithash="ancient")])
+    assert builder.has_failed_before({"build_method": "release"}) is True
+
+
 @patch("subprocess.call")
 def test_execute_build_script_success(mock_subprocess, requests_mock):
     requests_mock.get(f"{BASE}rust.amazon.properties", text="")


### PR DESCRIPTION
After PR #2098 removed the per-iteration `conan info` subprocess, the dominant remaining cost in library-builder iterations is the `POST /whathasfailedbefore` (or `/hasfailedbefore` for Go/Rust). Live timing on `boost_bin × popular-compilers-only`: 646 of those POSTs at ~125ms median = ~80s of the 247s build step. Every "already uploaded" iteration also pays the cost before short-circuiting.

This PR replaces N per-iteration POSTs with one fetch of `/failedbuilds/:lib/:ver` per builder instance, then matches in-memory. Same shape as PR #2098.

Refs #1342.

## Depends on conanproxy#72 (deployed)

Companion: compiler-explorer/conanproxy#72 added the `/failedbuilds` endpoint and is now deployed on the live proxy. Defensive design: 404 is treated as "no failures recorded" (fail-open) so a brief mismatch reverts to no-speedup, not incorrect behaviour.

### Live endpoint verification

Probed `https://conan.compiler-explorer.com` after PR A's deploy:

| Probe | Result |
|---|---|
| `GET /healthcheck` | 200 OK |
| `GET /failedbuilds/nonexistent-library/v0` | 200, `[]` |
| `GET /failedbuilds/libassert/1.0` | 200, 1447 rows |
| Row count vs `/allfailedbuilds` for libassert/1.0 | 1447 == 1447 ✓ |
| `POST /whathasfailedbefore` (unchanged route) | 200, still returns `{response, commithash}` |

Sample row shape (`/failedbuilds/libassert/1.0`):
```json
{"arch": "", "commithash": "61e1e0d", "compiler": "clang", "compiler_flags": "", "compiler_version": "armv7-clang-trunk", "libcxx": "libc++"}
```

This matches the `FailedBuildRecord` TypedDict and what `match_failed_build` reads, so the integration path is confirmed end-to-end against real data.

## Behaviour preserved

- **C++ / Fortran** had a client-side commit-hash filter (failures from an older commit treated as stale -- this is what lets trunk recovery work today). That filter moves into `match_failed_build` and is exercised by tests.
- **Go / Rust** had no commit-hash filter. Pass `None` to keep that semantic exact.
- **Cache invalidation**: `save_build_logging(Failed|TimedOut)` clears `_failed_builds`, mirroring the `_possible_builds` invalidation in `upload_builds`.

## Out of scope

- TTL / trunk-poisoning fix on the server side. C++/Fortran client-side filter still handles this; Go/Rust have a pre-existing gap that's not regressed by this change.
- Cross-builder de-dup. The four builders share more than this helper; cleaning that up is a much larger refactor.

## Test plan

- [x] `make test` passes (672 tests, 17 new for `match_failed_build` / `fetch_failed_builds` / behavioural caching, plus per-builder tests).
- [x] `make static-checks` passes.
- [x] PR A live endpoint verified against real data (see table above).
- [ ] After merge: re-run `lin-lib-build.yaml` for `boost_bin × popular-compilers-only`. Compare to baseline (run 25443739162: 4m19s, ~80s on `has_failed_before`). Capture timings here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)