### PR TITLE
Bulk-fetch /annotations once per builder

### DIFF
--- a/bin/lib/fortran_library_builder.py
+++ b/bin/lib/fortran_library_builder.py
@@ -24,9 +24,11 @@ from lib.amazon_properties import get_properties_compilers_and_libraries, get_sp
 from lib.installation_context import FetchFailure, PostFailure
 from lib.library_build_config import LibraryBuildConfig
 from lib.library_builder import (
+    AnnotationsBulk,
     FailedBuilds,
     PossibleBuilds,
     build_target_settings,
+    fetch_all_annotations,
     fetch_failed_builds,
     fetch_possible_builds,
     find_matching_package_id,
@@ -108,6 +110,7 @@ class FortranLibraryBuilder:
         self.conanserverproxy_token = None
         self._possible_builds: PossibleBuilds | None = None
         self._failed_builds: FailedBuilds | None = None
+        self._annotations_bulk: AnnotationsBulk | None = None
         self._annotations_cache: dict[str, dict] = {}
         self.http_session = requests.Session()
 
@@ -498,6 +501,16 @@ class FortranLibraryBuilder:
 
         return result
 
+    def _get_annotations_bulk(self) -> AnnotationsBulk:
+        if self._annotations_bulk is None:
+            self._annotations_bulk = fetch_all_annotations(
+                self.libname,
+                self.target_name,
+                lambda url: resil_get(self.http_session, url, stream=False, timeout=_TIMEOUT),
+                self.logger,
+            )
+        return self._annotations_bulk
+
     def get_build_annotations(self, buildfolder):
         if buildfolder in self._annotations_cache:
             self.logger.debug(f"Using cached annotations for {buildfolder}")
@@ -509,19 +522,10 @@ class FortranLibraryBuilder:
             self._annotations_cache[buildfolder] = result
             return result
 
-        url = f"{conanserver_url}/annotations/{self.libname}/{self.target_name}/{conanhash}"
-        with tempfile.TemporaryFile() as fd:
-            request = self.http_session.get(url, stream=True, timeout=_TIMEOUT)
-            if not request.ok:
-                raise FetchFailure(f"Fetch failure for {url}: {request}")
-            for chunk in request.iter_content(chunk_size=4 * 1024 * 1024):
-                fd.write(chunk)
-            fd.flush()
-            fd.seek(0)
-            buffer = fd.read()
-            result = json.loads(buffer)
-            self._annotations_cache[buildfolder] = result
-            return result
+        bulk_entry = self._get_annotations_bulk().get(conanhash, {})
+        result = dict(bulk_entry) if bulk_entry else defaultdict(lambda: [])
+        self._annotations_cache[buildfolder] = result
+        return result
 
     def get_commit_hash(self) -> str:
         if os.path.exists(f"{self.sourcefolder}/.git"):
@@ -590,6 +594,9 @@ class FortranLibraryBuilder:
         request = resil_post(self.http_session, url, json_data=json.dumps(annotations), headers=headers)
         if not request.ok:
             raise PostFailure(f"Post failure for {url}: {request}")
+
+        # Just wrote a new annotation server-side; bulk cache is stale.
+        self._annotations_bulk = None
 
     def makebuildfor(
         self,

--- a/bin/lib/go_library_builder.py
+++ b/bin/lib/go_library_builder.py
@@ -28,9 +28,11 @@ from lib.golang_stdlib import go_supports_trimpath
 from lib.installation_context import InstallationContext, PostFailure
 from lib.library_build_config import LibraryBuildConfig
 from lib.library_builder import (
+    AnnotationsBulk,
     FailedBuilds,
     PossibleBuilds,
     build_target_settings,
+    fetch_all_annotations,
     fetch_failed_builds,
     fetch_possible_builds,
     find_matching_package_id,
@@ -142,6 +144,7 @@ class GoLibraryBuilder:
         self.conanserverproxy_token: str | None = None
         self._possible_builds: PossibleBuilds | None = None
         self._failed_builds: FailedBuilds | None = None
+        self._annotations_bulk: AnnotationsBulk | None = None
         self._annotations_cache: dict[str, dict] = {}
         self.http_session = requests.Session()
 
@@ -509,6 +512,16 @@ require {self.module_path} {self.target_name}
         params["flagcollection"] = build_method
         return match_failed_build(self._get_failed_builds(), params, None)
 
+    def _get_annotations_bulk(self) -> AnnotationsBulk:
+        if self._annotations_bulk is None:
+            self._annotations_bulk = fetch_all_annotations(
+                self.libid,
+                self.target_name,
+                lambda url: resil_get(self.http_session, url, stream=False, timeout=_TIMEOUT),
+                self.logger,
+            )
+        return self._annotations_bulk
+
     def get_build_annotations(self, buildfolder: Path) -> dict:
         """Get build annotations from Conan server."""
         if str(buildfolder) in self._annotations_cache:
@@ -520,17 +533,8 @@ require {self.module_path} {self.target_name}
             self._annotations_cache[str(buildfolder)] = result
             return result
 
-        url = f"{CONANSERVER_URL}/annotations/{self.libid}/{self.target_name}/{conanhash}"
-        try:
-            request = self.http_session.get(url, timeout=_TIMEOUT)
-            if request.ok:
-                result = json.loads(request.content)
-                self._annotations_cache[str(buildfolder)] = result
-                return result
-        except (requests.RequestException, json.JSONDecodeError) as e:
-            self.logger.debug("Failed to get annotations: %s", e)
-
-        result = defaultdict(lambda: [])
+        bulk_entry = self._get_annotations_bulk().get(conanhash, {})
+        result = dict(bulk_entry) if bulk_entry else defaultdict(lambda: [])
         self._annotations_cache[str(buildfolder)] = result
         return result
 
@@ -569,6 +573,9 @@ require {self.module_path} {self.target_name}
         if isinstance(request, dict) or not request.ok:
             error_text = request.get("text", "") if isinstance(request, dict) else request.text
             raise RuntimeError(f"Post failure for {url}: {error_text}")
+
+        # Just wrote a new annotation server-side; bulk cache is stale.
+        self._annotations_bulk = None
 
     def executeconanscript(self, buildfolder: Path) -> BuildStatus:
         """Execute Conan export script."""

--- a/bin/lib/library_builder.py
+++ b/bin/lib/library_builder.py
@@ -270,6 +270,61 @@ def match_failed_build(
     return False
 
 
+type AnnotationsBulk = dict[str, dict[str, Any]]
+
+
+def annotations_bulk_url(libname: str, target_name: str) -> str:
+    encoded_lib = urllib.parse.quote(libname, safe="")
+    encoded_ver = urllib.parse.quote(target_name, safe="")
+    return f"{conanserver_url}/annotations/{encoded_lib}/{encoded_ver}"
+
+
+def fetch_all_annotations(
+    libname: str,
+    target_name: str,
+    fetcher: Callable[[str], requests.Response | None],
+    logger: Logger,
+) -> AnnotationsBulk:
+    """Fetch every annotation for (libname, target_name), keyed by buildhash.
+
+    Response shape: list of {buildhash, annotation, buildinfo}. We only need
+    the per-buildhash annotation dict (which has commithash etc.); buildinfo
+    is ignored for now since current callers only inspect commithash.
+
+    404 means no annotations exist yet; non-2xx and malformed payloads raise FetchFailure.
+    """
+    url = annotations_bulk_url(libname, target_name)
+    try:
+        response = fetcher(url)
+    except requests.RequestException as e:
+        raise FetchFailure(f"Annotations bulk request failed for {libname}/{target_name}: {e}") from e
+
+    if response is None:
+        raise FetchFailure(f"Annotations bulk request failed for {libname}/{target_name}")
+    if response.status_code == 404:
+        logger.debug("No annotations recorded for %s/%s", libname, target_name)
+        return {}
+    if not response.ok:
+        raise FetchFailure(f"Annotations bulk returned {response.status_code} for {libname}/{target_name}")
+
+    try:
+        payload = response.json()
+    except ValueError as e:
+        raise FetchFailure(f"Annotations bulk returned non-JSON for {libname}/{target_name}") from e
+    if not isinstance(payload, list):
+        raise FetchFailure(f"Annotations bulk returned non-array JSON for {libname}/{target_name}")
+
+    out: AnnotationsBulk = {}
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        buildhash = item.get("buildhash")
+        annotation = item.get("annotation")
+        if isinstance(buildhash, str) and isinstance(annotation, dict):
+            out[buildhash] = annotation
+    return out
+
+
 def resil_get(
     http_session: requests.Session,
     url: str,
@@ -386,6 +441,7 @@ class LibraryBuilder:
         self.platform = platform
         self._possible_builds: PossibleBuilds | None = None
         self._failed_builds: FailedBuilds | None = None
+        self._annotations_bulk: AnnotationsBulk | None = None
         self._annotations_cache: dict[str, dict] = {}
         self.http_session = requests.Session()
 
@@ -1356,6 +1412,16 @@ class LibraryBuilder:
 
         return result
 
+    def _get_annotations_bulk(self) -> AnnotationsBulk:
+        if self._annotations_bulk is None:
+            self._annotations_bulk = fetch_all_annotations(
+                self.libname,
+                self.target_name,
+                lambda url: resil_get(self.http_session, url, stream=False, timeout=_TIMEOUT),
+                self.logger,
+            )
+        return self._annotations_bulk
+
     def get_build_annotations(self, buildfolder):
         if buildfolder in self._annotations_cache:
             self.logger.debug(f"Using cached annotations for {buildfolder}")
@@ -1367,19 +1433,12 @@ class LibraryBuilder:
             self._annotations_cache[buildfolder] = result
             return result
 
-        url = f"{conanserver_url}/annotations/{self.libname}/{self.target_name}/{conanhash}"
-        with tempfile.TemporaryFile() as fd:
-            request = resil_get(self.http_session, url, stream=True, timeout=_TIMEOUT)
-            if not request or not request.ok:
-                raise FetchFailure(f"Fetch failure for {url}: {request}")
-            for chunk in request.iter_content(chunk_size=4 * 1024 * 1024):
-                fd.write(chunk)
-            fd.flush()
-            fd.seek(0)
-            buffer = fd.read()
-            result = json.loads(buffer)
-            self._annotations_cache[buildfolder] = result
-            return result
+        # Look up in the bulk-cached annotations dict; defensive copy because callers
+        # (set_as_uploaded) mutate the result before POSTing it back to the server.
+        bulk_entry = self._get_annotations_bulk().get(conanhash, {})
+        result = dict(bulk_entry) if bulk_entry else defaultdict(lambda: [])
+        self._annotations_cache[buildfolder] = result
+        return result
 
     def get_commit_hash(self) -> str:
         if self.current_commit_hash:
@@ -1472,6 +1531,9 @@ class LibraryBuilder:
         request = resil_post(self.http_session, url, json_data=json.dumps(annotations), headers=headers)
         if not request.ok:
             raise PostFailure(f"Post failure for {url}: {request}")
+
+        # We just wrote a new annotation server-side; the bulk cache is now stale.
+        self._annotations_bulk = None
 
     def makebuildfor(
         self,

--- a/bin/lib/rust_library_builder.py
+++ b/bin/lib/rust_library_builder.py
@@ -9,7 +9,6 @@ import os
 import re
 import shutil
 import subprocess
-import tempfile
 from collections import defaultdict
 from collections.abc import Generator
 from enum import Enum, unique
@@ -20,12 +19,14 @@ import requests
 
 from lib.amazon import get_ssm_param
 from lib.amazon_properties import get_properties_compilers_and_libraries
-from lib.installation_context import FetchFailure, InstallationContext, PostFailure
+from lib.installation_context import InstallationContext, PostFailure
 from lib.library_build_config import LibraryBuildConfig
 from lib.library_builder import (
+    AnnotationsBulk,
     FailedBuilds,
     PossibleBuilds,
     build_target_settings,
+    fetch_all_annotations,
     fetch_failed_builds,
     fetch_possible_builds,
     find_matching_package_id,
@@ -97,6 +98,7 @@ class RustLibraryBuilder:
         self.conanserverproxy_token = None
         self._possible_builds: PossibleBuilds | None = None
         self._failed_builds: FailedBuilds | None = None
+        self._annotations_bulk: AnnotationsBulk | None = None
         self._annotations_cache: dict[str, dict] = {}
         self.http_session = requests.Session()
 
@@ -338,6 +340,16 @@ class RustLibraryBuilder:
         # Failed/TimedOut add a failure row server-side; Ok deletes one. Either way the cache is stale.
         self._failed_builds = None
 
+    def _get_annotations_bulk(self) -> AnnotationsBulk:
+        if self._annotations_bulk is None:
+            self._annotations_bulk = fetch_all_annotations(
+                self.libname,
+                self.target_name,
+                lambda url: resil_get(self.http_session, url, stream=False, timeout=_TIMEOUT),
+                self.logger,
+            )
+        return self._annotations_bulk
+
     def get_build_annotations(self, buildfolder):
         if buildfolder in self._annotations_cache:
             self.logger.debug(f"Using cached annotations for {buildfolder}")
@@ -349,19 +361,10 @@ class RustLibraryBuilder:
             self._annotations_cache[buildfolder] = result
             return result
 
-        url = f"{conanserver_url}/annotations/{self.libname}/{self.target_name}/{conanhash}"
-        with tempfile.TemporaryFile() as fd:
-            request = self.http_session.get(url, stream=True, timeout=_TIMEOUT)
-            if not request.ok:
-                raise FetchFailure(f"Fetch failure for {url}: {request}")
-            for chunk in request.iter_content(chunk_size=4 * 1024 * 1024):
-                fd.write(chunk)
-            fd.flush()
-            fd.seek(0)
-            buffer = fd.read()
-            result = json.loads(buffer)
-            self._annotations_cache[buildfolder] = result
-            return result
+        bulk_entry = self._get_annotations_bulk().get(conanhash, {})
+        result = dict(bulk_entry) if bulk_entry else defaultdict(lambda: [])
+        self._annotations_cache[buildfolder] = result
+        return result
 
     def get_commit_hash(self) -> str:
         return self.target_name
@@ -419,6 +422,9 @@ class RustLibraryBuilder:
         request = resil_post(self.http_session, url, json.dumps(annotations), headers)
         if not request.ok:
             raise RuntimeError(f"Post failure for {url}: {request}")
+
+        # Just wrote a new annotation server-side; bulk cache is stale.
+        self._annotations_bulk = None
 
     def clone_branch(self, dest, staging: StagingDir):
         subprocess.check_call(

--- a/bin/test/fortran_library_builder_test.py
+++ b/bin/test/fortran_library_builder_test.py
@@ -252,6 +252,43 @@ def test_fortran_has_failed_before_stale_commit_returns_false(requests_mock):
     assert builder.has_failed_before() is False
 
 
+_FORTRAN_SEARCH_URL = "https://conan.compiler-explorer.com/v1/conans/fortranlib/2.0.0/fortranlib/2.0.0/search"
+_FORTRAN_ANNOTATIONS_URL = "https://conan.compiler-explorer.com/annotations/fortranlib/2.0.0"
+
+
+def test_fortran_is_already_uploaded_uses_bulk_annotations(requests_mock):
+    # Fortran's get_commit_hash falls back to target_name (here "2.0.0") when
+    # there's no .git directory at sourcefolder, which is the case in this test.
+    builder = _make_fortran_builder_with_buildparams(requests_mock)
+    builder.current_buildparameters_obj["os"] = "Linux"
+    builder.current_buildparameters_obj["buildtype"] = "Debug"
+    builder.current_buildparameters_obj["stdver"] = ""
+    requests_mock.get(
+        _FORTRAN_SEARCH_URL,
+        json={
+            "fhash": {
+                "settings": {
+                    "os": "Linux",
+                    "build_type": "Debug",
+                    "compiler": "fortran",
+                    "compiler.version": "f2018",
+                    "compiler.libcxx": "libgfortran",
+                    "arch": "x86_64",
+                    "stdver": "",
+                    "flagcollection": "",
+                }
+            }
+        },
+    )
+    matcher = requests_mock.get(
+        _FORTRAN_ANNOTATIONS_URL,
+        json=[{"buildhash": "fhash", "annotation": {"commithash": "2.0.0"}, "buildinfo": {}}],
+    )
+    assert builder.is_already_uploaded("/tmp/buildfolder1") is True
+    assert builder.is_already_uploaded("/tmp/buildfolder2") is True
+    assert matcher.call_count == 1
+
+
 @patch("subprocess.call")
 def test_execute_build_script_success(mock_subprocess, requests_mock):
     requests_mock.get(f"{BASE}fortran.amazon.properties", text="")

--- a/bin/test/go_library_builder_test.py
+++ b/bin/test/go_library_builder_test.py
@@ -365,6 +365,53 @@ class TestGoLibraryBuilderConanHelpers:
         # one fetch shared across calls -- the match logic runs in-memory
         assert matcher.call_count == 1
 
+    @patch("lib.go_library_builder.get_properties_compilers_and_libraries")
+    def test_is_already_uploaded_uses_bulk_annotations(self, mock_get_props, requests_mock):
+        """is_already_uploaded should hit /annotations/<libid>/<ver> bulk endpoint and cache it."""
+        mock_get_props.return_value = ({"gl1238": {"exe": "/opt/go/bin/go"}}, {})
+        logger = MagicMock()
+        install_context = MagicMock()
+        install_context.dry_run = False
+        buildconfig = create_go_test_build_config()
+
+        builder = GoLibraryBuilder(
+            logger=logger,
+            language="go",
+            libname="uuid",
+            target_name="v1.6.0",
+            install_context=install_context,
+            buildconfig=buildconfig,
+        )
+        builder.set_current_conan_build_parameters("Linux", "Debug", "gl1238", "x86_64")
+
+        # /search returns a matching package
+        requests_mock.get(
+            "https://conan.compiler-explorer.com/v1/conans/go_uuid/v1.6.0/go_uuid/v1.6.0/search",
+            json={
+                "ghash": {
+                    "settings": {
+                        "os": "Linux",
+                        "build_type": "Debug",
+                        "compiler": "golang",
+                        "compiler.version": "gl1238",
+                        "compiler.libcxx": "",
+                        "arch": "x86_64",
+                        "stdver": "",
+                        "flagcollection": "",
+                    }
+                }
+            },
+        )
+        # bulk annotations contains commithash matching target_name (Go's commithash semantics)
+        matcher = requests_mock.get(
+            "https://conan.compiler-explorer.com/annotations/go_uuid/v1.6.0",
+            json=[{"buildhash": "ghash", "annotation": {"commithash": "v1.6.0"}, "buildinfo": {}}],
+        )
+        assert builder.is_already_uploaded(Path("/tmp/buildfolder1")) is True
+        assert builder.is_already_uploaded(Path("/tmp/buildfolder2")) is True
+        # one fetch shared across iterations
+        assert matcher.call_count == 1
+
 
 class TestGoLibraryBuilderBuildStatus:
     """Tests for BuildStatus enum."""

--- a/bin/test/library_builder_test.py
+++ b/bin/test/library_builder_test.py
@@ -17,6 +17,7 @@ from lib.library_builder import (
     BuildStatus,
     LibraryBuilder,
     build_timeout,
+    fetch_all_annotations,
     fetch_failed_builds,
     match_conan_settings,
     match_failed_build,
@@ -865,3 +866,122 @@ def test_has_failed_before_no_records_returns_false(requests_mock):
     builder.current_commit_hash = "abc123"
     requests_mock.get(_FAILED_URL, json=[])
     assert builder.has_failed_before() is False
+
+
+# Direct unit tests for fetch_all_annotations.
+
+_ANNOTATIONS_BULK_URL = "https://conan.compiler-explorer.com/annotations/testlib/1.0.0"
+
+
+def test_fetch_all_annotations_returns_dict_keyed_by_buildhash(requests_mock):
+    requests_mock.get(
+        _ANNOTATIONS_BULK_URL,
+        json=[
+            {"buildhash": "h1", "annotation": {"commithash": "abc123"}, "buildinfo": {}},
+            {"buildhash": "h2", "annotation": {"commithash": "def456"}, "buildinfo": {}},
+        ],
+    )
+    logger = mock.Mock(spec_set=Logger)
+    result = fetch_all_annotations("testlib", "1.0.0", _fetch, logger)
+    assert result == {"h1": {"commithash": "abc123"}, "h2": {"commithash": "def456"}}
+
+
+def test_fetch_all_annotations_skips_malformed_entries(requests_mock):
+    requests_mock.get(
+        _ANNOTATIONS_BULK_URL,
+        json=[
+            {"buildhash": "h1", "annotation": {"commithash": "abc"}, "buildinfo": {}},
+            {"buildhash": "h2"},  # missing annotation
+            {"annotation": {"commithash": "def"}},  # missing buildhash
+            "not-a-dict",
+        ],
+    )
+    logger = mock.Mock(spec_set=Logger)
+    result = fetch_all_annotations("testlib", "1.0.0", _fetch, logger)
+    assert result == {"h1": {"commithash": "abc"}}
+
+
+def test_fetch_all_annotations_404_returns_empty(requests_mock):
+    requests_mock.get(_ANNOTATIONS_BULK_URL, status_code=404)
+    logger = mock.Mock(spec_set=Logger)
+    assert fetch_all_annotations("testlib", "1.0.0", _fetch, logger) == {}
+
+
+def test_fetch_all_annotations_500_raises(requests_mock):
+    requests_mock.get(_ANNOTATIONS_BULK_URL, status_code=500)
+    logger = mock.Mock(spec_set=Logger)
+    with pytest.raises(FetchFailure):
+        fetch_all_annotations("testlib", "1.0.0", _fetch, logger)
+
+
+def test_fetch_all_annotations_non_list_raises(requests_mock):
+    requests_mock.get(_ANNOTATIONS_BULK_URL, json={"not": "a list"})
+    logger = mock.Mock(spec_set=Logger)
+    with pytest.raises(FetchFailure):
+        fetch_all_annotations("testlib", "1.0.0", _fetch, logger)
+
+
+# Behavioural tests on LibraryBuilder.is_already_uploaded via the bulk-annotations cache.
+
+
+def _matched_settings_dict(**overrides):
+    base = {
+        "os": "Linux",
+        "build_type": "Debug",
+        "compiler": "gcc",
+        "compiler.version": "g141",
+        "compiler.libcxx": "libstdc++",
+        "arch": "x86_64",
+        "stdver": "",
+        "flagcollection": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_is_already_uploaded_uses_bulk_annotations(requests_mock):
+    builder = _make_builder_with_params(requests_mock)
+    builder.current_commit_hash = "abc123"
+    # /search returns one matching package
+    requests_mock.get(SEARCH_URL, json={"hash1": {"settings": _matched_settings_dict()}})
+    # bulk annotations contains the matching commithash
+    bulk_matcher = requests_mock.get(
+        _ANNOTATIONS_BULK_URL,
+        json=[{"buildhash": "hash1", "annotation": {"commithash": "abc123"}, "buildinfo": {}}],
+    )
+    assert builder.is_already_uploaded("/tmp/buildfolder1") is True
+    assert bulk_matcher.call_count == 1
+
+
+def test_is_already_uploaded_caches_bulk_across_buildfolders(requests_mock):
+    builder = _make_builder_with_params(requests_mock)
+    builder.current_commit_hash = "abc123"
+    requests_mock.get(SEARCH_URL, json={"hash1": {"settings": _matched_settings_dict()}})
+    bulk_matcher = requests_mock.get(
+        _ANNOTATIONS_BULK_URL,
+        json=[{"buildhash": "hash1", "annotation": {"commithash": "abc123"}, "buildinfo": {}}],
+    )
+    # Two iterations, two distinct buildfolders → bulk should be fetched once
+    assert builder.is_already_uploaded("/tmp/buildfolder1") is True
+    assert builder.is_already_uploaded("/tmp/buildfolder2") is True
+    assert bulk_matcher.call_count == 1
+
+
+def test_is_already_uploaded_returns_false_when_commithash_differs(requests_mock):
+    builder = _make_builder_with_params(requests_mock)
+    builder.current_commit_hash = "abc123"
+    requests_mock.get(SEARCH_URL, json={"hash1": {"settings": _matched_settings_dict()}})
+    requests_mock.get(
+        _ANNOTATIONS_BULK_URL,
+        json=[{"buildhash": "hash1", "annotation": {"commithash": "OLD"}, "buildinfo": {}}],
+    )
+    assert builder.is_already_uploaded("/tmp/buildfolder") is False
+
+
+def test_is_already_uploaded_returns_false_when_hash_missing_from_bulk(requests_mock):
+    """conanhash matches in /search but no annotation has been written yet."""
+    builder = _make_builder_with_params(requests_mock)
+    builder.current_commit_hash = "abc123"
+    requests_mock.get(SEARCH_URL, json={"hash1": {"settings": _matched_settings_dict()}})
+    requests_mock.get(_ANNOTATIONS_BULK_URL, json=[])
+    assert builder.is_already_uploaded("/tmp/buildfolder") is False

--- a/bin/test/rust_library_builder_test.py
+++ b/bin/test/rust_library_builder_test.py
@@ -145,6 +145,42 @@ def test_rust_has_failed_before_matches_regardless_of_commithash(requests_mock):
     assert builder.has_failed_before({"build_method": "release"}) is True
 
 
+_RUST_SEARCH_URL = "https://conan.compiler-explorer.com/v1/conans/rustlib/1.0.0/rustlib/1.0.0/search"
+_RUST_ANNOTATIONS_URL = "https://conan.compiler-explorer.com/annotations/rustlib/1.0.0"
+
+
+def test_rust_is_already_uploaded_uses_bulk_annotations(requests_mock):
+    builder = _make_rust_builder(requests_mock)
+    builder.current_buildparameters_obj["os"] = "Linux"
+    builder.current_buildparameters_obj["buildtype"] = "Debug"
+    builder.current_buildparameters_obj["stdver"] = ""
+    requests_mock.get(
+        _RUST_SEARCH_URL,
+        json={
+            "rhash": {
+                "settings": {
+                    "os": "Linux",
+                    "build_type": "Debug",
+                    "compiler": "rustc",
+                    "compiler.version": "rustc-1.70",
+                    "compiler.libcxx": "",
+                    "arch": "x86_64",
+                    "stdver": "",
+                    "flagcollection": "",
+                }
+            }
+        },
+    )
+    matcher = requests_mock.get(
+        _RUST_ANNOTATIONS_URL,
+        json=[{"buildhash": "rhash", "annotation": {"commithash": "1.0.0"}, "buildinfo": {}}],
+    )
+    # Rust uses target_name as commit_hash, so 1.0.0 matches
+    assert builder.is_already_uploaded("/tmp/buildfolder1", "/tmp/source") is True
+    assert builder.is_already_uploaded("/tmp/buildfolder2", "/tmp/source") is True
+    assert matcher.call_count == 1
+
+
 @patch("subprocess.call")
 def test_execute_build_script_success(mock_subprocess, requests_mock):
     requests_mock.get(f"{BASE}rust.amazon.properties", text="")


### PR DESCRIPTION
Fourth in the bulk-fetch + cache series for library-builder. Measured ~8s saved (104s → 96s on `boost_bin × popular-compilers-only`), matching the 7.9s instrumented per-iter cost from the prior run.

Refs #1342.

## What

`/annotations/{lib}/{ver}` (the bulk endpoint already exposed by conanproxy via `readAllAnnotations`) returns every annotation for a (lib, version) pair. Each builder now fetches once, indexes by buildhash in memory, and looks up locally per iteration.

Helpers added in `library_builder.py`:

- `type AnnotationsBulk = dict[str, dict[str, Any]]` — buildhash → annotation
- `annotations_bulk_url(libname, target_name)`
- `fetch_all_annotations(libname, target_name, fetcher, logger)` — handles 404 → `{}`, raises `FetchFailure` on 5xx / non-JSON / non-list

Per-builder changes (canonical first, then fortran/rust/go in lockstep):

- `_annotations_bulk: AnnotationsBulk | None` cache field
- `_get_annotations_bulk()` lazily fetches + memoises
- `get_build_annotations(buildfolder)` looks up by `conanhash` in the bulk dict, returns a defensive `dict(...)` copy because `set_as_uploaded` mutates the result
- `set_as_uploaded` invalidates `_annotations_bulk = None` after POSTing a new annotation server-side

Go uses `self.libid` (its `go_`-prefixed name) in the URL, consistent with its `/search` and `/failedbuilds` patterns.

## Methodology

Per the lesson saved to memory after #2100's prediction was 6× off: shipped to the canonical (C++) builder first, ran the workflow, captured timing, **then** decided whether to fan out. Measurement (run 25463498270) showed 8s saved across 1094 iterations, matching prediction this time. After that, replicated to fortran/rust/go.

## Cross-arc summary

| Step | `Build libraries` (s) | Notes |
|---|---:|---|
| Pre-#2098 | n/a | per-iter `conan info` subprocess |
| #2098 (search bulk) | 259 | conan info killed |
| #2100 (failedbuilds bulk) only | 271 | regression: cold /failedbuilds = 8-15s |
| + conanproxy#74 narrow index | 246 | partial fix |
| + conanproxy#75 covering index + #76 truncate + VACUUM | 104 | actual fix |
| + #2101 retry + dedup | (no measurement, behavioural fix) | |
| + this PR (bulk annotations) | **96** | |

**Total**: original 4m45s baseline → **1m38s** wall clock for the same workload. ~3× faster.

## Test plan

- [x] `make test` passes (681 tests, 9 new for `fetch_all_annotations` + behavioural `is_already_uploaded` cache reuse + commithash mismatch + missing-hash cases).
- [x] `make static-checks` passes.
- [x] Live workflow run on the bulk-annotations branch confirmed 96s build step (run 25463498270).

## Out of scope

The four-builder duplication continues to grow with each of these PRs. A shared `ConanProxyClient` (cache fields + HTTP helpers + fetch_* + match_*) is the right larger refactor; deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)