### PR TITLE
Add tagged versions for beman libraries

### DIFF
--- a/bin/lib/library_yaml.py
+++ b/bin/lib/library_yaml.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import os
+from collections import defaultdict
 from pathlib import Path
 
 import yaml
 
 from lib.amazon_properties import get_properties_compilers_and_libraries, get_specific_library_version_details
+from lib.config_expand import is_value_type
 from lib.config_safe_loader import ConfigSafeLoader
 from lib.installation_context import FetchFailure
 from lib.library_platform import LibraryPlatform
@@ -16,6 +18,51 @@ from lib.library_props import (
     version_to_id,
 )
 from lib.rust_crates import TopRustCrates
+
+
+def collect_library_leaves(node) -> dict[str, list[dict]]:
+    """Walk a libraries.yaml subtree, returning a flat libid -> [libdef, ...] mapping.
+
+    A dict that carries a ``targets`` key is treated as a library leaf; any other
+    dict is treated as a grouping node (e.g. ``nightly:``, ``beman:``) and recursed
+    into. Each leaf's libdef is merged with the scalar/list properties inherited
+    from its grouping ancestors, mirroring the inheritance the install pipeline
+    performs in ``installation._targets_from``. The same libid can occur in
+    multiple groupings, so values are lists.
+    """
+
+    leaves: dict[str, list[dict]] = defaultdict(list)
+
+    def walk(d, inherited):
+        if not isinstance(d, dict):
+            return
+        # Accumulate this node's own scalar/list props onto the inherited config,
+        # so children see (and override) parent settings.
+        local = dict(inherited)
+        for key, value in d.items():
+            if key != "targets" and is_value_type(value):
+                local[key] = value
+        # Two-pass walk: record leaves at the current level before descending into
+        # grouping siblings. This matters for libids that appear in multiple places
+        # (e.g. nlohmann_json directly under c++ and again under c++.nightly): the
+        # outer-level libdef is recorded first, preserving the version order pristine
+        # main produced for the generated Windows properties.
+        for key, value in d.items():
+            if not isinstance(value, dict) or "targets" not in value:
+                continue
+            merged = dict(local)
+            for k, v in value.items():
+                if is_value_type(v):
+                    merged[k] = v
+            merged["targets"] = value["targets"]
+            leaves[key].append(merged)
+        for value in d.values():
+            if not isinstance(value, dict) or "targets" in value:
+                continue
+            walk(value, local)
+
+    walk(node, {})
+    return leaves
 
 
 class LibraryYaml:
@@ -188,12 +235,20 @@ class LibraryYaml:
             logger.debug("Could not load existing Windows properties, proceeding without")
             windows_libraries = {}
 
-        reorganised_libs: dict[str, set] = dict()
+        # Walk the c++ tree recursively. Any dict carrying a `targets` list is a leaf
+        # (a library); every other dict is a grouping node (e.g. `nightly:` or `beman:`).
+        # The same libid can appear in multiple groupings, so we keep all libdefs per id.
+        libleaves: dict[str, list[dict]] = collect_library_leaves(self.yaml_doc["libraries"]["c++"])
 
         # id's in the yaml file are more unique than the ones in the linux (amazon) properties file (example boost & boost_bin)
-        #  so we need to map them to the linux properties file using the .lookupname used in the linux properties file
-        libraries_for_language = self.yaml_doc["libraries"]["c++"]
-        for libid in libraries_for_language:
+        #  so we need to map them to the linux properties file using the .lookupname used in the linux properties file.
+        # Track yaml libids per linux lookupname in insertion order (using dict-as-ordered-set)
+        # so the resulting version order is deterministic.
+        reorganised_libs: dict[str, dict[str, None]] = dict()
+        for libid, libdefs in libleaves.items():
+            if all(should_skip_library_for_windows(libid, libdef) for libdef in libdefs):
+                continue
+
             linux_libid = libid
             lookupname = libid
             if linux_libid not in linux_libraries:
@@ -203,29 +258,19 @@ class LibraryYaml:
                     lookupname = "catch2"
                 else:
                     lookupname = self.get_possible_lookupname(linux_libraries, linux_libid)
