### PR TITLE
Move conan-node bake to Ubuntu 24.04 (noble)

### DIFF
--- a/init/start-conan.sh
+++ b/init/start-conan.sh
@@ -15,7 +15,11 @@ CEPASSWORD=$(aws ssm get-parameter --name /compiler-explorer/conanpwd | jq -r .P
 export CESECRET
 export CEPASSWORD
 
-sudo -u ce -H /home/${CE_USER}/.local/bin/gunicorn -b 0.0.0.0:9300 -w 4 -t 300 conans.server.server_launcher:app &
+# Noble installs gunicorn into a venv; the legacy bionic AMI used a user-local pip install.
+GUNICORN=/home/${CE_USER}/venv/bin/gunicorn
+[ -x "${GUNICORN}" ] || GUNICORN=/home/${CE_USER}/.local/bin/gunicorn
+
+sudo -u ce -H "${GUNICORN}" -b 0.0.0.0:9300 -w 4 -t 300 conans.server.server_launcher:app &
 
 # shellcheck disable=SC2086
 #  (we deliberately pass multiple args in ${EXTRA_ARGS}

--- a/packer/conan.pkr.hcl
+++ b/packer/conan.pkr.hcl
@@ -17,10 +17,10 @@ variable "MY_SECRET_KEY" {
   default = ""
 }
 
-data "amazon-ami" "bionic" {
+data "amazon-ami" "noble" {
   access_key = "${var.MY_ACCESS_KEY}"
   filters = {
-    name                = "ubuntu/images/*ubuntu-bionic-18.04-amd64-server-*"
+    name                = "ubuntu/images/*ubuntu-noble-24.04-amd64-server-*"
     root-device-type    = "ebs"
     virtualization-type = "hvm"
   }
@@ -32,9 +32,9 @@ data "amazon-ami" "bionic" {
 
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
-source "amazon-ebs" "bionic" {
+source "amazon-ebs" "noble" {
   access_key = "${var.MY_ACCESS_KEY}"
-  ami_name                    = "ce-conan packer 18.04 @ ${local.timestamp}"
+  ami_name                    = "ce-conan packer 24.04 @ ${local.timestamp}"
   associate_public_ip_address = true
   iam_instance_profile        = "XaniaBlog"
   instance_type               = "t3.medium"
@@ -47,7 +47,7 @@ source "amazon-ebs" "bionic" {
   region            = "us-east-1"
   secret_key        = "${var.MY_SECRET_KEY}"
   security_group_id = "sg-f53f9f80"
-  source_ami        = "${data.amazon-ami.bionic.id}"
+  source_ami        = "${data.amazon-ami.noble.id}"
   ssh_username      = "ubuntu"
   subnet_id         = "subnet-1df1e135"
   tags = {
@@ -57,7 +57,7 @@ source "amazon-ebs" "bionic" {
 }
 
 build {
-  sources = ["source.amazon-ebs.bionic"]
+  sources = ["source.amazon-ebs.noble"]
 
   provisioner "file" {
     destination = "/home/ubuntu/"

--- a/setup-conan.sh
+++ b/setup-conan.sh
@@ -30,30 +30,35 @@ wait_for_apt
 
 apt-get -y update
 apt-get -y upgrade
-apt-get -y install unzip wget mosh fish jq ssmtp cronic upx python3-pip python3-venv sqlite3
+apt-get -y install \
+    unzip wget mosh fish jq ssmtp cronic upx \
+    python3-pip python3-venv \
+    sqlite3 \
+    lvm2 rsyslog
 apt-get -y autoremove
 
 # Install AWS CLI v2 (system pip is PEP 668-restricted on noble)
 pushd /tmp
 curl -sL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 unzip -q awscliv2.zip
-./aws/install --update
+./aws/install
 rm -rf aws awscliv2.zip
 popd
 
-# setup ce_user
-adduser --system --group ${CE_USER}
-
+# setup ce user with an explicit home (adduser --system on its own gives /nonexistent on noble)
+adduser --system --home /home/${CE_USER} --group ${CE_USER}
 mkdir -p /home/${CE_USER}/.conan_server
+chown -R ${CE_USER}:${CE_USER} /home/${CE_USER}
+
+# Data volume is LVM (created on the legacy bionic instance). Mounted at first boot
+# from the existing /etc/fstab below; do not mount during AMI bake — the volume
+# will not be present.
 echo "/dev/data/datavol       /home/${CE_USER}/.conan_server   ext4   defaults,user=${CE_USER}       0 0
 " >>/etc/fstab
 
-# note: dont mount yet, volume will not be available
-
 # setup conan-server in a venv (pinned to v1: builders use conan==1.59 and the
-# server must speak the matching protocol; v2 is a hard break).
+# server speaks the v1 wire protocol; v2 is a hard break).
 sudo -u ${CE_USER} -H python3 -m venv /home/${CE_USER}/venv
-sudo -u ${CE_USER} -H /home/${CE_USER}/venv/bin/pip install --upgrade pip
 sudo -u ${CE_USER} -H /home/${CE_USER}/venv/bin/pip install 'conan<2' gunicorn
 
 # setup conanproxy
@@ -94,7 +99,7 @@ PTRAIL='/etc/rsyslog.d/99-papertrail.conf'
 echo "*.*          @${LOG_DEST_HOST}:${LOG_DEST_PORT}" >"${PTRAIL}"
 service rsyslog restart
 pushd /tmp
-curl -sL 'https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote_syslog_linux_amd64.tar.gz' | tar zxf -
+curl -sL 'https://github.com/papertrail/remote_syslog2/releases/download/v0.21/remote_syslog_linux_amd64.tar.gz' | tar zxf -
 cp remote_syslog/remote_syslog /usr/local/bin/
 popd
 

--- a/setup-conan.sh
+++ b/setup-conan.sh
@@ -65,10 +65,12 @@ chown -R ${CE_USER}:${CE_USER} /home/${CE_USER}
 echo "/dev/data/datavol       /home/${CE_USER}/.conan_server   ext4   defaults,user=${CE_USER}       0 0
 " >>/etc/fstab
 
-# setup conan-server in a venv (pinned to v1: builders use conan==1.59 and the
-# server speaks the v1 wire protocol; v2 is a hard break).
+# setup conan-server in a venv. Pinned to 1.59 to match what builders run
+# (init/start-builder.sh:35); the live legacy server has been on 1.30.2 since
+# 2020, so 1.59 is a deliberate but minimal bump. v2 is a hard break (different
+# wire protocol).
 sudo -u ${CE_USER} -H python3 -m venv /home/${CE_USER}/venv
-sudo -u ${CE_USER} -H /home/${CE_USER}/venv/bin/pip install 'conan<2' gunicorn
+sudo -u ${CE_USER} -H /home/${CE_USER}/venv/bin/pip install 'conan==1.59' gunicorn
 
 # setup conanproxy
 mkdir -p /home/ubuntu/ceconan

--- a/setup-conan.sh
+++ b/setup-conan.sh
@@ -3,6 +3,12 @@
 set -ex
 
 CE_USER=ce
+# Match the legacy bionic conan-node's ce uid/gid (`id ce` -> uid=111(ce) gid=115(ce))
+# so files on the reattached data volume keep their owner and no chown is needed
+# on cutover or rollback. If these ever diverge from /etc/passwd on the live host,
+# update them before baking; a mismatch turns rollback into a recursive chown.
+CE_UID=111
+CE_GID=115
 NODE_VERSION="v22.11.0"
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${DIR}"
@@ -45,8 +51,11 @@ unzip -q awscliv2.zip
 rm -rf aws awscliv2.zip
 popd
 
-# setup ce user with an explicit home (adduser --system on its own gives /nonexistent on noble)
-adduser --system --home /home/${CE_USER} --group ${CE_USER}
+# Create ce group/user with the legacy uid/gid; explicit --home because adduser
+# --system defaults to /nonexistent on noble, which would break the venv below.
+groupadd --system --gid "${CE_GID}" "${CE_USER}"
+useradd --system --uid "${CE_UID}" --gid "${CE_GID}" \
+    --home-dir "/home/${CE_USER}" --shell /usr/sbin/nologin "${CE_USER}"
 mkdir -p /home/${CE_USER}/.conan_server
 chown -R ${CE_USER}:${CE_USER} /home/${CE_USER}
 

--- a/setup-conan.sh
+++ b/setup-conan.sh
@@ -29,12 +29,17 @@ sleep 5
 wait_for_apt
 
 apt-get -y update
-apt-get -y upgrade --force-yes
-apt-get -y install unzip wget mosh fish jq ssmtp cronic upx autojump python3-pip python3.8 python3.8-venv sqlite3
+apt-get -y upgrade
+apt-get -y install unzip wget mosh fish jq ssmtp cronic upx python3-pip python3-venv sqlite3
 apt-get -y autoremove
-pip3 install --upgrade pip
-hash -r pip3
-pip3 install --upgrade awscli
+
+# Install AWS CLI v2 (system pip is PEP 668-restricted on noble)
+pushd /tmp
+curl -sL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip -q awscliv2.zip
+./aws/install --update
+rm -rf aws awscliv2.zip
+popd
 
 # setup ce_user
 adduser --system --group ${CE_USER}
@@ -45,8 +50,11 @@ echo "/dev/data/datavol       /home/${CE_USER}/.conan_server   ext4   defaults,u
 
 # note: dont mount yet, volume will not be available
 
-# setup latest conan-server
-sudo -u ${CE_USER} -H pip3 install conan gunicorn
+# setup conan-server in a venv (pinned to v1: builders use conan==1.59 and the
+# server must speak the matching protocol; v2 is a hard break).
+sudo -u ${CE_USER} -H python3 -m venv /home/${CE_USER}/venv
+sudo -u ${CE_USER} -H /home/${CE_USER}/venv/bin/pip install --upgrade pip
+sudo -u ${CE_USER} -H /home/${CE_USER}/venv/bin/pip install 'conan<2' gunicorn
 
 # setup conanproxy
 mkdir -p /home/ubuntu/ceconan


### PR DESCRIPTION
Closes #2106.

Bionic is EOL and Node 16 / glibc 2.27 are now blocking conanproxy dependency upgrades. Re-target the packer source at noble and clean up the parts of `setup-conan.sh` that don't survive the jump.

## Changes

- `packer/conan.pkr.hcl`: bionic 18.04 → noble 24.04 (amd64).
- `setup-conan.sh`:
  - Drop `--force-yes` (removed) and `python3.8` / `autojump` (gone in noble).
  - Add `lvm2` and `rsyslog` to the apt list. The data volume is `/dev/data/datavol` (LVM), and noble's cloud image doesn't ship lvm2; rsyslog is required by the syslog-using systemd unit and the `service rsyslog restart` line.
  - Install AWS CLI v2 from the official zip rather than `pip install awscli` (PEP 668 blocks the latter on noble).
  - Install conan + gunicorn into `/home/ce/venv` rather than `~/.local`.
  - Pin `conan==1.59`. Live server is on **1.30.2** (since Oct 2020); builders run **1.59** (`init/start-builder.sh:35`). Pinning the new server to 1.59 brings both ends of the protocol into exact alignment, and is the smallest jump that's still installable on Python 3.12 (1.30.2 needs the long-removed `distutils`).
  - Replace `adduser --system` with explicit `groupadd`/`useradd` pinned to `uid=111, gid=115` to match the legacy host (`id ce` confirmed live). This keeps the reattached data volume's files owned by the new `ce` user; rollback is also just detach/reattach — no chown either way.
  - Bump `remote_syslog2` v0.20 → v0.21 to match `setup-common.sh`.
- `init/start-conan.sh`: use `/home/ce/venv/bin/gunicorn`, falling back to `~/.local/bin/gunicorn` so the still-running bionic instance keeps starting cleanly until cutover. The fallback can be ripped out once we're on noble.

## What's not in this PR

- `terraform/ec2.tf:4` (`conan_image_id`) is unchanged — that gets bumped to the new AMI ID in a follow-up after the bake. Same one-line change handles cutover.
- `packer/conan.pkr.hcl` still hardcodes `git clone ... main`, so the bake has to come off main, which means this PR has to merge before we can bake. (Adding a `BRANCH` variable like `ce-router.pkr.hcl` has would let us bake from a branch — worth a separate small PR.)

## Live-box state confirmed (2026-05-06)

- `id ce` → `uid=111(ce) gid=115(ce)`. Pinned in `setup-conan.sh`.
- `/etc/fstab`: `/dev/data/datavol  /home/ce/.conan_server  ext4  defaults,user=ce`. Volume is single-PV LVM as expected.
- `aws ec2 describe-volumes vol-0a99526fcf7bcfc11` → tagged `Name=CEConanServerVol1`, so the daily backup plan (`backups.tf:21-33`) is hitting the right volume.
- `df -h /home/ce/.conan_server` → **413G / 492G used, 88% full, 59G free**. Not blocking the cutover, but we need to grow it soon (online resize: `aws ec2 modify-volume`, then `pvresize` / `lvextend` / `resize2fs`). Filed as follow-up.
- `buildslogs.db` is 2.5 GB, last written 21:44 — alive.
- `~/.conan_server/` has no top-level DB-shaped state apart from buildslogs.db. `server.conf` mtime is **Oct 2020** — i.e. 1.30.2 has not auto-rewritten the config across 5 years of restarts, so the server↔config layer hasn't migrated and the rollback exposure is config-only.
- `pip3 show conan` (as ce) → **Version: 1.30.2**.

## Backups taken

- Manual pre-cutover snapshot: `snap-0619478ecb1a17f95`, tagged `conan-pre-noble-cutover`, started 23:30 UTC 2026-05-06. (Confirmed at 49% mid-PR; will be `completed` before any cutover.)
- Daily AWS Backup chain healthy: **14 completed recovery points** (Apr 23 → May 6, midnight CT each day, 500 GB).
- `server.conf` copied byte-for-byte to `/home/ce/.conan_server/server.conf.bionic-1.30.2.bak` on the data volume itself, in case 1.59 rewrites the config on first start (`jwt_secret` / password salt / write/read perms must survive untouched).

## Cutover plan

1. Merge this PR.
2. `make packer-conan` to bake the new AMI. Capture the AMI ID — it goes into step 6.
3. (Optional smoke test: launch one ad-hoc instance from the new AMI, no data volume attached — verify `id ce` is `uid=111 gid=115`, `/home/ce/venv/bin/gunicorn --version` runs, `aws --version` is v2. Then terminate.)
4. On the live box: `sudo systemctl stop ce-conan`, `sudo umount /home/ce/.conan_server`.
5. `aws ec2 detach-volume --volume-id vol-0a99526fcf7bcfc11` (and wait for `available` via `aws ec2 describe-volumes --volume-ids vol-0a99526fcf7bcfc11 --query 'Volumes[0].State'`).
6. Cutover PR (separate): bump `terraform/ec2.tf:4 conan_image_id` to the baked AMI; `terraform apply`. The instance is replaced and `aws_volume_attachment.ebs_conanserver` reattaches the existing data volume to the new instance at `/dev/xvdb`. ALB target group attachment recreates against the new instance — brief 502s through CloudFront during the gap.
7. SSH in, `sudo vgchange -ay data && sudo mount -a`, verify `~/.conan_server/data` and `buildslogs.db` are present, `sudo systemctl start ce-conan`.
8. Smoke-test: `curl https://conan.compiler-explorer.com/v1/ping`, kick a builder against staging.

## Revert plan

The pre-cutover bionic AMI is `ami-0b41dc7a318b530bd` (currently in `terraform/ec2.tf:4`). The data volume is `vol-0a99526fcf7bcfc11`. The pre-cutover EBS snapshot is `snap-0619478ecb1a17f95`. The new instance from cutover step 6 keeps no state of its own — root volume is `delete_on_termination = true`.

### Case A: noble bake is broken, data is fine

This is the expected revert path. Total time: ~5 min plus a `terraform apply` window.

```sh
# 1. stop service on the noble box, drop the mount
ssh conan-node 'sudo systemctl stop ce-conan && sudo umount /home/ce/.conan_server'

# 2. if 1.59 rewrote server.conf, put the bionic copy back before bionic comes up
ssh conan-node 'sudo diff -q /home/ce/.conan_server/server.conf /home/ce/.conan_server/server.conf.bionic-1.30.2.bak \
    || sudo cp -a /home/ce/.conan_server/server.conf.bionic-1.30.2.bak /home/ce/.conan_server/server.conf'

# 3. detach the data volume so terraform doesn't fight an in-use detach
aws ec2 detach-volume --volume-id vol-0a99526fcf7bcfc11
aws ec2 wait volume-available --volume-ids vol-0a99526fcf7bcfc11
```

Then in `terraform/ec2.tf`:
- Set `conan_image_id = "ami-0b41dc7a318b530bd"` (the bionic value above).

```sh
terraform apply   # terminates the noble instance, launches a fresh bionic from the old AMI,
                  # reattaches vol-0a99526fcf7bcfc11, re-registers with the ALB target group.
```

Then on the new bionic instance:

```sh
ssh conan-node 'sudo vgchange -ay data && sudo mount -a && \
                ls /home/ce/.conan_server/buildslogs.db && \
                sudo systemctl start ce-conan'
curl -fsS https://conan.compiler-explorer.com/v1/ping
```

Why this is safe: `delete_on_termination = true` only affects the *root* volume, not the data volume. The `aws_volume_attachment` resource references the volume by hardcoded ID (`vol-0a99526fcf7bcfc11`), so terraform never deletes it — it only attaches/detaches. ce's uid/gid have been the same on both AMIs (111/115), so no chown is required. The bionic AMI is the same image that's been running in production for years; booting it fresh just gets us back to the prior state.

### Case B: data volume was corrupted during the noble window

Don't `terraform apply` yet. Preserve the corrupt state and restore from snapshot.

```sh
# 1. stop the service so nothing else writes
ssh conan-node 'sudo systemctl stop ce-conan && sudo umount /home/ce/.conan_server'

# 2. snapshot the corrupt volume so we can investigate after the fact
aws ec2 create-snapshot --volume-id vol-0a99526fcf7bcfc11 \
    --description "Corrupt post-noble snapshot $(date -u +%Y-%m-%dT%H:%M:%SZ)" \
    --tag-specifications 'ResourceType=snapshot,Tags=[{Key=Name,Value=conan-post-noble-corrupt}]'

# 3. detach the corrupt volume (keep it; do not delete)
aws ec2 detach-volume --volume-id vol-0a99526fcf7bcfc11
aws ec2 wait volume-available --volume-ids vol-0a99526fcf7bcfc11

# 4. create a new volume from the pre-cutover snapshot
NEW_VOL=$(aws ec2 create-volume \
    --snapshot-id snap-0619478ecb1a17f95 \
    --availability-zone us-east-1a \
    --volume-type gp2 \
    --tag-specifications 'ResourceType=volume,Tags=[{Key=Name,Value=CEConanServerVol1},{Key=Site,Value=CompilerExplorer}]' \
    --query VolumeId --output text)
aws ec2 wait volume-available --volume-ids "$NEW_VOL"
echo "New data volume: $NEW_VOL"

# 5. tag the OLD volume so the daily backup plan stops backing it up
aws ec2 create-tags --resources vol-0a99526fcf7bcfc11 \
    --tags Key=Name,Value=CEConanServerVol1-corrupt
```

Then in `terraform/ec2.tf`:
- Set `conan_image_id` back to `ami-0b41dc7a318b530bd`.
- Update `aws_volume_attachment.ebs_conanserver.volume_id` to the printed `$NEW_VOL`.

`terraform apply`, then mount/start as in Case A. The corrupt volume sticks around (just not attached) until you're sure the new one is good, then `aws ec2 delete-volume --volume-id vol-0a99526fcf7bcfc11` to stop paying for it.

### What we lose either way

We've already detached the data volume on the way out (cutover step 5) and may have rolled back without taking it back through bionic — so anything *uploaded* to the noble server during the noble window stays on disk and will be served once the bionic server is reading the same volume. We'd only "lose" data if we restore from the snapshot in Case B, in which case we lose everything written during the noble window. The pre-cutover snapshot is the floor.

## Follow-ups (out of scope for this PR)

- Grow the data volume — 88% full and growing (`aws ec2 modify-volume` + `pvresize`/`lvextend`/`resize2fs`).
- Rip the gunicorn-path fallback out of `init/start-conan.sh` once we're on noble.
- `aws_instance.ConanNode.volume_tags` (`ec2.tf:68-71`) tags the *root* volume `Name=CEConanServerVol1`, so the backup plan also picks up the small root volume. Cosmetic but worth a separate PR.
- The data volume is referenced by ID in `aws_volume_attachment` but isn't itself a managed terraform resource. Adopting it via `aws_ebs_volume` data source + `aws_ec2_tag` would make the backup-by-tag dependency explicit instead of out-of-band.
- Add a `BRANCH` variable to `packer/conan.pkr.hcl` so future packer changes can be tested before merge.
- `setup-conan.sh` is significantly diverged from `setup-common.sh` (no Grafana agent, no log-instance-id, etc.). Worth a longer look at convergence.