### PR TITLE
llvm: Upgrade to version 22.1.6

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1174,6 +1174,8 @@ compilers:
           - assertions-21.1.0
           - 22.1.0
           - assertions-22.1.0
+          - 22.1.6
+          - assertions-22.1.6
     clang-hexagon:
       - type: tarballs
         check_exe: x86_64-linux-gnu/bin/clang++ --version

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1390,6 +1390,7 @@ libraries:
       - 20.1.0
       - 21.1.0
       - 22.1.0
+      - 22.1.6
       type: s3tarballs
     magic_enum:
       check_file: include/magic_enum.hpp


### PR DESCRIPTION
Make the newly released LLVM and Clang 22.1.6 available in Compiler Explorer.
Release notes: https://github.com/llvm/llvm-project/releases/tag/llvmorg-22.1.6