-            if should_skip_library_for_windows(lookupname, libraries_for_language[libid]):
+
+            # Only emit libs we already know about on either platform. Recursing into
+            # nested groupings can surface keys (e.g. flavor names like microsoft/ngcpp
+            # under c++.proxy) that aren't standalone libraries -- skip those rather
+            # than producing stub entries that would pollute the merged Windows config.
+            if lookupname not in linux_libraries and lookupname not in windows_libraries:
                 continue
 
             if lookupname not in reorganised_libs:
-                reorganised_libs[lookupname] = set()
+                reorganised_libs[lookupname] = dict()
 
             logger.debug(f"Mapping {linux_libid} to {lookupname}")
-            reorganised_libs[lookupname].add(linux_libid)
-
-        nightly_libraries_for_language = self.yaml_doc["libraries"]["c++"]["nightly"]
-        for libid in nightly_libraries_for_language:
-            linux_libid = libid
-            lookupname = libid
-            if linux_libid not in linux_libraries:
-                lookupname = self.get_possible_lookupname(linux_libraries, linux_libid)
-            if should_skip_library_for_windows(lookupname, nightly_libraries_for_language[libid]):
-                continue
-
-            if lookupname not in reorganised_libs:
-                reorganised_libs[lookupname] = set()
-
-            logger.debug(f"Mapping {linux_libid} to {lookupname}")
-            reorganised_libs[lookupname].add(linux_libid)
+            reorganised_libs[lookupname][linux_libid] = None
 
         for linux_libid, yamllibids in reorganised_libs.items():
             linux_lib = linux_libraries[linux_libid]
@@ -248,16 +293,9 @@ class LibraryYaml:
 
             all_libver_ids: list[str] = []
             for yamllibid in yamllibids:
-                if yamllibid in libraries_for_language:
-                    if "targets" in libraries_for_language[yamllibid]:
-                        for libver in libraries_for_language[yamllibid]["targets"]:
-                            all_libver_ids.append(self.get_libverid(libver, linux_lib, existing_lib))
-                if yamllibid in nightly_libraries_for_language:
-                    if not isinstance(nightly_libraries_for_language[yamllibid], dict):
-                        continue
-                    if "targets" in nightly_libraries_for_language[yamllibid]:
-                        for libver in nightly_libraries_for_language[yamllibid]["targets"]:
-                            all_libver_ids.append(self.get_libverid(libver, linux_lib, existing_lib))
+                for libdef in libleaves.get(yamllibid, []):
+                    for libver in libdef["targets"]:
+                        all_libver_ids.append(self.get_libverid(libver, linux_lib, existing_lib))
 
             versions_property_key = generate_library_property_key(linux_libid, "versions")
             libverprops += f"{versions_property_key}="
@@ -268,51 +306,21 @@ class LibraryYaml:
             libverprops += self.get_link_props(linux_lib, prefix)
 
             for yamllibid in yamllibids:
-                if yamllibid in libraries_for_language:
-                    if "targets" in libraries_for_language[yamllibid]:
-                        for libver in libraries_for_language[yamllibid]["targets"]:
-                            all_libver_ids.append(self.get_libverid(libver, linux_lib, existing_lib))
-
-                        for libver in libraries_for_language[yamllibid]["targets"]:
-                            libverid = self.get_libverid(libver, linux_lib, existing_lib)
-                            libvername = self.get_libvername(libver, linux_lib, existing_lib)
-                            version_property_key = generate_version_property_key(linux_libid, libverid, "version")
-                            libverprops += f"{version_property_key}={libvername}\n"
+                for libdef in libleaves.get(yamllibid, []):
+                    for libver in libdef["targets"]:
+                        libverid = self.get_libverid(libver, linux_lib, existing_lib)
+                        libvername = self.get_libvername(libver, linux_lib, existing_lib)
+                        version_property_key = generate_version_property_key(linux_libid, libverid, "version")
+                        libverprops += f"{version_property_key}={libvername}\n"
+                        linux_lib_version = get_specific_library_version_details(linux_libraries, linux_libid, libverid)
+                        if not linux_lib_version:
                             linux_lib_version = get_specific_library_version_details(
-                                linux_libraries, linux_libid, libverid
+                                linux_libraries, linux_libid, libvername
                             )
