### PR TITLE
Build date's tz lib without libcurl on Windows

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -713,6 +713,7 @@ libraries:
       check_file: README.md
       extra_cmake_arg:
       - -DBUILD_TZ_LIB=ON
+      - -DMANUAL_TZ_DB=%cmake_bool_windows%
       make_targets:
       - date-tz
       repo: HowardHinnant/date
@@ -1748,6 +1749,7 @@ libraries:
         check_file: README.md
         extra_cmake_arg:
         - -DBUILD_TZ_LIB=ON
+        - -DMANUAL_TZ_DB=%cmake_bool_windows%
         make_targets:
         - date-tz
         method: nightlyclone


### PR DESCRIPTION
## Problem

`date` is built with `BUILD_TZ_LIB=ON` (target `date-tz`). With the default `USE_SYSTEM_TZ_DB=OFF` / `MANUAL_TZ_DB=OFF`, the tz library uses the remote IANA tzdata API, so its `CMakeLists.txt` calls `find_package(CURL REQUIRED)`. The Windows builder has no libcurl (CE only builds curl as a Linux `cshared` library), so configure fails:

```
# date: USE_SYSTEM_TZ_DB OFF
# date: MANUAL_TZ_DB OFF
CMake Error: Could NOT find CURL (missing: CURL_LIBRARY CURL_INCLUDE_DIR)
  CMakeLists.txt:155 (find_package)
-- Configuring incomplete, errors occurred!
```

Result: every MSVC build of `date` errors at configure, and there are zero Windows binaries for `date/3.0.1` on the Conan proxy.

(This was previously masked by a PowerShell script-generation bug, fixed in #2146; with that fixed, the real CURL dependency surfaced.)

## Fix

Set `MANUAL_TZ_DB` via the existing `%cmake_bool_windows%` placeholder so it expands to:

- **Windows:** `-DMANUAL_TZ_DB=ON` -- no `find_package(CURL)`, configure succeeds
- **Linux:** `-DMANUAL_TZ_DB=OFF` -- unchanged; keeps the remote-tzdata path (curl is available)

No code change needed -- this reuses the same mechanism qt already uses (`-DFEATURE_rpath=%cmake_bool_not_windows%`). Applied to both the release (`3.0.1`) and nightly (`trunk`) date entries.

Note: `MANUAL_TZ_DB=ON` means the Windows tz lib doesn't auto-download tzdata; consumers point it at a tz database via `date::set_install(...)`. That's the standard approach for this library on Windows.

## Follow-up

After merge: clear date's recorded MSVC failures and re-run the Windows library build to confirm it now produces binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)