### PR TITLE
Add unit tests for the events-lambda

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -34,3 +34,6 @@ jobs:
         # Build (not deploy) both lambda zips so dependency-resolution or
         # packaging breakage is caught on the PR rather than at deploy time.
         run: make lambda-package events-lambda-package
+      - name: Test events-lambda
+        working-directory: events-lambda
+        run: npm install && npm test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,4 @@
-name: Python tests
+name: Tests
 
 on:
   push:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,6 +11,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
+      - name: Install Node.js
+        # Pin Node for the events-lambda lint/build/test steps; matches the
+        # nodejs22.x lambda runtime and the package.json engines requirement.
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -36,4 +42,4 @@ jobs:
         run: make lambda-package events-lambda-package
       - name: Test events-lambda
         working-directory: events-lambda
-        run: npm install && npm test
+        run: npm ci && npm test

--- a/events-lambda/events-connections.test.js
+++ b/events-lambda/events-connections.test.js
@@ -1,0 +1,84 @@
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import {DeleteItemCommand, DynamoDBClient, PutItemCommand, QueryCommand, ScanCommand} from '@aws-sdk/client-dynamodb';
+import {EventsConnections} from './events-connections.js';
+
+// Intercept the module-level DynamoDB client's send() and record every command.
+// `responder` returns the canned response for a given command.
+function recordSend(t, responder = () => ({})) {
+    const calls = [];
+    t.mock.method(DynamoDBClient.prototype, 'send', async cmd => {
+        calls.push(cmd);
+        return responder(cmd);
+    });
+    return calls;
+}
+
+test('add stores the connection id with a ttl', async t => {
+    const calls = recordSend(t);
+    await EventsConnections.add('conn-add');
+    assert.equal(calls.length, 1);
+    assert.ok(calls[0] instanceof PutItemCommand);
+    assert.equal(calls[0].input.Item.connectionId.S, 'conn-add');
+    assert.ok(Number(calls[0].input.Item.ttl.N) > 0);
+});
+
+test('update writes a composite-key item for the subscription', async t => {
+    const calls = recordSend(t);
+    await EventsConnections.update('conn-up', 'guid-up');
+    assert.ok(calls[0] instanceof PutItemCommand);
+    assert.equal(calls[0].input.Item.connectionId.S, 'conn-up#guid-up');
+    assert.equal(calls[0].input.Item.subscription.S, 'guid-up');
+});
+
+test('unsubscribe deletes the composite-key item', async t => {
+    const calls = recordSend(t);
+    await EventsConnections.unsubscribe('conn-un', 'guid-un');
+    assert.ok(calls[0] instanceof DeleteItemCommand);
+    assert.equal(calls[0].input.Key.connectionId.S, 'conn-un#guid-un');
+});
+
+test('subscribers returns the underlying connection ids from a dynamo query', async t => {
+    recordSend(t, cmd => {
+        if (cmd instanceof QueryCommand) {
+            return {Items: [{connectionId: {S: 'subbed#guid-q'}}], Count: 1, ScannedCount: 1};
+        }
+        return {};
+    });
+    const result = await EventsConnections.subscribers('guid-q');
+    assert.equal(result.Count, 1);
+    assert.equal(result.Items[0].connectionId.S, 'subbed');
+});
+
+test('remove scans for the connection prefix and deletes every match', async t => {
+    const calls = recordSend(t, cmd => {
+        if (cmd instanceof ScanCommand) {
+            return {Items: [{connectionId: {S: 'conn-rm#a'}}, {connectionId: {S: 'conn-rm#b'}}]};
+        }
+        return {};
+    });
+    await EventsConnections.remove('conn-rm');
+    const scan = calls.find(c => c instanceof ScanCommand);
+    assert.ok(scan);
+    assert.equal(scan.input.ExpressionAttributeValues[':connectionPrefix'].S, 'conn-rm#');
+    assert.equal(calls.filter(c => c instanceof DeleteItemCommand).length, 2);
+});
+
+test('getGuidSender returns the tracked sender from cache without querying', async t => {
+    const calls = recordSend(t);
+    await EventsConnections.trackGuidSender('guid-track', 'sender-conn');
+    const sender = await EventsConnections.getGuidSender('guid-track');
+    assert.equal(sender, 'sender-conn');
+    assert.equal(calls.filter(c => c instanceof QueryCommand).length, 0);
+});
+
+test('getGuidSender falls back to dynamo when not cached', async t => {
+    recordSend(t, cmd => {
+        if (cmd instanceof QueryCommand) {
+            return {Items: [{senderConnectionId: {S: 'fallback-sender'}}]};
+        }
+        return {};
+    });
+    const sender = await EventsConnections.getGuidSender('guid-uncached');
+    assert.equal(sender, 'fallback-sender');
+});

