### PR TITLE
[HLSL] Add DXC 1.10.2605.24 release

### DIFF
--- a/bin/yaml/hlsl.yaml
+++ b/bin/yaml/hlsl.yaml
@@ -11,6 +11,7 @@ compilers:
       type: s3tarballs
       check_exe: bin/dxc --version
       targets:
+        - "1.10.2605.24"
         - "1.10.2605.2"
         - "1.9.2602"
         - "1.8.2505.1"


### PR DESCRIPTION
This adds the latest DXC release 1.10.2605.24

https://github.com/microsoft/DirectXShaderCompiler/releases/tag/v1.10.2605.24