-                            if not linux_lib_version:
-                                linux_lib_version = get_specific_library_version_details(
-                                    linux_libraries, linux_libid, libvername
-                                )
 
-                            prefix = generate_version_property_key(linux_libid, libverid, "")
-                            prefix = prefix.rstrip(".")
-                            libverprops += self.get_link_props(linux_lib_version, prefix)
-
-                if yamllibid in nightly_libraries_for_language:
-                    if not isinstance(nightly_libraries_for_language[yamllibid], dict):
-                        continue
-                    if "targets" in nightly_libraries_for_language[yamllibid]:
-                        for libver in nightly_libraries_for_language[yamllibid]["targets"]:
-                            all_libver_ids.append(self.get_libverid(libver, linux_lib, existing_lib))
-
-                        for libver in nightly_libraries_for_language[yamllibid]["targets"]:
-                            libverid = self.get_libverid(libver, linux_lib, existing_lib)
-                            libvername = self.get_libvername(libver, linux_lib, existing_lib)
-                            version_property_key = generate_version_property_key(linux_libid, libverid, "version")
-                            libverprops += f"{version_property_key}={libvername}\n"
-                            linux_lib_version = get_specific_library_version_details(
-                                linux_libraries, linux_libid, libverid
-                            )
-                            if not linux_lib_version:
-                                linux_lib_version = get_specific_library_version_details(
-                                    linux_libraries, linux_libid, libvername
-                                )
-
-                            prefix = generate_version_property_key(linux_libid, libverid, "")
-                            prefix = prefix.rstrip(".")
-                            libverprops += self.get_link_props(linux_lib_version, prefix)
+                        prefix = generate_version_property_key(linux_libid, libverid, "")
+                        prefix = prefix.rstrip(".")
+                        libverprops += self.get_link_props(linux_lib_version, prefix)
 
             properties_txt += libverprops + "\n"
 

--- a/bin/test/library_yaml_test.py
+++ b/bin/test/library_yaml_test.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 
-from lib.library_yaml import LibraryYaml
+from lib.library_yaml import LibraryYaml, collect_library_leaves
 
 
 def make_lib_props(versions: dict) -> dict:
@@ -134,3 +134,55 @@ class TestGetLibvername:
         linux_lib = make_lib_props({"197": {"version": "19.7", "lookupversion": "v19.7"}})
         yaml = LibraryYaml.__new__(LibraryYaml)
         assert yaml.get_libvername({"name": "v19.7"}, linux_lib) == "19.7"
+
+
+class TestCollectLibraryLeaves:
+    def test_finds_top_level_leaves(self):
+        leaves = collect_library_leaves({"foo": {"targets": ["1.0"]}, "bar": {"targets": ["2.0"]}})
+        assert set(leaves.keys()) == {"foo", "bar"}
+        assert leaves["foo"][0]["targets"] == ["1.0"]
+
+    def test_grouping_node_recursed_into(self):
+        leaves = collect_library_leaves({"group": {"foo": {"targets": ["1.0"]}}})
+        assert "group" not in leaves
+        assert leaves["foo"][0]["targets"] == ["1.0"]
+
+    def test_inherits_scalar_props_from_grouping(self):
+        leaves = collect_library_leaves({
+            "group": {"build_type": "cmake", "type": "github", "foo": {"targets": ["1.0"]}}
+        })
+        libdef = leaves["foo"][0]
+        assert libdef["build_type"] == "cmake"
+        assert libdef["type"] == "github"
+
+    def test_inherits_list_props_from_grouping(self):
+        leaves = collect_library_leaves({"group": {"extra_cmake_arg": ["-DFOO=1"], "foo": {"targets": ["1.0"]}}})
+        assert leaves["foo"][0]["extra_cmake_arg"] == ["-DFOO=1"]
+
+    def test_leaf_overrides_inherited(self):
+        leaves = collect_library_leaves({
+            "group": {"build_type": "none", "foo": {"build_type": "cmake", "targets": ["1.0"]}}
+        })
+        assert leaves["foo"][0]["build_type"] == "cmake"
+
+    def test_same_libid_in_multiple_groupings(self):
+        leaves = collect_library_leaves({
+            "foo": {"targets": ["1.0"]},
+            "nightly": {"foo": {"targets": ["trunk"]}},
+        })
+        assert len(leaves["foo"]) == 2
+        # Outer-level leaf is recorded before the one inside the nested grouping.
+        assert leaves["foo"][0]["targets"] == ["1.0"]
+        assert leaves["foo"][1]["targets"] == ["trunk"]
+
+    def test_deeply_nested(self):
+        leaves = collect_library_leaves({"outer": {"target_prefix": "v", "inner": {"foo": {"targets": ["1.0"]}}}})
+        assert leaves["foo"][0]["target_prefix"] == "v"
+        assert leaves["foo"][0]["targets"] == ["1.0"]
+
+    def test_targets_key_makes_a_leaf_even_with_dict_children(self):
+        # If a node has both `targets` and dict children, the node itself is treated
+        # as a library leaf. Children are not recursed into.
+        leaves = collect_library_leaves({"foo": {"targets": ["1.0"], "child": {"targets": ["2.0"]}}})
+        assert "foo" in leaves
+        assert "child" not in leaves

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -325,6 +325,160 @@ libraries:
       targets:
       - 4.31.0.0
       type: github