--- a/events-lambda/events-onconnect.test.js
+++ b/events-lambda/events-onconnect.test.js
@@ -1,0 +1,23 @@
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import {DynamoDBClient} from '@aws-sdk/client-dynamodb';
+import {handler} from './events-onconnect.js';
+
+test('records the connection and returns 200', async t => {
+    const calls = [];
+    t.mock.method(DynamoDBClient.prototype, 'send', async cmd => {
+        calls.push(cmd);
+        return {};
+    });
+    const res = await handler({requestContext: {connectionId: 'conn-ok'}});
+    assert.equal(res.statusCode, 200);
+    assert.equal(calls.length, 1);
+});
+
+test('returns 500 when dynamo write fails', async t => {
+    t.mock.method(DynamoDBClient.prototype, 'send', async () => {
+        throw new Error('boom');
+    });
+    const res = await handler({requestContext: {connectionId: 'conn-fail'}});
+    assert.equal(res.statusCode, 500);
+});

--- a/events-lambda/events-ondisconnect.test.js
+++ b/events-lambda/events-ondisconnect.test.js
@@ -1,0 +1,23 @@
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import {DynamoDBClient} from '@aws-sdk/client-dynamodb';
+import {handler} from './events-ondisconnect.js';
+
+test('removes the connection and returns 200', async t => {
+    const calls = [];
+    t.mock.method(DynamoDBClient.prototype, 'send', async cmd => {
+        calls.push(cmd);
+        return {Items: []};
+    });
+    const res = await handler({requestContext: {connectionId: 'conn-bye'}});
+    assert.equal(res.statusCode, 200);
+    assert.ok(calls.length > 0);
+});
+
+test('still returns 200 when dynamo errors (removal failures are swallowed)', async t => {
+    t.mock.method(DynamoDBClient.prototype, 'send', async () => {
+        throw new Error('boom');
+    });
+    const res = await handler({requestContext: {connectionId: 'conn-bye-err'}});
+    assert.equal(res.statusCode, 200);
+});

