### PR TITLE
Add Mojo 0.26.2.0 and 1.0.0b1

### DIFF
--- a/bin/yaml/mojo.yaml
+++ b/bin/yaml/mojo.yaml
@@ -12,6 +12,8 @@ compilers:
       - 0.25.6.0
       - 0.25.7.0
       - 0.26.1.0
+      - 0.26.2.0
+      - 1.0.0b1
     nightly:
       if: nightly
       install_always: true


### PR DESCRIPTION
Add two Mojo versions that are available on PyPI but were missing from the targets list:

- 0.26.2.0
- 1.0.0b1

The existing 0.25.6.0, 0.25.7.0, and 0.26.1.0 targets are deliberately kept per [docs/AddingACompiler.md § "Don't remove or rename compilers on the public site"](https://github.com/compiler-explorer/compiler-explorer/blob/main/docs/AddingACompiler.md#dont-remove-or-rename-compilers-on-the-public-site).

Please let me know if we should be cleaning up old versions at some cadence.

Companion PR: compiler-explorer/compiler-explorer#8724