### PR TITLE
Fix PowerShell ParserError in Windows cmake build scripts

### DIFF
--- a/bin/lib/library_builder.py
+++ b/bin/lib/library_builder.py
@@ -723,6 +723,21 @@ class LibraryBuilder:
             escaped_var_value = var_value.replace('"', '`"')
             return f'$env:{var_name}="$env:{var_name};{escaped_var_value}"\n'
 
+    def script_run_logged(self, command: str, log_file: str, failure_message: str) -> str:
+        """Run a command, redirect its output to log_file, and surface the log tail on failure.
+
+        Emitted in the right shell dialect per platform: bash for Linux (cebuild.sh) and
+        PowerShell for Windows (cebuild.ps1). The bash `|| { ...; }` form is not valid
+        PowerShell, so Windows gets an explicit $LASTEXITCODE check instead.
+        """
+        if self.platform == LibraryPlatform.Windows:
+            return (
+                f"{command} > {log_file} 2>&1\n"
+                f"if ($LASTEXITCODE -ne 0) {{ Write-Host '{failure_message}'; "
+                f"Get-Content -Tail 200 {log_file}; exit 1 }}\n"
+            )
+        return f"{command} > {log_file} 2>&1 || {{ echo '{failure_message}' >&2; tail -200 {log_file} >&2; exit 1; }}\n"
+
     def writebuildscript(
         self,
         buildfolder,
@@ -941,14 +956,13 @@ class LibraryBuilder:
 
                 # Use appropriate CMAKE_*_FLAGS based on build type
                 cmake_flags_suffix = "_DEBUG" if buildtype == "Debug" else "_RELEASE"
-                cmakeline = (
+                cmakecmd = (
                     f'cmake --install-prefix "{installfolder}" {generator} "-DCMAKE_VERBOSE_MAKEFILE=ON" '
                     f'{targetparams} "-DCMAKE_BUILD_TYPE={buildtype}" {toolchainparam} {sysrootparam} '
                     f'"-DCMAKE_CXX_FLAGS{cmake_flags_suffix}={cxx_flags}" "-DCMAKE_C_FLAGS{cmake_flags_suffix}={c_flags}" '
-                    f'"-DCMAKE_ASM_FLAGS{cmake_flags_suffix}={asm_flags}" {extracmakeargs} {sourcefolder} '
-                    f"> cecmakelog.txt 2>&1 || "
-                    f"{{ echo 'cmake configure failed:' >&2; tail -200 cecmakelog.txt >&2; exit 1; }}\n"
+                    f'"-DCMAKE_ASM_FLAGS{cmake_flags_suffix}={asm_flags}" {extracmakeargs} {sourcefolder}'
                 )
+                cmakeline = self.script_run_logged(cmakecmd, "cecmakelog.txt", "cmake configure failed:")
                 self.logger.debug(cmakeline)
                 f.write(cmakeline)
 
@@ -967,15 +981,19 @@ class LibraryBuilder:
                 if len(self.buildconfig.make_targets) != 0:
                     if len(self.buildconfig.make_targets) == 1 and self.buildconfig.make_targets[0] == "all":
                         f.write(
-                            f"cmake --build . {extramakeargs} > cemakelog_.txt 2>&1 || "
-                            f"{{ echo 'cmake --build failed:' >&2; tail -200 cemakelog_.txt >&2; exit 1; }}\n"
+                            self.script_run_logged(
+                                f"cmake --build . {extramakeargs}", "cemakelog_.txt", "cmake --build failed:"
+                            )
                         )
                     else:
                         for lognum, target in enumerate(self.buildconfig.make_targets):
                             log_name = f"cemakelog_{lognum}.txt"
                             f.write(
-                                f"cmake --build . {extramakeargs} --target={target} > {log_name} 2>&1 || "
-                                f"{{ echo 'cmake --build {target} failed:' >&2; tail -200 {log_name} >&2; exit 1; }}\n"
+                                self.script_run_logged(
+                                    f"cmake --build . {extramakeargs} --target={target}",
+                                    log_name,
+                                    f"cmake --build {target} failed:",
+                                )
                             )
                 else:
                     lognum = 0
@@ -999,10 +1017,7 @@ class LibraryBuilder:
                         f.write("}\n")
 
                 if self.buildconfig.package_install:
-                    f.write(
-                        "cmake --install . > ceinstall_0.txt 2>&1 || "
-                        "{ echo 'cmake --install failed:' >&2; tail -200 ceinstall_0.txt >&2; exit 1; }\n"
-                    )
+                    f.write(self.script_run_logged("cmake --install .", "ceinstall_0.txt", "cmake --install failed:"))
             else:
                 if os.path.exists(os.path.join(sourcefolder, "Makefile")):
                     f.write("make clean > cemakeclean.txt 2>&1 || /bin/true\n")

--- a/bin/test/library_builder_test.py
+++ b/bin/test/library_builder_test.py
@@ -187,6 +187,54 @@ def test_can_write_conan_file(requests_mock):
     )
 
 
+def test_script_run_logged_linux_uses_bash_failure_handling(requests_mock):
+    requests_mock.get(f"{BASE}lang.amazon.properties", text="")
+    logger = mock.Mock(spec_set=Logger)
+    install_context = mock.Mock(spec_set=InstallationContext)
+    lb = LibraryBuilder(
+        logger,
+        "lang",
+        "somelib",
+        "target",
+        "src-folder",
+        install_context,
+        create_test_build_config(),
+        False,
+        LibraryPlatform.Linux,
+    )
+    line = lb.script_run_logged("cmake --build .", "cemakelog.txt", "cmake --build failed:")
+    assert line == (
+        "cmake --build . > cemakelog.txt 2>&1 || "
+        "{ echo 'cmake --build failed:' >&2; tail -200 cemakelog.txt >&2; exit 1; }\n"
+    )
+
+
+def test_script_run_logged_windows_uses_powershell_failure_handling(requests_mock):
+    requests_mock.get(f"{BASE}lang.amazon.properties", text="")
+    logger = mock.Mock(spec_set=Logger)
+    install_context = mock.Mock(spec_set=InstallationContext)
+    lb = LibraryBuilder(
+        logger,
+        "lang",
+        "somelib",
+        "target",
+        "src-folder",
+        install_context,
+        create_test_build_config(),
+        False,
+        LibraryPlatform.Windows,
+    )
+    script = lb.script_run_logged("cmake --build .", "cemakelog.txt", "cmake --build failed:")
+    # Regression: bash `|| { ... >&2 ...; }` is a PowerShell ParserError, which broke all compiled
+    # cmake library builds on Windows (e.g. date/date-tz) after PR #2094.
+    assert "||" not in script
+    assert ">&2" not in script
+    assert "cmake --build . > cemakelog.txt 2>&1" in script
+    assert "if ($LASTEXITCODE -ne 0)" in script
+    assert "Get-Content -Tail 200 cemakelog.txt" in script
+    assert script.endswith("exit 1 }\n")
+
+
 def test_get_toolchain_path_from_options_gcc_toolchain(requests_mock):
     requests_mock.get(f"{BASE}cpp.amazon.properties", text="")
     logger = mock.Mock(spec_set=Logger)


### PR DESCRIPTION
## Problem

`@mattgodbolt` -- this is a regression from #2094 ("Surface configure failures and quiet harmless make-clean noise").

That PR wrapped the cmake configure/build/install commands with bash error handling:

```
cmake ... > cecmakelog.txt 2>&1 || { echo 'cmake configure failed:' >&2; tail -200 cecmakelog.txt >&2; exit 1; }
```

This string is written verbatim into `cebuild.ps1` on Windows, where PowerShell can't parse `>&2` and aborts at the configure step before the compiler runs:

```
ParserError: cebuild.ps1:8
  8 | ... > cecmakelog.txt 2>&1 || { echo 'cmake configure failed:' >&2; tail -200 ... }
      | Missing file specification after redirection operator.
```

Net effect: since 2026-05-04 every **compiled** (non-header-only) cmake library on Windows has failed at the generated-script parse step. Header-only libs were unaffected (they skip the cmake build path), which is why it went unnoticed. `date` -- which compiles `date-tz` via `BUILD_TZ_LIB=ON` -- surfaced it: all popular MSVC builds failed with the parser error and got recorded as build failures, so nothing landed on the Conan proxy (0 Windows binaries for `date/3.0.1`).

## Fix

Add a platform-aware `script_run_logged(command, log_file, failure_message)` helper:

- **Linux (`cebuild.sh`)**: unchanged bash `|| { echo ...; tail -200 ...; exit 1; }`
- **Windows (`cebuild.ps1`)**: `cmd > log 2>&1` then `if ($LASTEXITCODE -ne 0) { Write-Host '...'; Get-Content -Tail 200 log; exit 1 }`

Applied at the three cmake sites that feed `cebuild.ps1` (configure, build/make-targets, install). The autotools `./configure` path is left as bash -- that whole branch is Linux-only (it does `rm -f *.so*`, `-j$NUMCPUS`, etc.) and Windows never reaches it.

## Tests

Added regression tests asserting the Windows script contains no `||` / `>&2` and uses the `$LASTEXITCODE` check, while Linux keeps the bash form. `make static-checks` is clean.

## Follow-up

After this lands I'll clear `date`'s re-recorded MSVC failures and re-trigger the Windows build to confirm it now reaches a real compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)