--- a/events-lambda/events-sendmessage.test.js
+++ b/events-lambda/events-sendmessage.test.js
@@ -1,0 +1,67 @@
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import {DynamoDBClient, QueryCommand} from '@aws-sdk/client-dynamodb';
+import {ApiGatewayManagementApiClient, PostToConnectionCommand} from '@aws-sdk/client-apigatewaymanagementapi';
+import {handler} from './events-sendmessage.js';
+
+const baseContext = {domainName: 'example.com', stage: 'prod', connectionId: 'sender-conn'};
+
+function event(body) {
+    return {requestContext: baseContext, body};
+}
+
+test('a subscribe message stores the subscription and returns 200', async t => {
+    const calls = [];
+    t.mock.method(DynamoDBClient.prototype, 'send', async cmd => {
+        calls.push(cmd);
+        return {};
+    });
+    const res = await handler(event('subscribe: guid-sub'));
+    assert.equal(res.statusCode, 200);
+    assert.ok(calls.some(c => c.input?.Item?.connectionId?.S === 'sender-conn#guid-sub'));
+});
+
+test('an object message relays to subscribers and returns 200', async t => {
+    t.mock.method(DynamoDBClient.prototype, 'send', async cmd => {
+        if (cmd instanceof QueryCommand) {
+            return {Items: [{connectionId: {S: 'listener-conn#guid-relay'}}], Count: 1};
+        }
+        return {};
+    });
+    const posted = [];
+    t.mock.method(ApiGatewayManagementApiClient.prototype, 'send', async cmd => {
+        posted.push(cmd);
+        return {};
+    });
+    const res = await handler(event(JSON.stringify({guid: 'guid-relay', code: '42'})));
+    assert.equal(res.statusCode, 200);
+    assert.equal(posted.length, 1);
+    assert.ok(posted[0] instanceof PostToConnectionCommand);
+    assert.equal(posted[0].input.ConnectionId, 'listener-conn');
+});
+
+test('an object message with no subscribers returns 501', async t => {
+    t.mock.method(DynamoDBClient.prototype, 'send', async cmd => {
+        if (cmd instanceof QueryCommand) {
+            return {Items: [], Count: 0};
+        }
+        return {};
+    });
+    t.mock.method(ApiGatewayManagementApiClient.prototype, 'send', async () => ({}));
+    const res = await handler(event(JSON.stringify({guid: 'guid-empty', code: '42'})));
+    assert.equal(res.statusCode, 501);
+});
+
+test('an unknown text message is echoed back to the sender', async t => {
+    const posted = [];
+    t.mock.method(DynamoDBClient.prototype, 'send', async () => ({}));
+    t.mock.method(ApiGatewayManagementApiClient.prototype, 'send', async cmd => {
+        posted.push(cmd);
+        return {};
+    });
+    const res = await handler(event('hello there'));
+    assert.equal(res.statusCode, 200);
+    assert.equal(posted.length, 1);
+    assert.equal(posted[0].input.ConnectionId, 'sender-conn');
+    assert.equal(posted[0].input.Data, 'unknown text message');
+});

--- a/events-lambda/package-lock.json
+++ b/events-lambda/package-lock.json
@@ -24,6 +24,9 @@
         "eslint-plugin-sonarjs": "^0.25.1",
         "eslint-plugin-unicorn": "^51.0.1",
         "prettier": "^3.2.5"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {

--- a/events-lambda/package.json
+++ b/events-lambda/package.json
@@ -4,9 +4,13 @@
   "version": "1.0.0",
   "author": "Compiler Explorer Authors",
   "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "lint": "eslint --max-warnings=0 . --fix",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "test": "node --test"
   },
   "devDependencies": {
     "eslint": "^8.57.0",


### PR DESCRIPTION
The events websocket lambda had no tests, only lint -- despite having real logic (composite-key subscriptions, subscriber relay, ack handling, connection cleanup). This adds a suite and runs it in CI, continuing the bitrot cleanup from #2152.

## Approach
- **No new dependencies.** Uses Node 22's built-in `node:test` runner. The AWS SDK clients are module-level singletons, so each test intercepts `Client.prototype.send` via `node:test`'s built-in `mock.method` -- no `aws-sdk-client-mock`/sinon, no test framework.
- 15 tests covering:
  - `events-connections.js` -- the DynamoDB layer: `add`, `update`, `unsubscribe`, `subscribers` (query + merge), `remove` (scan + delete-all), and GUID-sender cache/fallback.
  - `events-onconnect` / `events-ondisconnect` -- success and failure paths (incl. documenting that disconnect swallows DynamoDB errors and still returns 200).
  - `events-sendmessage` -- subscribe routing, object-message relay to subscribers, the no-listeners 501, and unknown-text echo.

## Wiring
- `npm test` -> `node --test` in `package.json`; `engines.node` pinned to `>=22` (matches the `nodejs22.x` runtime and satisfies eslint-plugin-n for the `node:test` import).
- CI runs the suite (`.github/workflows/python-tests.yaml`).
- Test files are named `*.test.js`, which the lambda build script already excludes from the deployed zip (verified: the built package contains only the runtime source).

## Validation
- `npm test` -- 15 passed
- `make static-checks` clean (events-lambda lint covers the new test files)
- events zip rebuilt; confirmed no `*.test.js` inside

🤖 Generated with [Claude Code](https://claude.com/claude-code)