### PR TITLE
Make FXC packaging resilient and log the real layout error

### DIFF
--- a/msvc-install/fxc-install.ps1
+++ b/msvc-install/fxc-install.ps1
@@ -96,8 +96,13 @@ function Get-Layout {
     $proc = Start-Process -Wait -PassThru -FilePath $installer -ArgumentList $args
     if ($proc.ExitCode -ne 0) {
         if (Test-Path $logPath) {
-            Write-Host "--- layout.log (tail) ---"
-            Get-Content $logPath -Tail 60 | ForEach-Object { Write-Host $_ }
+            # winsdksetup dumps its entire variable table near the end, which
+            # buries the real failure under ~100 lines. Print the whole log
+            # minus that noise so the Acquire/Apply error is visible.
+            Write-Host "--- layout.log ---"
+            Get-Content $logPath |
+                Where-Object { $_ -notmatch '(?i): Variable: ' } |
+                ForEach-Object { Write-Host $_ }
             Write-Host "--- end layout.log ---"
         }
         throw "winsdksetup.exe /layout for $label exited with code $($proc.ExitCode). Full log: $logPath"
@@ -382,17 +387,29 @@ New-Item -ItemType Directory -Force $extract_root  | Out-Null
 New-Item -ItemType Directory -Force $output_root   | Out-Null
 New-Item -ItemType Directory -Force $archives      | Out-Null
 
+$failures = @()
 foreach ($version in $versions) {
     $label = $version.Label
     Write-Host ""
     Write-Host "=== Windows SDK $label ==="
 
-    Download   -label $label -url $version.Url | Out-Null
-    $layoutPath = Get-Layout -label $label
-    Extract-FxcFromLayout -label $label -layoutPath $layoutPath
-    Zip-Fxc -label $label
+    try {
+        Download   -label $label -url $version.Url | Out-Null
+        $layoutPath = Get-Layout -label $label
+        Extract-FxcFromLayout -label $label -layoutPath $layoutPath
+        Zip-Fxc -label $label
+    } catch {
+        Write-Host "ERROR packaging SDK ${label}: $($_.Exception.Message)"
+        $failures += $label
+    }
 }
 
 Write-Host ""
 Write-Host "fxc.exe / d3dcompiler_47.dll extracted under $output_root"
 Write-Host "archives written to $archives"
+
+if ($failures) {
+    Write-Host ""
+    Write-Host "Failed SDK versions: $($failures -join ', ')"
+    exit 1
+}


### PR DESCRIPTION
The first `package-fxc` run (#26906153720) failed on the 8.1 SDK `/layout` step with exit `0x80070642` and gave no usable diagnostics:

- The error handler printed only `Get-Content -Tail 60` of `layout.log`. winsdksetup ends its log with a ~100-line variable dump, so the tail was entirely that noise and the actual Acquire/Apply failure scrolled off.
- The loop threw on the first failing version, so 10.0.19041 and 10.0.26100 were never attempted.

This PR:

- Prints the whole `layout.log` minus the `: Variable:` dump on failure, so the real reason for `0x80070642` will be visible on the next run.
- Processes each SDK version independently: failures are collected and reported at the end, the job still exits non-zero, but the SDKs that succeed get extracted and uploaded to `opt-nonfree/fxc/`.

This doesn't yet fix 8.1 itself (likely dead payloads behind the ancient fwlink, or a flag the 8.1 bootstrapper rejects) -- the next run's full log will tell us whether to drop 8.1 or adjust its invocation. Meanwhile the two Windows 10 SDKs should package successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)