### PR TITLE
Restore ProtocolError retry; dedup resil_get/resil_post

### DIFF
--- a/bin/lib/fortran_library_builder.py
+++ b/bin/lib/fortran_library_builder.py
@@ -11,7 +11,6 @@ import re
 import shutil
 import subprocess
 import tempfile
-import time
 from collections import defaultdict
 from collections.abc import Generator
 from enum import Enum, unique
@@ -19,7 +18,6 @@ from pathlib import Path
 from typing import Any, TextIO
 
 import requests
-from urllib3.exceptions import ProtocolError
 
 from lib.amazon import get_ssm_param
 from lib.amazon_properties import get_properties_compilers_and_libraries, get_specific_library_version_details
@@ -33,6 +31,8 @@ from lib.library_builder import (
     fetch_possible_builds,
     find_matching_package_id,
     match_failed_build,
+    resil_get,
+    resil_post,
 )
 from lib.library_platform import LibraryPlatform
 from lib.staging import StagingDir
@@ -261,49 +261,6 @@ class FortranLibraryBuilder:
 
         return expanded
 
-    def resil_get(self, url: str, stream: bool, timeout: int, headers=None) -> requests.Response | None:
-        request: requests.Response | None = None
-        retries = 3
-        while retries > 0:
-            try:
-                if headers is not None:
-                    request = self.http_session.get(url, stream=stream, headers=headers, timeout=timeout)
-                else:
-                    request = self.http_session.get(
-                        url, stream=stream, headers={"Content-Type": "application/json"}, timeout=timeout
-                    )
-
-                retries = 0
-            except ProtocolError:
-                retries = retries - 1
-                time.sleep(1)
-
-        return request
-
-    def resil_post(self, url, json_data, headers=None):
-        request = None
-        retries = 3
-        last_error = ""
-        while retries > 0:
-            try:
-                if headers is not None:
-                    request = self.http_session.post(url, data=json_data, headers=headers, timeout=_TIMEOUT)
-                else:
-                    request = self.http_session.post(
-                        url, data=json_data, headers={"Content-Type": "application/json"}, timeout=_TIMEOUT
-                    )
-
-                retries = 0
-            except ProtocolError as e:
-                last_error = e
-                retries = retries - 1
-                time.sleep(1)
-
-        if request is None:
-            request = {"ok": False, "text": last_error}
-
-        return request
-
     def writebuildscript(
         self,
         buildfolder,
@@ -483,7 +440,7 @@ class FortranLibraryBuilder:
             self._possible_builds = fetch_possible_builds(
                 self.libname,
                 self.target_name,
-                lambda url: self.resil_get(url, stream=False, timeout=_TIMEOUT),
+                lambda url: resil_get(self.http_session, url, stream=False, timeout=_TIMEOUT),
                 self.logger,
             )
         return self._possible_builds
@@ -500,7 +457,7 @@ class FortranLibraryBuilder:
         login_body = defaultdict(lambda: [])
         login_body["password"] = get_ssm_param("/compiler-explorer/conanpwd")
 
-        request = self.resil_post(url, json_data=json.dumps(login_body))
+        request = resil_post(self.http_session, url, json_data=json.dumps(login_body))
         if not request.ok:
             self.logger.info(request.text)
             raise PostFailure(f"Post failure for {url}: {request}")
@@ -534,7 +491,7 @@ class FortranLibraryBuilder:
 
         headers = {"Content-Type": "application/json", "Authorization": "Bearer " + self.conanserverproxy_token}
 
-        result = self.resil_post(url, json_data=json.dumps(buildparameters_copy), headers=headers)
+        result = resil_post(self.http_session, url, json_data=json.dumps(buildparameters_copy), headers=headers)
 
         # Failed/TimedOut add a failure row server-side; Ok deletes one. Either way the cache is stale.
         self._failed_builds = None
@@ -591,7 +548,7 @@ class FortranLibraryBuilder:
             self._failed_builds = fetch_failed_builds(
                 self.libname,
                 self.target_name,
-                lambda url: self.resil_get(url, stream=False, timeout=_TIMEOUT),
+                lambda url: resil_get(self.http_session, url, stream=False, timeout=_TIMEOUT),
                 self.logger,
             )
         return self._failed_builds
@@ -630,7 +587,7 @@ class FortranLibraryBuilder:
         headers = {"Content-Type": "application/json", "Authorization": "Bearer " + self.conanserverproxy_token}
 
         url = f"{conanserver_url}/annotations/{self.libname}/{self.target_name}/{conanhash}"
-        request = self.resil_post(url, json_data=json.dumps(annotations), headers=headers)
+        request = resil_post(self.http_session, url, json_data=json.dumps(annotations), headers=headers)
         if not request.ok:
             raise PostFailure(f"Post failure for {url}: {request}")
 

--- a/bin/lib/fortran_library_builder.py
+++ b/bin/lib/fortran_library_builder.py
@@ -261,6 +261,25 @@ class FortranLibraryBuilder:
 
         return expanded
 
+    def resil_get(self, url: str, stream: bool, timeout: int, headers=None) -> requests.Response | None:
+        request: requests.Response | None = None
+        retries = 3
+        while retries > 0:
+            try:
+                if headers is not None:
+                    request = self.http_session.get(url, stream=stream, headers=headers, timeout=timeout)
+                else:
+                    request = self.http_session.get(
+                        url, stream=stream, headers={"Content-Type": "application/json"}, timeout=timeout
+                    )
+
+                retries = 0
+            except ProtocolError:
+                retries = retries - 1
+                time.sleep(1)
+
+        return request
+
     def resil_post(self, url, json_data, headers=None):
         request = None
         retries = 3
@@ -464,7 +483,7 @@ class FortranLibraryBuilder:
             self._possible_builds = fetch_possible_builds(
                 self.libname,
                 self.target_name,
-                lambda url: self.http_session.get(url, timeout=_TIMEOUT),
+                lambda url: self.resil_get(url, stream=False, timeout=_TIMEOUT),
                 self.logger,
             )
         return self._possible_builds
@@ -572,7 +591,7 @@ class FortranLibraryBuilder:
             self._failed_builds = fetch_failed_builds(
                 self.libname,
                 self.target_name,
-                lambda url: self.http_session.get(url, timeout=_TIMEOUT),
+                lambda url: self.resil_get(url, stream=False, timeout=_TIMEOUT),
                 self.logger,
             )
         return self._failed_builds

--- a/bin/lib/go_library_builder.py
+++ b/bin/lib/go_library_builder.py
@@ -424,7 +424,7 @@ require {self.module_path} {self.target_name}
             self._possible_builds = fetch_possible_builds(
                 self.libid,
                 self.target_name,
-                lambda url: self.http_session.get(url, timeout=_TIMEOUT),
+                lambda url: self.resil_get(url, stream=False, timeout=_TIMEOUT),
                 self.logger,
             )
         return self._possible_builds
@@ -435,6 +435,24 @@ require {self.module_path} {self.target_name}
             return None
         target = build_target_settings(self.current_buildparameters_obj)
         return find_matching_package_id(self._get_possible_builds(), target)
+
+    def resil_get(self, url: str, stream: bool, timeout: int, headers: dict | None = None) -> requests.Response | None:
+        """Resilient GET request with retries on ProtocolError."""
+        request: requests.Response | None = None
+        retries = 3
+        while retries > 0:
+            try:
+                if headers is not None:
+                    request = self.http_session.get(url, stream=stream, headers=headers, timeout=timeout)
+                else:
+                    request = self.http_session.get(
+                        url, stream=stream, headers={"Content-Type": "application/json"}, timeout=timeout
+                    )
+                retries = 0
+            except ProtocolError:
+                retries -= 1
+
+        return request
 
     def resil_post(self, url: str, json_data: str, headers: dict | None = None) -> requests.Response | dict:
         """Resilient POST request with retries."""
@@ -519,7 +537,7 @@ require {self.module_path} {self.target_name}
             self._failed_builds = fetch_failed_builds(
                 self.libid,
                 self.target_name,
-                lambda url: self.http_session.get(url, timeout=_TIMEOUT),
+                lambda url: self.resil_get(url, stream=False, timeout=_TIMEOUT),
                 self.logger,
             )
         return self._failed_builds

--- a/bin/lib/go_library_builder.py
+++ b/bin/lib/go_library_builder.py
@@ -20,7 +20,6 @@ from pathlib import Path
 from typing import Any, TextIO
 
 import requests
-from urllib3.exceptions import ProtocolError
 
 from lib.amazon import get_ssm_param
 from lib.amazon_properties import get_properties_compilers_and_libraries
@@ -36,6 +35,8 @@ from lib.library_builder import (
     fetch_possible_builds,
     find_matching_package_id,
     match_failed_build,
+    resil_get,
+    resil_post,
 )
 from lib.library_platform import LibraryPlatform
 from lib.staging import StagingDir
@@ -424,7 +425,7 @@ require {self.module_path} {self.target_name}
             self._possible_builds = fetch_possible_builds(
                 self.libid,
                 self.target_name,
-                lambda url: self.resil_get(url, stream=False, timeout=_TIMEOUT),
+                lambda url: resil_get(self.http_session, url, stream=False, timeout=_TIMEOUT),
                 self.logger,
             )
         return self._possible_builds
@@ -436,46 +437,6 @@ require {self.module_path} {self.target_name}
         target = build_target_settings(self.current_buildparameters_obj)
         return find_matching_package_id(self._get_possible_builds(), target)
 
-    def resil_get(self, url: str, stream: bool, timeout: int, headers: dict | None = None) -> requests.Response | None:
-        """Resilient GET request with retries on ProtocolError."""
-        request: requests.Response | None = None
-        retries = 3
-        while retries > 0:
-            try:
-                if headers is not None:
-                    request = self.http_session.get(url, stream=stream, headers=headers, timeout=timeout)
-                else:
-                    request = self.http_session.get(
-                        url, stream=stream, headers={"Content-Type": "application/json"}, timeout=timeout
-                    )
-                retries = 0
-            except ProtocolError:
-                retries -= 1
-
-        return request
-
-    def resil_post(self, url: str, json_data: str, headers: dict | None = None) -> requests.Response | dict:
-        """Resilient POST request with retries."""
-        request = None
-        retries = 3
-        last_error: str | Exception = ""
-        while retries > 0:
-            try:
-                if headers is not None:
-                    request = self.http_session.post(url, data=json_data, headers=headers, timeout=_TIMEOUT)
-                else:
-                    request = self.http_session.post(
-                        url, data=json_data, headers={"Content-Type": "application/json"}, timeout=_TIMEOUT
-                    )
-                retries = 0
-            except ProtocolError as e:
-                last_error = e
-                retries -= 1
-
-        if request is None:
-            return {"ok": False, "text": str(last_error)}
-        return request
-
     def conanproxy_login(self) -> None:
         """Login to Conan proxy server."""
         url = f"{CONANSERVER_URL}/login"
@@ -483,7 +444,7 @@ require {self.module_path} {self.target_name}
         login_body["password"] = get_ssm_param("/compiler-explorer/conanpwd")
         req_data = json.dumps(login_body)
 
-        request = self.resil_post(url, req_data)
+        request = resil_post(self.http_session, url, req_data)
         if isinstance(request, dict) or not request.ok:
             error_text = request.get("text", "") if isinstance(request, dict) else request.text
             raise RuntimeError(f"Conan login failed: {error_text}")
@@ -524,7 +485,7 @@ require {self.module_path} {self.target_name}
         }
 
         req_data = json.dumps(buildparameters_copy)
