### PR TITLE
Install grafana-agent on conan-node + emit data-volume FS metrics

### DIFF
--- a/grafana/agent.yaml
+++ b/grafana/agent.yaml
@@ -57,8 +57,10 @@ integrations:
       - time
       - timex
       - udp_queues
-    # ignore all filesystems besides root
-    filesystem_ignored_mount_points: "^/.+$"
+    # filesystems to skip from filesystem metrics; substituted at bake time per host
+    # (see setup_grafana in setup-common.sh; conan-node uses a looser pattern that
+    # lets /home/ce/.conan_server through).
+    filesystem_ignored_mount_points: "@FS_IGNORE@"
     metric_relabel_configs:
       - source_labels: [ __name__, proto ]
         regex: "node_nfs_requests_total;[^4]"

--- a/grafana/agent.yaml
+++ b/grafana/agent.yaml
@@ -58,8 +58,9 @@ integrations:
       - timex
       - udp_queues
     # filesystems to skip from filesystem metrics; substituted at bake time per host
-    # (see setup_grafana in setup-common.sh; conan-node uses a looser pattern that
-    # lets /home/ce/.conan_server through).
+    # (see grafana/install-agent.sh; conan-node uses a looser pattern that lets
+    # /home/ce/.conan_server through, while other hosts keep the legacy "/-only"
+    # default).
     filesystem_ignored_mount_points: "@FS_IGNORE@"
     metric_relabel_configs:
       - source_labels: [ __name__, proto ]

--- a/grafana/install-agent.sh
+++ b/grafana/install-agent.sh
@@ -32,15 +32,24 @@ cp "grafana-agent-linux-${ARCH}" /usr/local/bin/grafana-agent
 rm -f agent-linux.zip "grafana-agent-linux-${ARCH}"
 popd
 
-PROM_PASSWORD=$(get_conf /compiler-explorer/promPassword)
-LOKI_PASSWORD=$(get_conf /compiler-explorer/lokiPassword)
+# Escape characters that have meaning in sed replacement strings. Without
+# this, a value containing &, \, or the delimiter would mis-substitute
+# (and for the secrets, potentially produce a corrupted config).
+sed_escape() { printf '%s' "$1" | sed -e 's/[\&]/\\&/g; s/#/\\#/g'; }
 
 mkdir -p /etc/grafana
 cp "${GRAFANA_DIR}/agent.yaml" /etc/grafana/agent.yaml.tpl
-sed -i "s/@PROM_PASSWORD@/${PROM_PASSWORD}/g" /etc/grafana/agent.yaml.tpl
-sed -i "s/@LOKI_PASSWORD@/${LOKI_PASSWORD}/g" /etc/grafana/agent.yaml.tpl
-# # delimiter because FS_IGNORE regex generally contains slashes.
-sed -i "s#@FS_IGNORE@#${FS_IGNORE}#g" /etc/grafana/agent.yaml.tpl
+
+# Disable xtrace while handling secrets so they don't leak into bake logs.
+{ set +x; } 2>/dev/null
+PROM_PASSWORD=$(get_conf /compiler-explorer/promPassword)
+LOKI_PASSWORD=$(get_conf /compiler-explorer/lokiPassword)
+sed -i "s#@PROM_PASSWORD@#$(sed_escape "${PROM_PASSWORD}")#g" /etc/grafana/agent.yaml.tpl
+sed -i "s#@LOKI_PASSWORD@#$(sed_escape "${LOKI_PASSWORD}")#g" /etc/grafana/agent.yaml.tpl
+unset PROM_PASSWORD LOKI_PASSWORD
+set -x
+
+sed -i "s#@FS_IGNORE@#$(sed_escape "${FS_IGNORE}")#g" /etc/grafana/agent.yaml.tpl
 chmod 600 /etc/grafana/agent.yaml.tpl
 
 case "${INSTALL_TYPE}" in

