### PR TITLE
Update pre-commit hooks (ruff, mypy v2, terraform)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,14 +13,14 @@ repos:
       - id: check-toml
       - id: detect-private-key
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.9
+    rev: v0.15.15
     hooks:
       - id: ruff
         args: [ --fix, --preview ]
       - id: ruff-format
         args: [ --preview ]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.17.1
+    rev: v2.1.0
     hooks:
       - id: mypy
         additional_dependencies:
@@ -38,7 +38,7 @@ repos:
         # severity is CLI-only (not a valid .shellcheckrc directive); gate on errors.
         args: ["--severity=error"]
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.100.0
+    rev: v1.106.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/bin/lib/ce_install.py
+++ b/bin/lib/ce_install.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import fnmatch
 import json
 import logging
-import logging.config
 import multiprocessing
 import os
 import signal

--- a/bin/test/github_app_test.py
+++ b/bin/test/github_app_test.py
@@ -33,7 +33,8 @@ def generate_test_key_pair():
     ).decode()
 
     pem_public = (
-        private_key.public_key()
+        private_key
+        .public_key()
         .public_bytes(
             encoding=serialization.Encoding.PEM,
             format=serialization.PublicFormat.SubjectPublicKeyInfo,

--- a/lambda/stats_test.py
+++ b/lambda/stats_test.py
@@ -5,7 +5,6 @@ from typing import Dict
 from unittest import mock
 
 import boto3
-import botocore.client
 import botocore.session
 import pytest
 from aws_embedded_metrics.logger.metrics_logger import MetricsLogger


### PR DESCRIPTION
`pre-commit autoupdate` bumps for the three out-of-date hooks:
- ruff `v0.12.9` → `v0.15.15`
- mypy `v1.17.1` → `v2.1.0` (major)
- terraform `v1.100.0` → `v1.106.0`

Fallout was small:
- ruff auto-removed two genuinely-unused imports (`logging.config` in `ce_install.py`, `botocore.client` in `stats_test.py` — verified neither is referenced).
- ruff-format reformatted one method chain.
- **mypy v2 reports no new errors.**

`pre-commit run --all-files` passes (ruff, ruff-format, mypy, shellcheck, terraform fmt/validate, tests, lambda lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)