### PR TITLE
Add `glibc` as a library

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -77,15 +77,14 @@ libraries:
       type: github
     glibc:
       after_stage_script:
+      - mv {{untar_dir}} src
       - mkdir -p build
       - cd build
-      - '../{{untar_dir}}/configure --prefix=/opt/compiler-explorer/libs/glibc/glibc-{{name}}'
+      - ../src/configure --prefix=/usr
       - make -j
-      - make install
-      - rm -rf ../{{untar_dir}}
-      - mkdir -p ../{{untar_dir}}
+      - make install DESTDIR=$(realpath ../{{untar_dir}})
       build_type: none
-      check_file: lib/libc.so
+      check_file: usr/lib64/libc.so
       compression: gz
       dir: libs/glibc/glibc-{{name}}
       lib_type: cshared

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -91,6 +91,7 @@ libraries:
       targets:
         - '2.16'
         - '2.41'
+        - '2.42'
       type: tarballs
       untar_dir: glibc-{{name}}
       url: https://ftp.gnu.org/gnu/glibc/glibc-{{name}}.tar.gz

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -90,7 +90,7 @@ libraries:
       lib_type: cshared
       targets:
         - '2.16'
-        - '2.42'
+        - '2.41'
       type: tarballs
       untar_dir: glibc-{{name}}
       url: https://ftp.gnu.org/gnu/glibc/glibc-{{name}}.tar.gz

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -75,6 +75,26 @@ libraries:
       targets:
       - 9.1.0
       type: github
+    glibc:
+      after_stage_script:
+      - mkdir -p build
+      - cd build
+      - '../{{untar_dir}}/configure --prefix=/opt/compiler-explorer/libs/glibc/glibc-{{name}}'
+      - make -j
+      - make install
+      - rm -rf ../{{untar_dir}}
+      build_type: none
+      check_file: lib/libc.so
+      compression: gz
+      dir: libs/glibc/glibc-{{name}}
+      lib_type: cshared
+      targets:
+        - '2.16'
+        - '2.42'
+      type: tarballs
+      untar_dir: glibc-{{name}}
+      url: https://ftp.gnu.org/gnu/glibc/glibc-{{name}}.tar.gz
+      use_compiler: g161
   c++:
     abseil:
       build_type: cmake

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -83,6 +83,7 @@ libraries:
       - make -j
       - make install
       - rm -rf ../{{untar_dir}}
+      - mkdir -p ../{{untar_dir}}
       build_type: none
       check_file: lib/libc.so
       compression: gz


### PR DESCRIPTION
I’m not quite sure how libraries work, so this only adds two versions of `glibc` as a test. If the build configuration works, I’d like to add more versions.

For https://github.com/compiler-explorer/compiler-explorer/issues/3103.