### PR TITLE
Drop the Windows 8.1 SDK from FXC packaging

### DIFF
--- a/msvc-install/fxc-install.ps1
+++ b/msvc-install/fxc-install.ps1
@@ -22,12 +22,14 @@
 
 # FXC has been largely unmaintained for a while, so we only pull a few SDKs
 # from major versions of Windows.
-# 8.1 - Windows 8.1 (the last SDK to support Windows 7).
 # 10.0.19041 - Windows 10 20H1 and 20H2.
 # 10.0.26100 - Windows 11 24H2 and 23H2.
+#
+# The 8.1 SDK (the last to support Windows 7) is gone: its winsdksetup.exe
+# /layout fails in Apply because the standalone SDK MSI payloads 404 on
+# Microsoft's CDN, so there is no way to acquire fxc.exe from it anymore.
 
 $versions = (
-    (New-Object PSObject -Property @{ Label = "8.1"; Url = "https://go.microsoft.com/fwlink/p/?LinkId=323507" }),
     (New-Object PSObject -Property @{ Label = "10.0.19041"; Url = "https://go.microsoft.com/fwlink/?linkid=2311805" }),
     (New-Object PSObject -Property @{ Label = "10.0.26100"; Url = "https://go.microsoft.com/fwlink/?linkid=2361308" })
 )


### PR DESCRIPTION
Follow-up to #2148. With diagnostics in place, run #26906744325 showed the real reason the 8.1 SDK fails: `winsdksetup.exe /layout` gets to Apply and then can't download the standalone SDK MSI payloads from Microsoft's CDN:

```
Error 0x80070002: Failed attempt to download URL:
  https://download.microsoft.com/download/B/0/C/B0C80BA3-.../standalonesdk/.../Windows Software Development Kit-x86_en-us.msi
Failed to resolve source for file: ...\Installers\Windows Software Development Kit-x86_en-us.msi, error: 0x80070642
Error 0x80070642: Failed while caching, aborting execution.
```

`0x80070002` is `ERROR_FILE_NOT_FOUND` -- the payloads are simply gone from Microsoft's servers. Nothing we pass to the bootstrapper fixes a 404, so the 8.1 SDK can no longer yield fxc.exe via this approach.

Remove the 8.1 entry from `$versions` (with a comment recording why) and keep the two Windows 10 SDKs, whose fwlinks are still live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)