+    beman_any_view:
+      build_type: none
+      check_file: README.md
+      repo: bemanproject/any_view
+      target_prefix: v
+      targets:
+      - name: 1.0.0
+        target_prefix: ''
+      - 1.1.0
+      type: github
+    beman_cache_latest:
+      build_type: none
+      check_file: README.md
+      repo: bemanproject/cache_latest
+      target_prefix: v
+      targets:
+      - 0.1.0
+      type: github
+    beman_copyable_function:
+      build_type: none
+      check_file: README.md
+      repo: bemanproject/copyable_function
+      target_prefix: v
+      targets:
+      - 0.1.0
+      type: github
+    beman_cstring_view:
+      build_type: none
+      check_file: README.md
+      repo: bemanproject/cstring_view
+      target_prefix: v
+      targets:
+      - 0.1.0
+      type: github
+    beman_exemplar:
+      build_type: none
+      check_file: README.md
+      repo: bemanproject/exemplar
+      target_prefix: v
+      targets:
+      - name: 1.0.0
+        target_prefix: ''
+      - name: 2.0.0
+        target_prefix: ''
+      - name: 2.1.0
+        target_prefix: ''
+      - name: 2.1.1
+        target_prefix: ''
+      - name: 2.2.0
+        target_prefix: ''
+      - name: 2.2.1
+        target_prefix: ''
+      - 2.3.0
+      - 2.4.0
+      type: github
+    beman_indices_view:
+      build_type: none
+      check_file: README.md
+      repo: bemanproject/indices_view
+      target_prefix: v
+      targets:
+      - 0.1.0
+      type: github
+    beman_inplace_vector:
+      build_type: none
+      check_file: README.md
+      repo: bemanproject/inplace_vector
+      target_prefix: v
+      targets:
+      - 0.1.0
+      type: github
+    beman_iterator_interface:
+      after_stage_script:
+      - sed -i 's/add_subdirectory(examples)//g' CMakeLists.txt
+      build_type: cmake
+      check_file: README.md
+      extra_cmake_arg:
+      - -DBUILD_TESTING=OFF
+      lib_type: static
+      package_install: true
+      repo: bemanproject/iterator_interface
+      staticliblink:
+      - beman.iterator_interface
+      target_prefix: v
+      targets:
+      - 0.1.0
+      type: github
+    beman_monadics:
+      build_type: none
+      check_file: README.md
+      repo: bemanproject/monadics
+      target_prefix: v
+      targets:
+      - 0.1.0
+      - 1.0.0
+      type: github
+    beman_optional:
+      build_type: none
+      check_file: README.md
+      repo: bemanproject/optional
+      target_prefix: v
+      targets:
+      - 1.0.0
+      type: github
+    beman_scan_view:
+      build_type: none
+      check_file: README.md
+      repo: bemanproject/scan_view
+      target_prefix: v
+      targets:
+      - 0.1.0
+      type: github
+    beman_scope:
+      build_type: none
+      check_file: README.md
+      repo: bemanproject/scope
+      targets:
+      - 0.0.1
+      type: github
+    beman_take_before:
+      build_type: none
+      check_file: README.md
+      repo: bemanproject/take_before
+      target_prefix: v
+      targets:
+      - 0.1.0
+      type: github
+    beman_timed_lock_alg:
+      build_type: none
+      check_file: README.md
+      repo: bemanproject/timed_lock_alg
+      target_prefix: v
+      targets:
+      - 1.0.0
+      - 1.1.0
+      type: github
+    beman_transform_view:
+      build_type: none
+      check_file: README.md
+      repo: bemanproject/transform_view
+      target_prefix: v
+      targets:
+      - 0.1.0
+      - 0.2.0
+      type: github
+    beman_utf_view:
+      build_type: none
+      check_file: README.md
+      repo: bemanproject/utf_view
+      target_prefix: v
+      targets:
+      - 0.1.0
+      - 0.2.0
+      type: github
     benchmark:
       build_type: cmake
       extra_cmake_arg:

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -325,160 +325,89 @@ libraries:
       targets:
       - 4.31.0.0
       type: github
