### PR TITLE
Adopt the conan data volume into terraform

### DIFF
--- a/docs/resizing_conan_disk.md
+++ b/docs/resizing_conan_disk.md
@@ -2,28 +2,48 @@
 
 Our Conan instance has an extra volume just to store the Conan packages.
 
-This is a volume with the ID: `vol-0a99526fcf7bcfc11`
-
-AWS says it's connected as `/dev/xvdb` in linux, but that's not actually correct, so ignore that.
+It's `vol-0a99526fcf7bcfc11`, defined as `aws_ebs_volume.conan_data` in
+`terraform/ec2.tf` and tagged `Name=CEConanServerVol1`. The resource has
+`lifecycle { prevent_destroy = true }` so a stray `terraform destroy` can't
+nuke it.
 
 You can resize everything while the server is online and the disk is mounted.
 
 ## Enlarging the volume in AWS
 
-If you click on the volume in the AWS console, you can click on Modify and enter a new Size in GiB.
+Open a PR that bumps `size` on `aws_ebs_volume.conan_data` in
+`terraform/ec2.tf`, then merge and `terraform apply`. EBS volume size
+modifications are online — no detach, no instance restart.
+
+If you need to resize urgently and a PR isn't practical, you can do it
+out-of-band with the CLI and back-fill the terraform change afterwards:
+
+```sh
+aws ec2 modify-volume --volume-id vol-0a99526fcf7bcfc11 --size <NEW_GIB>
+```
+
+Either way, wait for the modification to reach state `optimizing` before
+running the host-side steps below — that's when the new size becomes visible
+to the kernel. Check with:
+
+```sh
+aws ec2 describe-volumes-modifications --volume-ids vol-0a99526fcf7bcfc11
+```
 
 ## Recognizing the new size in Linux
 
 * Login to the server with `ce conan login`