-        request = self.resil_post(url, req_data, headers)
+        request = resil_post(self.http_session, url, req_data, headers)
         if isinstance(request, dict) or not request.ok:
             error_text = request.get("text", "") if isinstance(request, dict) else request.text
             raise PostFailure(f"Post failure for {url}: {error_text}")
@@ -537,7 +498,7 @@ require {self.module_path} {self.target_name}
             self._failed_builds = fetch_failed_builds(
                 self.libid,
                 self.target_name,
-                lambda url: self.resil_get(url, stream=False, timeout=_TIMEOUT),
+                lambda url: resil_get(self.http_session, url, stream=False, timeout=_TIMEOUT),
                 self.logger,
             )
         return self._failed_builds
@@ -604,7 +565,7 @@ require {self.module_path} {self.target_name}
         }
         url = f"{CONANSERVER_URL}/annotations/{self.libid}/{self.target_name}/{conanhash}"
 
-        request = self.resil_post(url, json.dumps(annotations), headers)
+        request = resil_post(self.http_session, url, json.dumps(annotations), headers)
         if isinstance(request, dict) or not request.ok:
             error_text = request.get("text", "") if isinstance(request, dict) else request.text
             raise RuntimeError(f"Post failure for {url}: {error_text}")

--- a/bin/lib/library_builder.py
+++ b/bin/lib/library_builder.py
@@ -270,6 +270,53 @@ def match_failed_build(
     return False
 
 
+def resil_get(
+    http_session: requests.Session,
+    url: str,
+    *,
+    stream: bool,
+    timeout: int,
+    headers: dict[str, str] | None = None,
+) -> requests.Response | None:
+    """GET with 3 retries on urllib3 ProtocolError (TCP-level transient errors), 1s between attempts."""
+    request: requests.Response | None = None
+    retries = 3
+    actual_headers = headers if headers is not None else {"Content-Type": "application/json"}
+    while retries > 0:
+        try:
+            request = http_session.get(url, stream=stream, headers=actual_headers, timeout=timeout)
+            retries = 0
+        except ProtocolError:
+            retries -= 1
+            time.sleep(1)
+    return request
+
+
+def resil_post(
+    http_session: requests.Session,
+    url: str,
+    json_data: str,
+    headers: dict[str, str] | None = None,
+) -> requests.Response | dict[str, Any]:
+    """POST with 3 retries on urllib3 ProtocolError. Returns a Response, or a {ok: False, text: ...} dict on full failure."""
+    request: requests.Response | None = None
+    retries = 3
+    last_error: str | Exception = ""
+    actual_headers = headers if headers is not None else {"Content-Type": "application/json"}
+    while retries > 0:
+        try:
+            request = http_session.post(url, data=json_data, headers=actual_headers, timeout=_TIMEOUT)
+            retries = 0
+        except ProtocolError as e:
+            last_error = e
+            retries -= 1
+            time.sleep(1)
+
+    if request is None:
+        return {"ok": False, "text": str(last_error)}
+    return request
+
+
 def build_target_settings(buildparams: dict[str, Any]) -> dict[str, str]:
     """Translate current_buildparameters_obj keys into conan settings dotted form.
 
@@ -588,49 +635,6 @@ class LibraryBuilder:
         expanded = self.replace_optional_arg(expanded, "cmake_bool_windows", cmake_bool_windows)
 
         return expanded
-
-    def resil_post(self, url, json_data, headers=None):
-        request = None
-        retries = 3
-        last_error = ""
-        while retries > 0:
-            try:
-                if headers is not None:
-                    request = self.http_session.post(url, data=json_data, headers=headers, timeout=_TIMEOUT)
-                else:
-                    request = self.http_session.post(
-                        url, data=json_data, headers={"Content-Type": "application/json"}, timeout=_TIMEOUT
-                    )
-
-                retries = 0
-            except ProtocolError as e:
-                last_error = e
-                retries = retries - 1
-                time.sleep(1)
-
-        if request is None:
-            request = {"ok": False, "text": last_error}
-
-        return request
-
-    def resil_get(self, url: str, stream: bool, timeout: int, headers=None) -> requests.Response | None:
-        request: requests.Response | None = None
-        retries = 3
-        while retries > 0:
-            try:
-                if headers is not None:
-                    request = self.http_session.get(url, stream=stream, headers=headers, timeout=timeout)
-                else:
-                    request = self.http_session.get(
-                        url, stream=stream, headers={"Content-Type": "application/json"}, timeout=timeout
-                    )
-
-                retries = 0
-            except ProtocolError:
-                retries = retries - 1
-                time.sleep(1)
-
-        return request
 
     def expand_build_script_line(
         self, line: str, buildos, buildtype, compilerTypeOrGcc, compiler, compilerexe, libcxx, arch, stdver, extraflags
@@ -1276,7 +1280,7 @@ class LibraryBuilder:
             self._possible_builds = fetch_possible_builds(
                 self.libname,
                 self.target_name,
-                lambda url: self.resil_get(url, stream=False, timeout=_TIMEOUT),
+                lambda url: resil_get(self.http_session, url, stream=False, timeout=_TIMEOUT),
                 self.logger,
             )
         return self._possible_builds
@@ -1301,7 +1305,7 @@ class LibraryBuilder:
                     "No password found for conan server, setup AWS credentials to access the CE SSM, or set CONAN_PASSWORD environment variable"
                 ) from exc
 
-        request = self.resil_post(url, json_data=json.dumps(login_body))
+        request = resil_post(self.http_session, url, json_data=json.dumps(login_body))
         if not request.ok:
             self.logger.info(request.text)
             raise PostFailure(f"Post failure for {url}: {request}")
@@ -1345,7 +1349,7 @@ class LibraryBuilder:
 
         headers = {"Content-Type": "application/json", "Authorization": "Bearer " + self.conanserverproxy_token}
 
-        result = self.resil_post(url, json_data=json.dumps(buildparameters_copy), headers=headers)
+        result = resil_post(self.http_session, url, json_data=json.dumps(buildparameters_copy), headers=headers)
 
         # Failed/TimedOut add a failure row server-side; Ok deletes one. Either way the cache is stale.
         self._failed_builds = None
@@ -1365,7 +1369,7 @@ class LibraryBuilder:
 
         url = f"{conanserver_url}/annotations/{self.libname}/{self.target_name}/{conanhash}"
         with tempfile.TemporaryFile() as fd:
-            request = self.resil_get(url, stream=True, timeout=_TIMEOUT)
+            request = resil_get(self.http_session, url, stream=True, timeout=_TIMEOUT)
             if not request or not request.ok:
                 raise FetchFailure(f"Fetch failure for {url}: {request}")
             for chunk in request.iter_content(chunk_size=4 * 1024 * 1024):
@@ -1408,7 +1412,7 @@ class LibraryBuilder:
             self._failed_builds = fetch_failed_builds(
                 self.libname,
                 self.target_name,
-                lambda url: self.resil_get(url, stream=False, timeout=_TIMEOUT),
+                lambda url: resil_get(self.http_session, url, stream=False, timeout=_TIMEOUT),
                 self.logger,
             )
         return self._failed_builds
@@ -1465,7 +1469,7 @@ class LibraryBuilder:
         headers = {"Content-Type": "application/json", "Authorization": "Bearer " + self.conanserverproxy_token}
 
         url = f"{conanserver_url}/annotations/{self.libname}/{self.target_name}/{conanhash}"
-        request = self.resil_post(url, json_data=json.dumps(annotations), headers=headers)
+        request = resil_post(self.http_session, url, json_data=json.dumps(annotations), headers=headers)
         if not request.ok:
             raise PostFailure(f"Post failure for {url}: {request}")
 
@@ -1619,7 +1623,7 @@ class LibraryBuilder:
     def download_compiler_usage_csv(self):
         url = "https://compiler-explorer.s3.amazonaws.com/public/compiler_usage.csv"
         with tempfile.TemporaryFile() as fd:
-            request = self.resil_get(url, stream=True, timeout=_TIMEOUT)
+            request = resil_get(self.http_session, url, stream=True, timeout=_TIMEOUT)
             if not request or not request.ok:
                 raise FetchFailure(f"Fetch failure for {url}: {request}")
             for chunk in request.iter_content(chunk_size=4 * 1024 * 1024):

--- a/bin/lib/rust_library_builder.py
+++ b/bin/lib/rust_library_builder.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from typing import Any, TextIO
 
 import requests
-from urllib3.exceptions import ProtocolError
 
 from lib.amazon import get_ssm_param
 from lib.amazon_properties import get_properties_compilers_and_libraries
@@ -31,6 +30,8 @@ from lib.library_builder import (
     fetch_possible_builds,
     find_matching_package_id,
     match_failed_build,
+    resil_get,
+    resil_post,
 )
 from lib.library_platform import LibraryPlatform
 from lib.rust_crates import RustCrate, get_builder_user_agent_id
@@ -273,7 +274,7 @@ class RustLibraryBuilder:
             self._possible_builds = fetch_possible_builds(
                 self.libname,
                 self.target_name,
-                lambda url: self.resil_get(url, stream=False, timeout=_TIMEOUT),
+                lambda url: resil_get(self.http_session, url, stream=False, timeout=_TIMEOUT),
                 self.logger,
             )
         return self._possible_builds
@@ -284,47 +285,6 @@ class RustLibraryBuilder:
         target = build_target_settings(self.current_buildparameters_obj)
         return find_matching_package_id(self._get_possible_builds(), target)
 
-    def resil_get(self, url: str, stream: bool, timeout: int, headers=None) -> requests.Response | None:
-        request: requests.Response | None = None
-        retries = 3
-        while retries > 0:
-            try:
-                if headers is not None:
-                    request = self.http_session.get(url, stream=stream, headers=headers, timeout=timeout)
-                else:
-                    request = self.http_session.get(
-                        url, stream=stream, headers={"Content-Type": "application/json"}, timeout=timeout
-                    )
-
-                retries = 0
-            except ProtocolError:
-                retries = retries - 1
-
-        return request
-
-    def resil_post(self, url, json_data, headers=None):
-        request = None
-        retries = 3
-        last_error = ""
-        while retries > 0:
-            try:
-                if headers is not None:
-                    request = self.http_session.post(url, data=json_data, headers=headers, timeout=_TIMEOUT)
-                else:
-                    request = self.http_session.post(
-                        url, data=json_data, headers={"Content-Type": "application/json"}, timeout=_TIMEOUT
-                    )
-
-                retries = 0
-            except ProtocolError as e:
-                last_error = e
-                retries = retries - 1
-
-        if request is None:
-            request = {"ok": False, "text": last_error}
-
-        return request
-
     def conanproxy_login(self):
         url = f"{conanserver_url}/login"
 
@@ -333,7 +293,7 @@ class RustLibraryBuilder:
 
         req_data = json.dumps(login_body)
 
-        request = self.resil_post(url, req_data)
+        request = resil_post(self.http_session, url, req_data)
         if not request.ok:
             self.logger.info(request.text)
             raise RuntimeError(f"Post failure for {url}: {request}")
@@ -371,7 +331,7 @@ class RustLibraryBuilder:
         headers = {"Content-Type": "application/json", "Authorization": "Bearer " + self.conanserverproxy_token}
 
         req_data = json.dumps(buildparameters_copy)
-        request = self.resil_post(url, req_data, headers)
+        request = resil_post(self.http_session, url, req_data, headers)
         if not request.ok:
             raise PostFailure(f"Post failure for {url}: {request}")
 
@@ -411,7 +371,7 @@ class RustLibraryBuilder:
             self._failed_builds = fetch_failed_builds(
                 self.libname,
                 self.target_name,
-                lambda url: self.resil_get(url, stream=False, timeout=_TIMEOUT),
+                lambda url: resil_get(self.http_session, url, stream=False, timeout=_TIMEOUT),
                 self.logger,
             )
         return self._failed_builds
@@ -456,7 +416,7 @@ class RustLibraryBuilder:
         headers = {"Content-Type": "application/json", "Authorization": "Bearer " + self.conanserverproxy_token}
         url = f"{conanserver_url}/annotations/{self.libname}/{self.target_name}/{conanhash}"
 
-        request = self.resil_post(url, json.dumps(annotations), headers)
+        request = resil_post(self.http_session, url, json.dumps(annotations), headers)
         if not request.ok:
             raise RuntimeError(f"Post failure for {url}: {request}")
 

--- a/bin/lib/rust_library_builder.py
+++ b/bin/lib/rust_library_builder.py
@@ -273,7 +273,7 @@ class RustLibraryBuilder:
             self._possible_builds = fetch_possible_builds(
                 self.libname,
                 self.target_name,
-                lambda url: self.http_session.get(url, timeout=_TIMEOUT),
+                lambda url: self.resil_get(url, stream=False, timeout=_TIMEOUT),
                 self.logger,
             )
         return self._possible_builds
@@ -283,6 +283,24 @@ class RustLibraryBuilder:
             return None
         target = build_target_settings(self.current_buildparameters_obj)
         return find_matching_package_id(self._get_possible_builds(), target)
+
+    def resil_get(self, url: str, stream: bool, timeout: int, headers=None) -> requests.Response | None:
+        request: requests.Response | None = None
+        retries = 3
+        while retries > 0:
+            try:
+                if headers is not None:
+                    request = self.http_session.get(url, stream=stream, headers=headers, timeout=timeout)
+                else:
+                    request = self.http_session.get(
+                        url, stream=stream, headers={"Content-Type": "application/json"}, timeout=timeout
+                    )
+
+                retries = 0
+            except ProtocolError:
+                retries = retries - 1
+
+        return request
 
     def resil_post(self, url, json_data, headers=None):
         request = None
@@ -393,7 +411,7 @@ class RustLibraryBuilder:
             self._failed_builds = fetch_failed_builds(
                 self.libname,
                 self.target_name,
-                lambda url: self.http_session.get(url, timeout=_TIMEOUT),
+                lambda url: self.resil_get(url, stream=False, timeout=_TIMEOUT),
                 self.logger,
             )
         return self._failed_builds


### PR DESCRIPTION
Found via post-merge review of #2100. Two related fixes:

## 1. Behavioural regression: ProtocolError retry lost in 3 of 4 builders

Pre-#2100, all four builders' `has_failed_before` went through `resil_post`, which retries 3 times on urllib3 `ProtocolError` (TCP-level transient errors). After the bulk-fetch refactor, only the canonical (C++) builder used `resil_get`; fortran/rust/go passed `self.http_session.get` directly to the new `fetch_*` helpers, so a single `ProtocolError` aborts the whole builder run.

Same regression also affects the `/search` fetch in those three builders -- introduced in #2098 and propagated in #2100.

Note: only `ProtocolError` (TCP-level transient), not 5xx -- both old and new code abort on a 5xx response.

## 2. Dedup: extract resil_get/resil_post to module-level helpers

Originally I added `resil_get` as a method to each of the three sister builders and noted the duplication as out-of-scope. On reflection, that doubled the existing duplication (four `resil_post`s + four new `resil_get`s = 8 nearly-identical method bodies) instead of fixing it.

Now: one `resil_get` and one `resil_post` at module level in `library_builder.py`, taking `http_session` as the first argument. Each builder's call sites switch from `self.resil_post(url, ...)` to `resil_post(self.http_session, url, ...)`.

**Net diff vs `main`: -63 lines across the four builders.**

### Tiny behaviour change

Rust and Go's pre-existing `resil_post` had no sleep between retries (the others did). The unified version sleeps 1s, matching C++/Fortran -- which is the obviously-correct backoff behaviour for transient TCP errors. Three back-to-back retries with no sleep almost certainly all fall in the same network blip.

## Still acknowledged debt

Even after this, there's substantial parallel structure across the four builders: cache fields (`_possible_builds`, `_failed_builds`, `_annotations_cache`), `_get_possible_builds`, `_get_failed_builds`, `get_build_annotations`, `conanproxy_login`, etc. A shared `ConanProxyClient` (mixin or composed) is the right larger refactor. Out of scope here.

## Test plan

- [x] `make test` passes (672 tests).
- [x] `make static-checks` passes.
- [ ] Live: behaviour change only fires on `urllib3.ProtocolError`, hard to provoke deterministically. Code review of the diff is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)