-    beman_any_view:
+    beman:
       build_type: none
       check_file: README.md
-      repo: bemanproject/any_view
+      repo: bemanproject/{{ context[-1].removeprefix('beman_') }}
       target_prefix: v
-      targets:
-      - name: 1.0.0
+      type: github
+      beman_any_view:
+        targets:
+        - name: 1.0.0
+          target_prefix: ''
+        - 1.1.0
+      beman_cache_latest:
+        targets:
+        - 0.1.0
+      beman_copyable_function:
+        targets:
+        - 0.1.0
+      beman_cstring_view:
+        targets:
+        - 0.1.0
+      beman_exemplar:
+        targets:
+        - name: 1.0.0
+          target_prefix: ''
+        - name: 2.0.0
+          target_prefix: ''
+        - name: 2.1.0
+          target_prefix: ''
+        - name: 2.1.1
+          target_prefix: ''
+        - name: 2.2.0
+          target_prefix: ''
+        - name: 2.2.1
+          target_prefix: ''
+        - 2.3.0
+        - 2.4.0
+      beman_indices_view:
+        targets:
+        - 0.1.0
+      beman_inplace_vector:
+        targets:
+        - 0.1.0
+      beman_iterator_interface:
+        after_stage_script:
+        - sed -i 's/add_subdirectory(examples)//g' CMakeLists.txt
+        build_type: cmake
+        extra_cmake_arg:
+        - -DBUILD_TESTING=OFF
+        lib_type: static
+        package_install: true
+        staticliblink:
+        - beman.iterator_interface
+        targets:
+        - 0.1.0
+      beman_monadics:
+        targets:
+        - 0.1.0
+        - 1.0.0
+      beman_optional:
+        targets:
+        - 1.0.0
+      beman_scan_view:
+        targets:
+        - 0.1.0
+      beman_scope:
         target_prefix: ''
