### PR TITLE
Cut conan-node over to the noble AMI

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -1,7 +1,7 @@
 locals {
   runner_image_id        = "ami-05d4fb32368117b54"
   gpu_runner_image_id    = "ami-05df317ba6d2893be"
-  conan_image_id         = "ami-0b41dc7a318b530bd"
+  conan_image_id         = "ami-0a414afebbce8ed51"
   smbserver_image_id     = "ami-01e7c7963a9c4755d"
   smbtestserver_image_id = "ami-0284c821376912369"
   admin_subnet           = module.ce_network.subnet["1a"].id

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -81,6 +81,10 @@ resource "aws_volume_attachment" "ebs_conanserver" {
   device_name = "/dev/xvdb"
   volume_id   = "vol-0a99526fcf7bcfc11"
   instance_id = aws_instance.ConanNode.id
+  # Have terraform stop the instance (ACPI shutdown -> graceful systemd
+  # unmount of /home/ce/.conan_server) before detaching the data volume.
+  # Without this, destroy of this resource on an in-use volume hangs.
+  stop_instance_before_detaching = true
 }
 
 


### PR DESCRIPTION
Follow-up to #2107. Bumps `conan_image_id` from the legacy bionic AMI (`ami-0b41dc7a318b530bd`) to the freshly-baked noble one (`ami-0a414afebbce8ed51`).

Also adds `stop_instance_before_detaching = true` to `aws_volume_attachment.ebs_conanserver` so `terraform apply` can drive the whole cutover end-to-end. Without that, destroying the attachment would call DetachVolume on a still-mounted volume, AWS would queue the request, and apply would time out partway through.

## terraform plan -target

```
aws_instance.ConanNode                                  must be replaced
  ami: ami-0b41dc7a318b530bd -> ami-0a414afebbce8ed51   # forces replacement
aws_volume_attachment.ebs_conanserver                   must be replaced
  instance_id: i-0cb1956a200ec609b -> (known after apply)  # forces replacement
  stop_instance_before_detaching: + true
aws_alb_target_group_attachment.CEConanServerTargetInstance  must be replaced
  target_id: i-0cb1956a200ec609b -> (known after apply)  # forces replacement

Plan: 3 to add, 0 to change, 3 to destroy.
```

The data volume `vol-0a99526fcf7bcfc11` is not in the plan — it's only referenced by ID, never managed by terraform.

## What apply does, in order

1. Destroy the ALB target group attachment (deregister i-0cb1956a200ec609b).
2. Destroy the volume attachment: AWS StopInstance on the bionic conan-node → ACPI shutdown → systemd brings down ce-conan and unmounts `/home/ce/.conan_server` cleanly → DetachVolume succeeds.
3. Destroy the instance (terminates the now-stopped bionic instance; root volume is `delete_on_termination=true`).
4. Create the new noble instance from `ami-0a414afebbce8ed51`.
5. Create the new volume attachment: re-attaches `vol-0a99526fcf7bcfc11` at `/dev/xvdb`.
6. Create the new ALB target group attachment.

On boot, the new instance:
- udev activates the `data` VG (`lvm2` is installed in the new AMI).
- fstab mounts `/home/ce/.conan_server`.
- `remote-fs.target` reaches active.
- `ce-conan.service` starts (it was `systemctl enable`d at bake time per `setup-conan.sh:78`, with `After=remote-fs.target`).

Nothing manual needed.

## Verify after apply

```sh
curl -fsS https://conan.compiler-explorer.com/v1/ping
```

If anything's off, SSH in and look at `journalctl -u ce-conan` and `df /home/ce/.conan_server`.

If `server.conf` got rewritten by 1.66 on first start and something looks suspicious, the byte-exact bionic copy is at `/home/ce/.conan_server/server.conf.bionic-1.30.2.bak` on the data volume.

## Backups

- Pre-cutover snapshot: `snap-0619478ecb1a17f95` (completed, tagged `conan-pre-noble-cutover`).
- Daily AWS Backup chain: 14 completed recovery points.

## Revert

See the "Revert plan" section of #2107.