--- a/grafana/install-agent.sh
+++ b/grafana/install-agent.sh
@@ -12,7 +12,7 @@
 #   FS_IGNORE        regex of mount points to drop (default '^/.+$')
 #   GRAFANA_VERSION  grafana-agent release tag (default 0.41.1)
 
-set -ex
+set -euxo pipefail
 
 GRAFANA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FS_IGNORE=${FS_IGNORE:-'^/.+$'}

--- a/grafana/install-agent.sh
+++ b/grafana/install-agent.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Install grafana-agent + ce-metrics and substitute the templated agent.yaml.
+#
+# Callers control which mount points node_exporter emits filesystem metrics
+# for via FS_IGNORE (a regex of mount points to exclude). The default keeps
+# the legacy "/-only" behaviour for hosts that have no real data mount; the
+# conan node overrides it because /home/ce/.conan_server is what we want to
+# alert on.
+#
+# Optional env vars:
+#   INSTALL_TYPE     ci | admin | <empty>  - picks which make-config.sh to use
+#   FS_IGNORE        regex of mount points to drop (default '^/.+$')
+#   GRAFANA_VERSION  grafana-agent release tag (default 0.41.1)
+
+set -ex
+
+GRAFANA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FS_IGNORE=${FS_IGNORE:-'^/.+$'}
+INSTALL_TYPE=${INSTALL_TYPE:-}
+GRAFANA_VERSION=${GRAFANA_VERSION:-0.41.1}
+
+ARCH=$(dpkg --print-architecture)
+
+get_conf() {
+    aws ssm get-parameter --name "$1" | jq -r .Parameter.Value
+}
+
+pushd /tmp
+curl -sLo agent-linux.zip "https://github.com/grafana/agent/releases/download/v${GRAFANA_VERSION}/grafana-agent-linux-${ARCH}.zip"
+unzip -o agent-linux.zip
+cp "grafana-agent-linux-${ARCH}" /usr/local/bin/grafana-agent
+rm -f agent-linux.zip "grafana-agent-linux-${ARCH}"
+popd
+
+PROM_PASSWORD=$(get_conf /compiler-explorer/promPassword)
+LOKI_PASSWORD=$(get_conf /compiler-explorer/lokiPassword)
+
+mkdir -p /etc/grafana
+cp "${GRAFANA_DIR}/agent.yaml" /etc/grafana/agent.yaml.tpl
+sed -i "s/@PROM_PASSWORD@/${PROM_PASSWORD}/g" /etc/grafana/agent.yaml.tpl
+sed -i "s/@LOKI_PASSWORD@/${LOKI_PASSWORD}/g" /etc/grafana/agent.yaml.tpl
+# # delimiter because FS_IGNORE regex generally contains slashes.
+sed -i "s#@FS_IGNORE@#${FS_IGNORE}#g" /etc/grafana/agent.yaml.tpl
+chmod 600 /etc/grafana/agent.yaml.tpl
+
+case "${INSTALL_TYPE}" in
+    ci)    cp "${GRAFANA_DIR}/make-config-ci.sh"    /etc/grafana/make-config.sh ;;
+    admin) cp "${GRAFANA_DIR}/make-config-admin.sh" /etc/grafana/make-config.sh ;;
+    *)     cp "${GRAFANA_DIR}/make-config.sh"       /etc/grafana/make-config.sh ;;
+esac
+
+cp "${GRAFANA_DIR}/update-metrics.sh" /etc/grafana/update-metrics.sh
+cp "${GRAFANA_DIR}/ce-metrics.service" /lib/systemd/system/ce-metrics.service
+cp "${GRAFANA_DIR}/grafana-agent.service" /lib/systemd/system/grafana-agent.service
+
+systemctl daemon-reload
+systemctl enable ce-metrics
+systemctl enable grafana-agent