-      - 1.1.0
-      type: github
-    beman_cache_latest:
-      build_type: none
-      check_file: README.md
-      repo: bemanproject/cache_latest
-      target_prefix: v
-      targets:
-      - 0.1.0
-      type: github
-    beman_copyable_function:
-      build_type: none
-      check_file: README.md
-      repo: bemanproject/copyable_function
-      target_prefix: v
-      targets:
-      - 0.1.0
-      type: github
-    beman_cstring_view:
-      build_type: none
-      check_file: README.md
-      repo: bemanproject/cstring_view
-      target_prefix: v
-      targets:
-      - 0.1.0
-      type: github
-    beman_exemplar:
-      build_type: none
-      check_file: README.md
-      repo: bemanproject/exemplar
-      target_prefix: v
-      targets:
-      - name: 1.0.0
-        target_prefix: ''
-      - name: 2.0.0
-        target_prefix: ''
-      - name: 2.1.0
-        target_prefix: ''
-      - name: 2.1.1
-        target_prefix: ''
-      - name: 2.2.0
-        target_prefix: ''
-      - name: 2.2.1
-        target_prefix: ''
-      - 2.3.0
-      - 2.4.0
-      type: github
-    beman_indices_view:
-      build_type: none
-      check_file: README.md
-      repo: bemanproject/indices_view
-      target_prefix: v
-      targets:
-      - 0.1.0
-      type: github
-    beman_inplace_vector:
-      build_type: none
-      check_file: README.md
-      repo: bemanproject/inplace_vector
-      target_prefix: v
-      targets:
-      - 0.1.0
-      type: github
-    beman_iterator_interface:
-      after_stage_script:
-      - sed -i 's/add_subdirectory(examples)//g' CMakeLists.txt
-      build_type: cmake
-      check_file: README.md
-      extra_cmake_arg:
-      - -DBUILD_TESTING=OFF
-      lib_type: static
-      package_install: true
-      repo: bemanproject/iterator_interface
-      staticliblink:
-      - beman.iterator_interface
-      target_prefix: v
-      targets:
-      - 0.1.0
-      type: github
-    beman_monadics:
-      build_type: none
-      check_file: README.md
-      repo: bemanproject/monadics
-      target_prefix: v
-      targets:
-      - 0.1.0
-      - 1.0.0
-      type: github
-    beman_optional:
-      build_type: none
-      check_file: README.md
-      repo: bemanproject/optional
-      target_prefix: v
-      targets:
-      - 1.0.0
-      type: github
-    beman_scan_view:
-      build_type: none
-      check_file: README.md
-      repo: bemanproject/scan_view
-      target_prefix: v
-      targets:
-      - 0.1.0
-      type: github
-    beman_scope:
-      build_type: none
-      check_file: README.md
-      repo: bemanproject/scope
-      targets:
-      - 0.0.1
-      type: github
-    beman_take_before:
-      build_type: none
-      check_file: README.md
-      repo: bemanproject/take_before
-      target_prefix: v
-      targets:
-      - 0.1.0
-      type: github
-    beman_timed_lock_alg:
-      build_type: none
-      check_file: README.md
-      repo: bemanproject/timed_lock_alg
-      target_prefix: v
-      targets:
-      - 1.0.0
-      - 1.1.0
-      type: github
-    beman_transform_view:
-      build_type: none
-      check_file: README.md
-      repo: bemanproject/transform_view
-      target_prefix: v
-      targets:
-      - 0.1.0
-      - 0.2.0
-      type: github
-    beman_utf_view:
-      build_type: none
-      check_file: README.md
-      repo: bemanproject/utf_view
-      target_prefix: v
-      targets:
-      - 0.1.0
-      - 0.2.0
-      type: github
+        targets:
+        - 0.0.1
+      beman_take_before:
+        targets:
+        - 0.1.0
+      beman_timed_lock_alg:
+        targets:
+        - 1.0.0
+        - 1.1.0
+      beman_transform_view:
+        targets:
+        - 0.1.0
+        - 0.2.0
+      beman_utf_view:
+        targets:
+        - 0.1.0
+        - 0.2.0
     benchmark:
       build_type: cmake
       extra_cmake_arg:

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -328,7 +328,7 @@ libraries:
     beman:
       build_type: none
       check_file: README.md
-      repo: bemanproject/{{ context[-1].removeprefix('beman_') }}
+      repo: bemanproject/{{ context[-1] | replace('beman_', '', 1) }}
       target_prefix: v
       type: github
       beman_any_view:
@@ -1506,182 +1506,84 @@ libraries:
         targets:
         - trunk
         type: github
-      beman_any_view:
+      beman:
         build_type: none
         check_file: README.md
         method: nightlyclone
-        repo: bemanproject/any_view
-        targets:
-        - main
+        repo: bemanproject/{{ context[-1] | replace('beman_', '', 1) }}
         type: github
