### PR TITLE
Make shellcheck hook gate on errors (severity is CLI-only)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,8 @@ repos:
     rev: 3.0.0
     hooks:
       - id: shellcheck
+        # severity is CLI-only (not a valid .shellcheckrc directive); gate on errors.
+        args: ["--severity=error"]
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.100.0
     hooks:

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,3 +1,2 @@
 disable=SC2164  # cd and popd
 disable=SC2043  # loop will only execute once
-severity=error


### PR DESCRIPTION
`.shellcheckrc` declared `severity=error`, but `severity` is **not** a valid `.shellcheckrc` directive (only `disable`/`enable`/`source`/`source-path`/`external-sources`/`shell` are) — shellcheck silently ignored it. As a result the pre-commit `shellcheck` hook was gating on `info`-level findings (SC2086 etc.) and failing on several scripts repo-wide.

Move the intent to where it actually works:
- Pass `--severity=error` to the hook via `args`.
- Drop the dead `severity=error` line from `.shellcheckrc` (kept the valid `disable=` lines).

The hook now passes repo-wide (`pre-commit run shellcheck --all-files` → green).

Found while bumping the infra Node version; split out so it stands alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)