### PR TITLE
Add Triton 3.7.0

### DIFF
--- a/bin/yaml/triton.yaml
+++ b/bin/yaml/triton.yaml
@@ -12,6 +12,7 @@ compilers:
       - setuptools # Unfortunately, Triton 2.x requires this
     check_exe: [ "bin/python3.12", "-c", "import triton; print(triton.__version__)" ]
     targets:
+      - 3.7.0
       - 3.6.0
       - 3.5.1
       - 3.5.0


### PR DESCRIPTION
Summary:
- add Triton 3.7.0 to the Triton pip compiler targets

Validation:
- PYTHONPATH=bin PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -p no:cacheprovider bin/test/build_check_test.py
- python3 -c 'import yaml; yaml.safe_load(open("bin/yaml/triton.yaml", encoding="utf-8"))'