-      beman_cache_latest:
-        build_type: none
-        check_file: README.md
-        method: nightlyclone
-        repo: bemanproject/cache_latest
-        targets:
-        - main
-        type: github
-      beman_copyable_function:
-        build_type: none
-        check_file: README.md
-        method: nightlyclone
-        repo: bemanproject/copyable_function
-        targets:
-        - main
-        type: github
-      beman_cstring_view:
-        build_type: none
-        check_file: README.md
-        method: nightlyclone
-        repo: bemanproject/cstring_view
-        targets:
-        - main
-        type: github
-      beman_execution:
-        build_type: none
-        check_file: README.md
-        method: nightlyclone
-        repo: bemanproject/execution
-        targets:
-        - main
-        type: github
-      beman_exemplar:
-        build_type: none
-        check_file: README.md
-        method: nightlyclone
-        repo: bemanproject/exemplar
-        targets:
-        - main
-        type: github
-      beman_indices_view:
-        build_type: none
-        check_file: README.md
-        method: nightlyclone
-        repo: bemanproject/indices_view
-        targets:
-        - main
-        type: github
-      beman_inplace_vector:
-        build_type: none
-        check_file: README.md
-        method: nightlyclone
-        repo: bemanproject/inplace_vector
-        targets:
-        - main
-        type: github
-      beman_iterator_interface:
-        after_stage_script:
-        - sed -i 's/add_subdirectory(examples)//g' CMakeLists.txt
-        build_type: cmake
-        check_file: README.md
-        extra_cmake_arg:
-        - -DBUILD_TESTING=OFF
-        lib_type: static
-        method: nightlyclone
-        package_install: true
-        repo: bemanproject/iterator_interface
-        staticliblink:
-        - beman.iterator_interface
-        targets:
-        - main
-        type: github
-      beman_map:
-        build_type: none
-        check_file: README.md
-        method: nightlyclone
-        repo: bemanproject/map
-        targets:
-        - main
-        type: github
-      beman_monadics:
-        build_type: none
-        check_file: README.md
-        method: nightlyclone
-        repo: bemanproject/monadics
-        targets:
-        - main
-        type: github
-      beman_net:
-        build_type: none
-        check_file: README.md
-        method: nightlyclone
-        repo: bemanproject/net
-        targets:
-        - main
-        type: github
-      beman_optional:
-        build_type: none
-        check_file: README.md
-        method: nightlyclone
-        repo: bemanproject/optional
-        targets:
-        - main
-        type: github
-      beman_scan_view:
-        build_type: none
-        check_file: README.md
-        method: nightlyclone
-        repo: bemanproject/scan_view
-        targets:
-        - main
-        type: github
-      beman_scope:
-        build_type: none
-        check_file: README.md
-        method: nightlyclone
-        repo: bemanproject/scope
-        targets:
-        - main
-        type: github
-      beman_span:
-        build_type: none
-        check_file: README.md
-        method: nightlyclone
-        repo: bemanproject/span
-        targets:
-        - main
-        type: github
-      beman_take_before:
-        build_type: none
-        check_file: README.md
-        method: nightlyclone
-        repo: bemanproject/take_before
-        targets:
-        - main
-        type: github
-      beman_task:
-        build_type: none
-        check_file: README.md
-        method: nightlyclone
-        repo: bemanproject/task
-        targets:
-        - main
-        type: github
-      beman_timed_lock_alg:
-        build_type: none
-        check_file: README.md
-        method: nightlyclone
-        repo: bemanproject/timed_lock_alg
-        targets:
-        - main
-        type: github
-      beman_transform_view:
-        build_type: none
-        check_file: README.md
-        method: nightlyclone
-        repo: bemanproject/transform_view
-        targets:
-        - main
-        type: github
-      beman_utf_view:
-        build_type: none
-        check_file: README.md
-        method: nightlyclone
-        repo: bemanproject/utf_view
-        targets:
-        - main
-        type: github
+        beman_any_view:
+          targets:
+          - main
+        beman_cache_latest:
+          targets:
+          - main
+        beman_copyable_function:
+          targets:
+          - main
+        beman_cstring_view:
+          targets:
+          - main
+        beman_execution:
+          targets:
+          - main
+        beman_exemplar:
+          targets:
+          - main
+        beman_indices_view:
+          targets:
+          - main
+        beman_inplace_vector:
+          targets:
+          - main
+        beman_iterator_interface:
+          after_stage_script:
+          - sed -i 's/add_subdirectory(examples)//g' CMakeLists.txt
+          build_type: cmake
+          extra_cmake_arg:
+          - -DBUILD_TESTING=OFF
+          lib_type: static
+          package_install: true
+          staticliblink:
+          - beman.iterator_interface
+          targets:
+          - main
+        beman_map:
+          targets:
+          - main
+        beman_monadics:
+          targets:
+          - main
+        beman_net:
+          targets:
+          - main
+        beman_optional:
+          targets:
+          - main
+        beman_scan_view:
+          targets:
+          - main
+        beman_scope:
+          targets:
+          - main
+        beman_span:
+          targets:
+          - main
+        beman_take_before:
+          targets:
+          - main
+        beman_task:
+          targets:
+          - main
+        beman_timed_lock_alg:
+          targets:
+          - main
+        beman_transform_view:
+          targets:
+          - main
+        beman_utf_view:
+          targets:
+          - main
       benchmark:
         build_type: cmake
         check_file: README.md


