### PR TITLE
Allow lin-lib-build.yaml to clone a non-main branch

### DIFF
--- a/.github/workflows/lin-lib-build.yaml
+++ b/.github/workflows/lin-lib-build.yaml
@@ -11,6 +11,10 @@ on:
                 description: 'Compiler'
                 default: 'popular-compilers-only'
                 required: true
+            branch:
+                description: 'infra branch to clone (defaults to main)'
+                default: 'main'
+                required: false
     workflow_call:
         inputs:
             library:
@@ -22,6 +26,11 @@ on:
                 description: 'Compiler'
                 default: 'popular-compilers-only'
                 required: true
+                type: string
+            branch:
+                description: 'infra branch to clone (defaults to main)'
+                default: 'main'
+                required: false
                 type: string
 
 jobs:
@@ -59,10 +68,10 @@ jobs:
           echo "Detected language: $LANGUAGE, library: $LIBRARY_NAME"
 
       - name: Download build script
-        run: curl -sL "https://raw.githubusercontent.com/compiler-explorer/infra/refs/heads/main/init/start-builder.sh" -o "/tmp/start-builder.sh"
+        run: curl -sL "https://raw.githubusercontent.com/compiler-explorer/infra/refs/heads/${{ inputs.branch || 'main' }}/init/start-builder.sh" -o "/tmp/start-builder.sh"
 
       - name: Build libraries
-        run: cd /tmp && chmod +x start-builder.sh && ./start-builder.sh "${{ secrets.CONAN_PASSWORD }}" "${{ steps.extract.outputs.language }}" "${{ steps.extract.outputs.library_name }}" "${{ inputs.compiler }}"
+        run: cd /tmp && chmod +x start-builder.sh && ./start-builder.sh "${{ secrets.CONAN_PASSWORD }}" "${{ steps.extract.outputs.language }}" "${{ steps.extract.outputs.library_name }}" "${{ inputs.compiler }}" "${{ inputs.branch || 'main' }}"
 
       - name: Upload build failure artifacts
         if: failure()

--- a/init/start-builder.sh
+++ b/init/start-builder.sh
@@ -6,6 +6,7 @@ export CONAN_PASSWORD=$1
 LANGUAGE=$2
 LIBRARYTOBUILD=$3
 FORCECOMPILER=$4
+BRANCH=${5:-main}
 
 FORCECOMPILERPARAM=""
 if [ "$FORCECOMPILER" = "popular-compilers-only" ]; then
@@ -27,7 +28,7 @@ git config --global --add safe.directory '*'
 mkdir -p /tmp/build
 cd /tmp/build
 rm -rf infra
-git clone https://github.com/compiler-explorer/infra
+git clone --branch "$BRANCH" --single-branch https://github.com/compiler-explorer/infra
 
 cd /tmp/build/infra
 


### PR DESCRIPTION
Enables triggering the library-build perf-test workflow against a feature branch rather than always cloning `main`. Useful for diagnostic instrumentation runs and for validating library-builder changes before merge.

## Changes

- **`init/start-builder.sh`**: accepts an optional 5th positional arg `BRANCH` (defaults to `main`), passed to `git clone --branch`.
- **`.github/workflows/lin-lib-build.yaml`**: exposes a matching `branch` input (defaults to `main`), threads it through both the script-download URL and the `start-builder.sh` invocation.

## Backwards compatibility

Existing scheduled triggers and ad-hoc `workflow_dispatch` calls without the new arg behave exactly as before — both default to `main`.

## Why now

Used in the diagnostic phase of compiler-explorer/infra#1342 to capture per-iteration timing and confirm where library-builder wall time was actually going (turned out to be cold `/failedbuilds` SQLite queries, fixed in conanproxy#75 + #76 + a manual VACUUM). The instrumentation itself is throwaway, but the ability to run the perf-test workflow against a branch is generally useful — leaving it merged.

## Usage

```bash
gh workflow run lin-lib-build.yaml --ref my-branch -f branch=my-branch
```

(`--ref` selects which copy of the workflow YAML runs; `-f branch=...` is what end up at the cloned-code step. They're independent on purpose so you could mix-and-match if you ever needed to.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)