--- a/setup-common.sh
+++ b/setup-common.sh
@@ -135,6 +135,7 @@ setup_grafana() {
     cp $GRAFANA_CONFIG /etc/grafana/agent.yaml.tpl
     sed -i "s/@PROM_PASSWORD@/${PROM_PASSWORD}/g" /etc/grafana/agent.yaml.tpl
     sed -i "s/@LOKI_PASSWORD@/${LOKI_PASSWORD}/g" /etc/grafana/agent.yaml.tpl
+    sed -i 's#@FS_IGNORE@#^/.+$#g' /etc/grafana/agent.yaml.tpl
     chmod 600 /etc/grafana/agent.yaml.tpl
     if [ "${INSTALL_TYPE}" = "ci" ]; then
       cp /infra/grafana/make-config-ci.sh /etc/grafana/make-config.sh

--- a/setup-common.sh
+++ b/setup-common.sh
@@ -117,43 +117,10 @@ systemctl enable remote-syslog
 cp /infra/init/log-instance-id.service /lib/systemd/system/log-instance-id.service
 systemctl enable log-instance-id
 
-setup_grafana() {
-    local GRAFANA_CONFIG=/infra/grafana/agent.yaml
-    local GRAFANA_VERSION=0.41.1
-
-    pushd /tmp
-    curl -sLo agent-linux.zip "https://github.com/grafana/agent/releases/download/v${GRAFANA_VERSION}/grafana-agent-linux-${ARCH}.zip"
-    unzip agent-linux.zip
-    cp "grafana-agent-linux-${ARCH}" /usr/local/bin/grafana-agent
-    popd
-
-    local PROM_PASSWORD
-    local LOKI_PASSWORD
-    PROM_PASSWORD=$(get_conf /compiler-explorer/promPassword)
-    LOKI_PASSWORD=$(get_conf /compiler-explorer/lokiPassword)
-    mkdir -p /etc/grafana
-    cp $GRAFANA_CONFIG /etc/grafana/agent.yaml.tpl
-    sed -i "s/@PROM_PASSWORD@/${PROM_PASSWORD}/g" /etc/grafana/agent.yaml.tpl
-    sed -i "s/@LOKI_PASSWORD@/${LOKI_PASSWORD}/g" /etc/grafana/agent.yaml.tpl
-    sed -i 's#@FS_IGNORE@#^/.+$#g' /etc/grafana/agent.yaml.tpl
-    chmod 600 /etc/grafana/agent.yaml.tpl
-    if [ "${INSTALL_TYPE}" = "ci" ]; then
-      cp /infra/grafana/make-config-ci.sh /etc/grafana/make-config.sh
-    elif [ "${INSTALL_TYPE}" = "admin" ]; then
-      cp /infra/grafana/make-config-admin.sh /etc/grafana/make-config.sh
-    else
-      cp /infra/grafana/make-config.sh /etc/grafana/make-config.sh
-    fi
-
-    cp /infra/grafana/update-metrics.sh /etc/grafana/update-metrics.sh
-    cp /infra/grafana/ce-metrics.service /lib/systemd/system/ce-metrics.service
-    cp /infra/grafana/grafana-agent.service /lib/systemd/system/grafana-agent.service
-
-    systemctl daemon-reload
-    systemctl enable ce-metrics
-    systemctl enable grafana-agent
-}
-setup_grafana
+# The default exclude regex ('^/.+$') keeps the legacy "/-only" behaviour for
+# nodes that have no real data mount. Hosts with extra data mounts (e.g.
+# conan-node) call install-agent.sh themselves with FS_IGNORE set.
+INSTALL_TYPE="${INSTALL_TYPE}" /infra/grafana/install-agent.sh
 
 # Skip NFS setup if SKIP_NFS_SETUP is set
 if [ "${SKIP_NFS_SETUP:-}" != "1" ]; then

--- a/setup-conan.sh
+++ b/setup-conan.sh
@@ -150,6 +150,37 @@ WantedBy=multi-user.target
 EOF
 systemctl enable remote-syslog
 
+# setup grafana-agent (filesystem + journal metrics into Grafana Cloud).
+# Conan node has /home/ce/.conan_server as a real data mount in addition to /,
+# so the FS_IGNORE pattern only excludes kernel/virtual filesystems instead of
+# the default '^/.+$' which drops everything that isn't '/'.
+ARCH=$(dpkg --print-architecture)
+GRAFANA_VERSION=0.41.1
+pushd /tmp
+curl -sLo agent-linux.zip "https://github.com/grafana/agent/releases/download/v${GRAFANA_VERSION}/grafana-agent-linux-${ARCH}.zip"
+unzip -o agent-linux.zip
+cp "grafana-agent-linux-${ARCH}" /usr/local/bin/grafana-agent
+rm -f agent-linux.zip "grafana-agent-linux-${ARCH}"
+popd
+
+PROM_PASSWORD=$(get_conf /compiler-explorer/promPassword)
+LOKI_PASSWORD=$(get_conf /compiler-explorer/lokiPassword)
+mkdir -p /etc/grafana
+cp /home/ubuntu/infra/grafana/agent.yaml /etc/grafana/agent.yaml.tpl
+sed -i "s/@PROM_PASSWORD@/${PROM_PASSWORD}/g" /etc/grafana/agent.yaml.tpl
+sed -i "s/@LOKI_PASSWORD@/${LOKI_PASSWORD}/g" /etc/grafana/agent.yaml.tpl
+sed -i 's#@FS_IGNORE@#^/(proc|sys|dev|run|tmp|snap|boot)($|/)#g' /etc/grafana/agent.yaml.tpl
+chmod 600 /etc/grafana/agent.yaml.tpl
+
+cp /home/ubuntu/infra/grafana/make-config.sh /etc/grafana/make-config.sh
+cp /home/ubuntu/infra/grafana/update-metrics.sh /etc/grafana/update-metrics.sh
+cp /home/ubuntu/infra/grafana/ce-metrics.service /lib/systemd/system/ce-metrics.service
+cp /home/ubuntu/infra/grafana/grafana-agent.service /lib/systemd/system/grafana-agent.service
+
+systemctl daemon-reload
+systemctl enable ce-metrics
+systemctl enable grafana-agent
+
 # ---
 
 cd /home/ubuntu/

--- a/setup-conan.sh
+++ b/setup-conan.sh
@@ -150,36 +150,11 @@ WantedBy=multi-user.target
 EOF
 systemctl enable remote-syslog
 
-# setup grafana-agent (filesystem + journal metrics into Grafana Cloud).
-# Conan node has /home/ce/.conan_server as a real data mount in addition to /,
-# so the FS_IGNORE pattern only excludes kernel/virtual filesystems instead of
-# the default '^/.+$' which drops everything that isn't '/'.
-ARCH=$(dpkg --print-architecture)
-GRAFANA_VERSION=0.41.1
-pushd /tmp
-curl -sLo agent-linux.zip "https://github.com/grafana/agent/releases/download/v${GRAFANA_VERSION}/grafana-agent-linux-${ARCH}.zip"
-unzip -o agent-linux.zip
-cp "grafana-agent-linux-${ARCH}" /usr/local/bin/grafana-agent
-rm -f agent-linux.zip "grafana-agent-linux-${ARCH}"
-popd
-
-PROM_PASSWORD=$(get_conf /compiler-explorer/promPassword)
-LOKI_PASSWORD=$(get_conf /compiler-explorer/lokiPassword)
-mkdir -p /etc/grafana
-cp /home/ubuntu/infra/grafana/agent.yaml /etc/grafana/agent.yaml.tpl
-sed -i "s/@PROM_PASSWORD@/${PROM_PASSWORD}/g" /etc/grafana/agent.yaml.tpl
-sed -i "s/@LOKI_PASSWORD@/${LOKI_PASSWORD}/g" /etc/grafana/agent.yaml.tpl
-sed -i 's#@FS_IGNORE@#^/(proc|sys|dev|run|tmp|snap|boot)($|/)#g' /etc/grafana/agent.yaml.tpl
-chmod 600 /etc/grafana/agent.yaml.tpl
-
-cp /home/ubuntu/infra/grafana/make-config.sh /etc/grafana/make-config.sh
-cp /home/ubuntu/infra/grafana/update-metrics.sh /etc/grafana/update-metrics.sh
-cp /home/ubuntu/infra/grafana/ce-metrics.service /lib/systemd/system/ce-metrics.service
-cp /home/ubuntu/infra/grafana/grafana-agent.service /lib/systemd/system/grafana-agent.service
-
-systemctl daemon-reload
-systemctl enable ce-metrics
-systemctl enable grafana-agent
+# Install grafana-agent. Conan-node has a real data mount at
+# /home/ce/.conan_server, so override FS_IGNORE to drop only kernel/virtual
+# filesystems rather than the default '^/.+$' which would also drop the data
+# mount.
+FS_IGNORE='^/(proc|sys|dev|run|tmp|snap|boot)($|/)' /home/ubuntu/infra/grafana/install-agent.sh
 
 # ---
 

--- a/setup-conan.sh
+++ b/setup-conan.sh
@@ -151,10 +151,15 @@ EOF
 systemctl enable remote-syslog
 
 # Install grafana-agent. Conan-node has a real data mount at
-# /home/ce/.conan_server, so override FS_IGNORE to drop only kernel/virtual
-# filesystems rather than the default '^/.+$' which would also drop the data
-# mount.
-FS_IGNORE='^/(proc|sys|dev|run|tmp|snap|boot)($|/)' /home/ubuntu/infra/grafana/install-agent.sh
+# /home/ce/.conan_server, so override FS_IGNORE to let it through. We'd
+# rather express this as an allowlist ('only / and /home/ce/.conan_server')
+# but grafana-agent's node_exporter integration only exposes the deny side
+# (filesystem_mount_points_exclude). The denylist below covers every mount
+# type we know to be noisy or high-cardinality (kernel, tmpfs, snap, EFS,
+# CEFS, docker), so if we ever add anything fundamentally new -- a different
+# autofs, a sidecar container's overlay -- update this regex before the
+# Grafana Cloud bill notices.
+FS_IGNORE='^/(dev|proc|sys|run|tmp|snap|boot|cefs|efs|var/lib/(docker|snapd))($|/)' /home/ubuntu/infra/grafana/install-agent.sh
 
 # ---
 


### PR DESCRIPTION
Closes #1114.

The conan node was the only host without grafana-agent, so `/home/ce/.conan_server` disk usage wasn't reaching Grafana. Today's near-miss (the data volume drifted to 88% silently) is exactly what the alert on this metric is supposed to catch. The fix:

## Changes

- New `grafana/install-agent.sh` — extracts the agent install (download, password substitution, service enable) out of `setup_grafana()` in `setup-common.sh` into a shared script. Callers parameterise via `FS_IGNORE` (regex of mount points to drop from filesystem metrics) and `INSTALL_TYPE` (ci / admin / default).
- `setup-common.sh`: replaces `setup_grafana()` with a one-line invocation of the shared script. Default `FS_IGNORE` of `^/.+$` preserves byte-for-byte the previous "/-only" behaviour, so existing nodes/builders/ce-router/admin are unchanged.
- `setup-conan.sh`: invokes the shared script with a looser `FS_IGNORE` that drops only kernel/virtual filesystems (`^/(proc|sys|dev|run|tmp|snap|boot)($|/)`), so `/` *and* `/home/ce/.conan_server` are emitted to Prometheus.
- `grafana/agent.yaml`: replaces hardcoded `^/.+$` with `@FS_IGNORE@` placeholder.

## Roll-out

Re-bake the conan AMI from this branch and cut over (same flow as #2107 / #2108): `make packer-conan`, then a one-line PR bumping `terraform/ec2.tf:4 conan_image_id` to the new AMI ID, then `terraform apply`. Brief outage during the cutover window; the data volume detaches/reattaches per `aws_volume_attachment.ebs_conanserver` exactly as before.

After cutover, the metric `node_filesystem_avail_bytes{mountpoint="/home/ce/.conan_server"}` becomes available, and the alert rule clones the existing `mountpoint="/"` one with the new mountpoint label.