### PR TITLE
Give Windows blue-green deploys a 10-minute HTTP health timeout

### DIFF
--- a/bin/lib/blue_green_deploy.py
+++ b/bin/lib/blue_green_deploy.py
@@ -483,11 +483,14 @@ class BlueGreenDeployment:
             # the inactive color isn't receiving traffic. We must use HTTP health checks.
             if self.running_on_admin_node:
                 print("\nStep 3: Checking HTTP health endpoints")
+                # Windows instances run compiler discovery on startup, which routinely
+                # takes well over 5 minutes; give them longer before giving up.
+                http_timeout = 600 if self.cfg.env.is_windows else 300
                 try:
-                    wait_for_http_health(instances, timeout=300)  # 5 minute timeout for HTTP checks
+                    wait_for_http_health(instances, timeout=http_timeout)
                     print("✅ All instances are responding to health checks!")
                 except TimeoutError:
-                    LOGGER.error("HTTP health checks timed out after 5 minutes")
+                    LOGGER.error("HTTP health checks timed out after %d seconds", http_timeout)
                     LOGGER.error("This indicates instances are not properly responding to health checks")
 
                     # Try to get more info about what's wrong


### PR DESCRIPTION
Windows instances run compiler discovery on startup, which routinely takes well over the hardcoded **5-minute** HTTP health-check window in `blue_green_deploy.py`. The result: a perfectly healthy Windows deploy fails spuriously — the app starts listening ~7 min after launch, just after the deploy gives up and rolls back.

Hit this deploying winstaging on the new Node 22.20.0 AMI: the instance was fine (`/healthcheck` → 200, all services up) but the deploy aborted at the 5-min mark.

Change: use a **600s** timeout for Windows environments (`self.cfg.env.is_windows`), leave Linux at 300s, and make the timeout-error message report the actual seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)