### PR TITLE
🐛 Fix library YAML that provides a version with `/{{name}}` suffix

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -2166,7 +2166,7 @@ libraries:
         build_type: none
         check_file: include/phd/embed.hpp
         method: nightlyclone
-        path_name: libs/phd/embed
+        path_name: libs/phd/embed/{{name}}
         repo: ThePhD/embed
         targets:
         - main


### PR DESCRIPTION
This should be the right path name that takes into account the `{{name}}` bit!