### PR TITLE
clang-cl: Add 22.1.6

### DIFF
--- a/bin/yaml/windows.yaml
+++ b/bin/yaml/windows.yaml
@@ -32,6 +32,7 @@ windows:
         url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{{name}}/clang+llvm-{{name}}-x86_64-pc-windows-msvc.tar.xz
         targets:
           - 18.1.0
+          - 22.1.6
   hlsl:
     rga:
       type: ziparchive


### PR DESCRIPTION
This adds the latest release of LLVM/clang-cl, 22.1.6 for Windows. Currently, only 18.1.0 is installed.

Aside: It seems like clang-cl isn't available on the public version of compiler-explorer even though it's declared in the `c++.amazonwin.properties` config.