-* Double check the device name with `sudo lsblk -f`, it should be `/dev/nvme1n1` (and ext4)
-* Just to be sure type `sudo fdisk --list` and see if `/dev/nvme1n1` (not nvme0!) is indeed the new size
-* `sudo growpart /dev/nvme1n1 1`
-* `sudo pvresize /dev/nvme1n1p1`
-* Check with `sudo pvs` that the PV has a new size now
-* `sudo lvextend -l +100%FREE /dev/mapper/data-datavol`
-* Check with `sudo lvs` that the LV has a new size now
-* `sudo resize2fs /dev/mapper/data-datavol`
-* Check with `df -h` if the mount has a new size
+* Confirm the device with `sudo lsblk -f`. On the current Nitro instance it's
+  `/dev/nvme1n1` with one partition `/dev/nvme1n1p1` carrying the LVM PV.
+  (AWS reports the attachment as `/dev/xvdb`; ignore that, it's a legacy
+  alias the kernel doesn't actually use on Nitro.)
+* `sudo growpart /dev/nvme1n1 1` — grows the partition to fill the device
+* `sudo pvresize /dev/nvme1n1p1` — grows the LVM PV to fill the partition
+* `sudo lvextend -l +100%FREE /dev/data/datavol` — grows the LV
+* `sudo resize2fs /dev/mapper/data-datavol` — grows the ext4 filesystem
+* `df -h /home/ce/.conan_server` — sanity check the new size
+
+All of these are online and non-disruptive; ce-conan keeps serving throughout.
 
 ## To start/restart conan if it had failed because of no diskspace
 

--- a/docs/resizing_conan_disk.md
+++ b/docs/resizing_conan_disk.md
@@ -11,20 +11,14 @@ You can resize everything while the server is online and the disk is mounted.
 
 ## Enlarging the volume in AWS
 
-Open a PR that bumps `size` on `aws_ebs_volume.conan_data` in
-`terraform/ec2.tf`, then merge and `terraform apply`. EBS volume size
-modifications are online — no detach, no instance restart.
+Bump `size` on `aws_ebs_volume.conan_data` in `terraform/ec2.tf`, open a PR,
+and `terraform apply`. You don't have to merge first — apply from the branch
+if you're working under time pressure, and merge afterwards. EBS volume size
+modifications are online: no detach, no instance restart.
 
-If you need to resize urgently and a PR isn't practical, you can do it
-out-of-band with the CLI and back-fill the terraform change afterwards:
-
-```sh
-aws ec2 modify-volume --volume-id vol-0a99526fcf7bcfc11 --size <NEW_GIB>
-```
-
-Either way, wait for the modification to reach state `optimizing` before
-running the host-side steps below — that's when the new size becomes visible
-to the kernel. Check with:
+Wait for the modification to reach state `optimizing` before running the
+host-side steps below — that's when the new size becomes visible to the
+kernel. Check with:
 
 ```sh
 aws ec2 describe-volumes-modifications --volume-ids vol-0a99526fcf7bcfc11

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -66,7 +66,7 @@ resource "aws_instance" "ConanNode" {
   }
 
   volume_tags = {
-    Name = "CEConanServerVol1"
+    Name = "ConanNodeRoot"
     Site = "CompilerExplorer"
   }
 

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -77,9 +77,30 @@ resource "aws_instance" "ConanNode" {
   }
 }
 
+# The conan-server data volume. Holds /home/ce/.conan_server (the conan
+# package store) and conanproxy's buildslogs.db. This is the single piece
+# of irreplaceable state on the conan-node -- everything else can be re-baked
+# from packer. prevent_destroy guards against an accidental terraform destroy
+# wiping the volume out; routine instance replacements detach/reattach via
+# aws_volume_attachment.ebs_conanserver below and don't touch this resource.
+resource "aws_ebs_volume" "conan_data" {
+  availability_zone = "us-east-1a"
+  size              = 600
+  type              = "gp2"
+  encrypted         = false
+
+  tags = {
+    Name = "CEConanServerVol1"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 resource "aws_volume_attachment" "ebs_conanserver" {
   device_name = "/dev/xvdb"
-  volume_id   = "vol-0a99526fcf7bcfc11"
+  volume_id   = aws_ebs_volume.conan_data.id
   instance_id = aws_instance.ConanNode.id
   # Have terraform stop the instance (ACPI shutdown -> graceful systemd
   # unmount of /home/ce/.conan_server) before detaching the data volume.


### PR DESCRIPTION
Brings `vol-0a99526fcf7bcfc11` (the conan-server data volume — `/home/ce/.conan_server`, 600 GB, gp2) under terraform management. Until now it was created out-of-band and only referenced by hardcoded ID from `aws_volume_attachment.ebs_conanserver`, with size / type / AZ / encryption / tags all living only in the AWS console.

## Changes

- New `aws_ebs_volume.conan_data` resource matching the live volume's attributes:
  - 600 GB, gp2, us-east-1a, unencrypted
  - `Name = "CEConanServerVol1"` tag (Site comes from the provider's `default_tags`)
- `lifecycle { prevent_destroy = true }` so any future terraform destroy plan that touches this resource errors out, rather than silently nuking the data.
- `aws_volume_attachment.ebs_conanserver.volume_id` switched from the hardcoded string to `aws_ebs_volume.conan_data.id`.
- `aws_instance.ConanNode.volume_tags.Name` changed from `CEConanServerVol1` to `ConanNodeRoot`. The 10 GB root volume was getting tagged with the same Name as the data volume, which meant the daily `aws_backup_selection.conan-server` (`backups.tf:21-33`) was picking up *both* volumes. Apply will rename the root volume's `Name` tag in place; data volume is untouched.
- `docs/resizing_conan_disk.md` updated to describe the terraform-managed flow.

## Required: import before applying

The volume already exists. Without an import, `terraform apply` will try to *create a new* EBS volume of the same name, fail noisily, and leave drift. Run **before** apply:

```sh
terraform import aws_ebs_volume.conan_data vol-0a99526fcf7bcfc11
```

I tested this exact import on the live state during the PR draft, confirmed `terraform plan` shows zero diff afterwards, then `terraform state rm`'d it back out so the merger does it cleanly.

## After import

`terraform plan` should show one in-place change — the root-volume `Name` tag rename on `aws_instance.ConanNode`. Both `aws_ebs_volume.conan_data` and `aws_volume_attachment.ebs_conanserver` should show no diff (the volume_id reference swap resolves to the same ID).

## What this gives us

- Future resizes are a one-line PR: `size = 600` → `size = 700`.
- The daily backup chain now selects only the actual data volume; the root volume drops out of the backup set.
- `prevent_destroy` means even if someone runs a destroy plan that includes this resource (intentionally or via blast-radius), terraform refuses. To actually delete the volume one day you'd have to remove the lifecycle block in a separate PR first.
