### PR TITLE
Add cmake_built_headeronly lib_type; fix beman_iterator_interface build

### DIFF
--- a/.github/workflows/lin-lib-build.yaml
+++ b/.github/workflows/lin-lib-build.yaml
@@ -65,6 +65,9 @@ jobs:
 
           echo "language=$LANGUAGE" >> $GITHUB_OUTPUT
           echo "library_name=$LIBRARY_NAME" >> $GITHUB_OUTPUT
+          # actions/upload-artifact rejects forward slashes in artifact names, so
+          # provide a sanitized variant for use in the failure-artifact step.
+          echo "library_safe=${LIBRARY_NAME//\//-}" >> $GITHUB_OUTPUT
           echo "Detected language: $LANGUAGE, library: $LIBRARY_NAME"
 
       - name: Download build script
@@ -77,7 +80,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: build-failure-${{ inputs.compiler }}-${{ steps.extract.outputs.library_name }}-${{ github.run_id }}
+          name: build-failure-${{ inputs.compiler }}-${{ steps.extract.outputs.library_safe }}-${{ github.run_id }}
           path: |
             /tmp/*.cpp
             /tmp/*.ii

--- a/bin/lib/library_build_config.py
+++ b/bin/lib/library_build_config.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from lib.installation_context import is_windows
 
-valid_lib_types = ["static", "shared", "cshared", "headeronly"]
+valid_lib_types = ["static", "shared", "cshared", "headeronly", "cmake_built_headeronly"]
 
 
 class LibraryBuildConfig:
@@ -22,6 +22,19 @@ class LibraryBuildConfig:
             raise RuntimeError(
                 f"Header-only libraries should not have staticliblink or sharedliblink {self.staticliblink} {self.sharedliblink}"
             )
+        if self.lib_type == "cmake_built_headeronly":
+            if self.staticliblink != [] or self.sharedliblink != []:
+                raise RuntimeError(
+                    "cmake_built_headeronly libraries should not have staticliblink or sharedliblink "
+                    f"{self.staticliblink} {self.sharedliblink}"
+                )
+            if self.build_type != "cmake":
+                raise RuntimeError(f"cmake_built_headeronly requires build_type: cmake (got {self.build_type})")
+            if not self.config_get("package_install", False):
+                raise RuntimeError(
+                    "cmake_built_headeronly requires package_install: true so the configured "
+                    "headers from `cmake --install` land in the install tree."
+                )
         self.url = "None"
         self.description = ""
         self.configure_flags = self.config_get("configure_flags", [])

--- a/bin/lib/library_builder.py
+++ b/bin/lib/library_builder.py
@@ -1608,8 +1608,10 @@ class LibraryBuilder:
         build_status = self.executebuildscript(build_folder)
         if build_status == BuildStatus.Ok:
             if self.buildconfig.package_install:
-                if self.buildconfig.lib_type == "headeronly":
-                    self.logger.debug("Header only library, no binaries to upload")
+                if self.buildconfig.lib_type in ("headeronly", "cmake_built_headeronly"):
+                    # No archive/shared object expected: validate the cmake-install
+                    # tree by counting the headers it placed under include/.
+                    self.logger.debug(f"{self.buildconfig.lib_type} library, no binaries to upload")
                     filesfound = self.countHeaders(Path(install_folder) / "include")
                 else:
                     filesfound = self.countValidLibraryBinaries(
@@ -1769,6 +1771,12 @@ class LibraryBuilder:
             else:
                 self.logger.info("Header-only library, no need to build")
                 return [builds_succeeded, 1, builds_failed]
+        elif self.buildconfig.lib_type == "cmake_built_headeronly":
+            # Header-only on disk, but the build script must run per-compiler so
+            # configure_file substitutions and generated CMake package config files
+            # land in the install tree. Fall through to the per-compiler loop;
+            # makebuildfor counts headers (not binaries) for this lib_type.
+            self.logger.info("Header-only library that needs a per-compiler cmake build for configured artifacts")
         elif buildfor == "nonx86":
             self.forcebuild = True
             checkcompiler = ""

--- a/bin/test/library_build_config_test.py
+++ b/bin/test/library_build_config_test.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pytest
+from lib.library_build_config import LibraryBuildConfig
+
+
+def _config(**overrides):
+    base = {"build_type": "none"}
+    base.update(overrides)
+    return base
+
+
+class TestLibTypeValidation:
+    def test_default_lib_type_is_headeronly(self):
+        cfg = LibraryBuildConfig(_config())
+        assert cfg.lib_type == "headeronly"
+
+    def test_invalid_lib_type_rejected(self):
+        with pytest.raises(RuntimeError, match="not a valid lib_type"):
+            LibraryBuildConfig(_config(lib_type="bogus"))
+
+    def test_headeronly_forbids_staticliblink(self):
+        with pytest.raises(RuntimeError, match="should not have staticliblink"):
+            LibraryBuildConfig(_config(lib_type="headeronly", staticliblink=["foo"]))
+
+    def test_headeronly_forbids_sharedliblink(self):
+        with pytest.raises(RuntimeError, match="should not have staticliblink or sharedliblink"):
+            LibraryBuildConfig(_config(lib_type="headeronly", sharedliblink=["foo"]))
+
+
+class TestCmakeBuiltHeaderonly:
+    def test_minimum_valid_config(self):
+        cfg = LibraryBuildConfig(_config(lib_type="cmake_built_headeronly", build_type="cmake", package_install=True))
+        assert cfg.lib_type == "cmake_built_headeronly"
+        assert cfg.package_install is True
+
+    def test_requires_cmake_build_type(self):
+        with pytest.raises(RuntimeError, match="requires build_type: cmake"):
+            LibraryBuildConfig(_config(lib_type="cmake_built_headeronly", build_type="none", package_install=True))
+
+    def test_requires_package_install(self):
+        with pytest.raises(RuntimeError, match="requires package_install: true"):
+            LibraryBuildConfig(_config(lib_type="cmake_built_headeronly", build_type="cmake"))
+
+    def test_forbids_staticliblink(self):
+        with pytest.raises(RuntimeError, match="should not have staticliblink"):
+            LibraryBuildConfig(
+                _config(
+                    lib_type="cmake_built_headeronly",
+                    build_type="cmake",
+                    package_install=True,
+                    staticliblink=["foo"],
+                )
+            )
+
+    def test_forbids_sharedliblink(self):
+        with pytest.raises(RuntimeError, match="should not have staticliblink or sharedliblink"):
+            LibraryBuildConfig(
+                _config(
+                    lib_type="cmake_built_headeronly",
+                    build_type="cmake",
+                    package_install=True,
+                    sharedliblink=["foo"],
+                )
+            )
+
+
+class TestCsharedValidation:
+    def test_cshared_requires_use_compiler(self):
+        with pytest.raises(RuntimeError, match="required to supply a .cross.compiler"):
+            LibraryBuildConfig(_config(lib_type="cshared"))

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -373,6 +373,8 @@ libraries:
         build_type: cmake
         extra_cmake_arg:
         - -DBUILD_TESTING=OFF
+        - -DBEMAN_ITERATOR_INTERFACE_BUILD_TESTS=OFF
+        - -DBEMAN_ITERATOR_INTERFACE_BUILD_EXAMPLES=OFF
         lib_type: static
         package_install: true
         staticliblink:
@@ -1542,6 +1544,8 @@ libraries:
           build_type: cmake
           extra_cmake_arg:
           - -DBUILD_TESTING=OFF
+          - -DBEMAN_ITERATOR_INTERFACE_BUILD_TESTS=OFF
+          - -DBEMAN_ITERATOR_INTERFACE_BUILD_EXAMPLES=OFF
           lib_type: static
           package_install: true
           staticliblink:

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -375,10 +375,8 @@ libraries:
         - -DBUILD_TESTING=OFF
         - -DBEMAN_ITERATOR_INTERFACE_BUILD_TESTS=OFF
         - -DBEMAN_ITERATOR_INTERFACE_BUILD_EXAMPLES=OFF
-        lib_type: static
+        lib_type: cmake_built_headeronly
         package_install: true
-        staticliblink:
-        - beman.iterator_interface
         targets:
         - 0.1.0
       beman_monadics:
@@ -1546,10 +1544,8 @@ libraries:
           - -DBUILD_TESTING=OFF
           - -DBEMAN_ITERATOR_INTERFACE_BUILD_TESTS=OFF
           - -DBEMAN_ITERATOR_INTERFACE_BUILD_EXAMPLES=OFF
-          lib_type: static
+          lib_type: cmake_built_headeronly
           package_install: true
-          staticliblink:
-          - beman.iterator_interface
           targets:
           - main
         beman_map:

--- a/docs/library_configuration.md
+++ b/docs/library_configuration.md
@@ -55,12 +55,53 @@ Set via `lib_type`. Determines what the build produces and how CE links the libr
 
 | Value | Description |
 |---|---|
-| `headeronly` | No compiled output. Source/headers only. Cannot have `staticliblink` or `sharedliblink`. |
+| `headeronly` | No compiled output. Source/headers only. Cannot have `staticliblink` or `sharedliblink`. The build pipeline early-returns for header-only libs on Linux -- no per-compiler build runs. |
+| `cmake_built_headeronly` | Header-only artifact (no `.a`/`.so`), but the cmake build script runs **per compiler** so that `configure_file` substitutions and generated CMake package config files end up in the install tree. Requires `build_type: cmake` and `package_install: true`; cannot have `staticliblink`/`sharedliblink`. See [cmake_built_headeronly in depth](#cmake_built_headeronly-in-depth). |
 | `static` | Produces static archives (`.a` / `.lib`). |
 | `shared` | Produces shared objects (`.so` / `.dll`) linked against C++ stdlib. |
 | `cshared` | C shared library with no C++ stdlib dependency. Requires `use_compiler`. See [cshared in depth](#cshared-in-depth). |
 
 Parsed and validated in `bin/lib/library_build_config.py:LibraryBuildConfig`.
+
+### `cmake_built_headeronly` in depth
+
+This is for libraries whose *shipped artifact* is a tree of headers (no compiled
+archive), but whose *build* genuinely needs to run cmake — typically because the
+upstream CMakeLists uses `configure_file` to substitute a `config.hpp.in`
+template, or because `cmake --install` writes generated CMake package config
+files (`lib/cmake/<name>/<name>-config.cmake` etc.) that downstream `find_package`
+consumers depend on.
+
+It is distinct from plain `headeronly` in two important ways:
+
+- **`headeronly`** assumes the headers are usable straight out of the source
+  clone. The build pipeline early-returns; the lib is installed once into
+  `/opt/compiler-explorer/libs/<lib>/<ver>/` and every compiler shares that
+  single tree.
+- **`cmake_built_headeronly`** runs the cmake configure / build / install per
+  (compiler, arch, libcxx) combination, exactly like a `static` lib would. The
+  install tree is uploaded to conan and CE delivers the right per-compiler
+  tarball at user-compile time. The only thing it skips is the
+  `countValidLibraryBinaries` step (which would fail on an INTERFACE-target
+  cmake project that produces no `.a`).
+
+It is distinct from `static` in that the build pipeline does not require a
+`lib<name>.a` archive to be produced; the post-build check uses `countHeaders`
+on `<install>/include` instead.
+
+Why it's `cmake_built_headeronly` rather than just `headeronly` + `build_type:
+cmake`: the two are *not* orthogonal in the existing codebase -- there are
+already libraries (fmt, googletest, catch2, benchmark, date, dlib, gcem, ...)
+that combine the implicit default `lib_type: headeronly` with `build_type:
+cmake`, and rely on the build being silently skipped. Making the existing
+`headeronly` honour `build_type` would change behaviour for all of those.
+`cmake_built_headeronly` is an explicit opt-in.
+
+CE properties for a `cmake_built_headeronly` library should use
+`packagedheaders=true` plus `lookupversion=<install-dir>` per version (the same
+pattern as a `packagedheaders=true` static lib), and must not declare
+`staticliblink`. See `libs.beman_iterator_interface` in
+`compiler-explorer/etc/config/c++.amazon.properties` for a worked example.
 
 ### `cshared` in depth
 


### PR DESCRIPTION
## Summary

This PR introduces a new library type, `cmake_built_headeronly`, for header-only libraries that still require a per-compiler cmake build (so `configure_file` substitutions and generated CMake config files land in the install tree). It then uses this lib_type to fix `beman_iterator_interface`, which is the motivating case.

### `cmake_built_headeronly` lib_type

Two existing lib_types were close but neither fits:

- `headeronly` — early-returns from `makebuild` and never invokes any build script. No way to run cmake.
- `static` / `shared` with `build_type: cmake` — runs cmake per-compiler, but `countValidLibraryBinaries` then looks for `lib<name>.a` / `lib<name>.so`, and an `add_library(... INTERFACE)` target produces neither. The build is reported as failed with "No binaries found to export".

`cmake_built_headeronly` runs the per-compiler cmake build like a static lib but counts headers (`countHeaders`) for the post-build success check, mirroring how `headeronly` would have validated the install tree if it ran one.

Validation is strict: requires `build_type: cmake`, requires `package_install: true`, and forbids `staticliblink`/`sharedliblink`. It is an explicit opt-in rather than something we infer from `headeronly + build_type: cmake`, because there are 14+ existing libraries (fmt, googletest, catch2, benchmark, dlib, gcem, etc.) that already silently combine `lib_type: headeronly` with `build_type: cmake` and would change behaviour if we made it implicit.

Files:
- `bin/lib/library_build_config.py` — adds the lib_type to `valid_lib_types`, validates the constraints above.
- `bin/lib/library_builder.py` — `makebuild` falls through (per-compiler iteration runs) instead of early-returning; `makebuildfor` reuses the `countHeaders(install/include)` check used for `headeronly`.
- `bin/test/library_build_config_test.py` (new) — 10 tests covering the validation rules.
- `docs/library_configuration.md` — table updated; in-depth section explains when to choose `cmake_built_headeronly` vs `headeronly` vs `static` and why it is opt-in.

### `beman_iterator_interface` fix

The library defines its own `BEMAN_ITERATOR_INTERFACE_BUILD_TESTS` / `BEMAN_ITERATOR_INTERFACE_BUILD_EXAMPLES` options that default to `ON` when `PROJECT_IS_TOP_LEVEL` is true (which is what happens when CE configures the build directly), so the standard `-DBUILD_TESTING=OFF` we were already passing doesn't actually suppress the `tests/` subdirectory. Tests then call `find_package(GTest)` which isn't present in the build sandbox, so configure failed for all 290 compiler/arch combinations — see https://github.com/compiler-explorer/infra/actions/runs/25510395360.

Once tests/examples were disabled, the configure succeeded but cmake produced an INTERFACE library (no `.a`), so the build was still reported as failed for "No binaries found to export". `cmake_built_headeronly` resolves the second half.

Both the tagged (`c++.beman.beman_iterator_interface`) and trunk (`c++.nightly.beman.beman_iterator_interface`) entries get the new lib_type and the explicit upstream options.

### Workflow fix

`actions/upload-artifact@v4` rejects `/` in artifact names, so `lin-lib-build.yaml` now exposes a `library_safe` extracted-output that sanitizes `/` → `-` for the failure-artifact upload step. This was hit when triggering a build for `libraries/c++/beman/beman_iterator_interface`.

## Test plan

- [x] `make static-checks` passes locally
- [x] New unit tests in `library_build_config_test.py` pass
- [x] Trigger `lin-lib-build.yaml` against this branch for `libraries/c++/beman/beman_iterator_interface` and confirm conan packages upload cleanly — run [25514037808](https://github.com/compiler-explorer/infra/actions/runs/25514037808): **281 packages built OK, 0 skipped, 9 failed**. The 9 failures are all CMake compiler-ABI-test failures on cross-compilers / very old GCCs (`g62`, `g127`, `armg14*`, `ppcg1520`, `rv32-gcc1520`, `edg-6_8-default-15`); the same compilers fail for 32–42 other major libraries each (abseil, bde, benchmark, boost_bin, …) and the project does not set `skip_compilers` for them.
- [ ] Verify a real compile against `beman_iterator_interface 0.1.0` resolves on prod once the build lands.