### PR DESCRIPTION
## Summary
- The existing beman entries under the `nightly:` group only install the `main` branch.
- This adds matching non-nightly entries for each `bemanproject/*` repo that has tags, fetched via the default `archive` method so each tag becomes a real directory under `/opt/compiler-explorer/libs/beman_<lib>/`.
- Repos without tags (execution, map, net, span, task) are left as nightly-only.

## Refactor: shared parent for beman entries

Both the new tagged block and the existing `nightly:` block had a lot of repetition (every entry had the same `build_type`, `check_file`, `type`, `method` where applicable, and a `repo: bemanproject/<name>` line). Both are now grouped under a single `beman:` parent that declares the common settings once and templates the repo as `bemanproject/{{ context[-1] | replace('beman_', '', 1) }}`. Per-target `target_prefix: ''` overrides handle the small number of tags that don't carry a `v` prefix; `beman_iterator_interface` and `beman_scope` keep their genuine per-entry overrides. The grouping changes the ce_install filter path (`libraries/c++/beman/...` and `libraries/c++/nightly/beman/...`) but does **not** change install paths -- every install directory is byte-for-byte identical to the pre-refactor tree (verified locally for both 28 tagged and 21 nightly targets).

## Helper fix: `get_ce_properties_for_cpp_windows_libraries` now recurses

The Windows properties generator hand-iterated only the immediate children of `c++` and `c++.nightly`, so introducing any new grouping (e.g. `c++.beman:`) silently dropped libs from its output. It now uses a recursive `collect_library_leaves` walker that mirrors the inheritance rules in `installation._targets_from`. The walker is two-pass at each level (leaves before descents) so the version order in the merged Windows properties stays stable for libs that appear in both top-level and nested groupings. A known-lib guard prevents nested flavor names like `microsoft`/`ngcpp` under the existing `c++.proxy` group from being emitted as spurious standalone entries, and `reorganised_libs` is now an insertion-ordered dict instead of a set so the output is deterministic. `ce_install cpp-library generate-windows-props` against pristine main differs only by the expected new `beman_iterator_interface` 0.1.0 entry and a deterministic reorder of the `catch2` versions list. New unit tests cover the walker directly.

## Test plan
- [x] Locally `ce_install --dest ~/opt/compiler-explorer install 'libraries/c++/beman/**'` installs all 28 tagged versions cleanly
- [x] Locally `ce_install --enable nightly --dest /tmp/beman_nightly install 'libraries/c++/nightly/beman/**'` installs all 21 trunk versions cleanly
- [x] Spot-checked install trees contain the expected `include/` (`beman_iterator_interface/v0.1.0`, `beman_monadics/v0.1.0`)
- [x] Diffed install layouts post-refactor against the pre-refactor install -- 100% identical
- [x] `make test` passes (684 tests + 8 new tests for `collect_library_leaves`)
- [x] `make pre-commit` passes (terraform hooks fail in my local env without terraform installed; everything else is green)
- [ ] Companion compiler-explorer PR adds the version entries in `c++.amazon.properties`