### PR TITLE
Fix thephd.dev nightly target names in cpp.yaml

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1700,7 +1700,7 @@ compilers:
           - contracts-GNUext-trunk
           - thomas-healy-trunk
           - trivial-relocation-trunk
-          - gcc.thephd.dev
+          - thephd.dev
       clang:
         type: nightly
         check_exe: bin/clang++ --version
@@ -1713,7 +1713,7 @@ compilers:
           - concepts-trunk
           - embed-trunk
           - dang-main
-          - clang.thephd.dev
+          - thephd.dev
           - widberg-main
           - mizvekov-resugar
           - relocatable-trunk


### PR DESCRIPTION
The new gcc.thephd.dev/clang.thephd.dev targets resolved to S3 lookups gcc-gcc.thephd.dev / clang-clang.thephd.dev (NightlyInstallable prefixes target_name with context[-1]), which don't exist. S3 has gcc-thephd.dev and clang-thephd.dev, so use thephd.dev as the target name under each.

The mismatch was silent because installers_for swallows the "Unable to find nightlies" RuntimeError as a warning.