### PR TITLE
Speed up ce_install list (5.9s -> 2.2s)

### DIFF
--- a/bin/lib/amazon.py
+++ b/bin/lib/amazon.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
 from datetime import datetime
 from operator import attrgetter
 
@@ -16,21 +17,20 @@ class LazyObjectWrapper:
         self.__fn = fn
         self.__setup = False
         self.__obj = None
+        self.__lock = threading.Lock()
 
     def __ensure_setup(self):
-        if not self.__setup:
+        if self.__setup:
+            return
+        with self.__lock:
+            if self.__setup:
+                return
             self.__obj = self.__fn()
             self.__setup = True
 
     def __getattr__(self, attr):
         self.__ensure_setup()
         return getattr(self.__obj, attr)
-
-
-# this is a free function to avoid potentially shadowing any underlying members
-# which could happen if this was itself placed as a member of LazyObjectWrapper
-def force_lazy_init(lazy):
-    lazy._LazyObjectWrapper__ensure_setup()
 
 
 def _import_boto():

--- a/bin/lib/cdn.py
+++ b/bin/lib/cdn.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from tempfile import mkdtemp
 from zipfile import ZipFile
 
-from lib.amazon import botocore, force_lazy_init, s3_client
+from lib.amazon import botocore, s3_client
 
 logger = logging.getLogger("ce-cdn")
 
@@ -243,8 +243,6 @@ class DeploymentJob:
         return file
 
     def check_hashes(self):
-        force_lazy_init(s3_client)
-
         if ".zip" in self.tar_file_path:
             files = self.__unpack_zip()
         else:
@@ -269,9 +267,6 @@ class DeploymentJob:
 
     def run(self):
         logger.debug("running with %d workers", self.max_workers)
-
-        # work around race condition with parallel lazy init of boto3
-        force_lazy_init(s3_client)
 
         if ".zip" in self.tar_file_path:
             files = self.__unpack_zip()

--- a/bin/lib/config_expand.py
+++ b/bin/lib/config_expand.py
@@ -67,9 +67,11 @@ def expand_target(target: MutableMapping[str, Any], context: list[str]) -> Mutab
         for key, value in target.items():
             try:
                 if is_list_of_strings(value):
-                    target[key] = [expand_one(x, target) for x in value]
+                    if any(string_needs_expansion(x) for x in value):
+                        target[key] = [expand_one(x, target) if string_needs_expansion(x) else x for x in value]
                 elif isinstance(value, str):
-                    target[key] = expand_one(value, target)
+                    if string_needs_expansion(value):
+                        target[key] = expand_one(value, target)
                 elif isinstance(value, float):
                     target[key] = str(value)
             except KeyError as ke:

--- a/bin/lib/installable/archives.py
+++ b/bin/lib/installable/archives.py
@@ -362,17 +362,31 @@ def s3_available_compilers():
 class RestQueryTarballInstallable(TarballInstallable):
     def __init__(self, install_context: InstallationContext, config: dict[str, Any]):
         super().__init__(install_context, config)
-        document = self.install_context.fetch_rest_query(self.config_get("url"))
-        query = self.config_get("query")
+        self._rest_query_url = self.config_get("url")
+        self._rest_query = self.config_get("query")
+        # TarballInstallable.__init__ stored the query URL in self.url; drop it so the
+        # cached_property below resolves lazily — the REST fetch is only needed at install time.
+        del self.url
+
+    @functools.cached_property
+    def url(self) -> str:  # type: ignore[override]
+        document = self.install_context.fetch_rest_query(self._rest_query_url)
         try:
-            self.url = eval(query, {}, dict(document=document))
+            resolved = eval(self._rest_query, {}, dict(document=document))
         except Exception:  # noqa: BLE001
-            self._logger.exception("Exception evaluating query '%s' for %s", query, self)
+            self._logger.exception("Exception evaluating query '%s' for %s", self._rest_query, self)
             raise
-        if not self.url:
+        if not resolved:
             self._logger.warning("No installation candidate found")
         else:
-            self._logger.info("resolved to %s", self.url)
+            self._logger.info("resolved to %s", resolved)
+        return resolved or ""
+
+    def to_json_dict(self) -> dict[str, Any]:
+        # Force url resolution so JSON consumers see the same schema as before the
+        # cached_property change; lazy resolution would otherwise omit it entirely.
+        _ = self.url
+        return super().to_json_dict()
 
     def should_install(self) -> bool:
         if not self.url:


### PR DESCRIPTION
## Summary

`bin/ce_install --enable nightly list` was taking ~6s. Profiled it and found three independent issues:

1. **`expand_target` re-renders fully-expanded strings.** The `while needs_expansion(target)` loop iterates over every value on every pass and calls Jinja2 on it, even when the string has no `{{` / `{%` / `{#` left. Added a `string_needs_expansion` short-circuit so we only render strings that still contain template syntax. Saves ~1s on every `ce_install` invocation, not just nightly.

2. **`RestQueryTarballInstallable.__init__` makes five sequential REST calls.** Swift, Zig, Pony, Carbon endpoints (~3.4s total HTTP) were being hit just to *construct* installables — for `list`, the URL is never read. Made `url` a `functools.cached_property` so the fetch happens lazily at install/`should_install` time. `to_json_dict` is overridden to force resolution so `list --json` keeps the same output schema.

3. **`LazyObjectWrapper.__ensure_setup` was not thread-safe.** Classic check-then-act race. `cdn.py` had a manual `force_lazy_init(s3_client)` workaround with a comment ("work around race condition with parallel lazy init of boto3"). The same race is latent in `instance.elb_instances` which first-touches `ec2` from a 16-thread pool with no guard. Added double-checked locking inside the wrapper and retired the workaround + helper function.

### Timings

| | Before | After |
| --- | --- | --- |
| `ce_install --enable nightly list` | 5.96s | 2.22s |
| `ce_install list` | 2.57s | 1.41s |

## Test plan

- [x] `uv run pytest bin/test/` — 677 passed
- [x] `make static-checks` — ruff, ruff format, mypy, shellcheck all pass (terraform fmt fails locally because no `terraform` binary; unrelated)
- [x] `ce_install --enable nightly list` output diffed identical to `main`
- [x] `ce_install --enable nightly list --json` output still contains `url` field for `restQueryTarballs` entries
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)