### PR TITLE
Add verify-compilers-locally skill

### DIFF
--- a/.claude/skills/verify-compilers-locally/SKILL.md
+++ b/.claude/skills/verify-compilers-locally/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: verify-compilers-locally
+description: This skill should be used when the user wants to verify that newly-added compilers actually install and compile in a real Compiler Explorer instance before/after merging a PR. Triggers include "test the compilers locally", "verify this compiler PR", "do they all compile", "run a local CE and check compiler X", or adopting an infra install-config + CE properties pair (like AOCC, ICX, a new GCC/Clang group). Covers the full loop: ce_install the compilers (plus toolchain deps), launch CE locally with extracted local.properties, drive the compile API across every new compiler id, report a pass/fail table, then tear down.
+version: 0.1.0
+---
+
+# Verify compilers locally
+
+End-to-end check that a set of new compilers installs and compiles a simple
+program inside a real CE instance. This is the loop behind "does this compiler
+PR actually work", exercising the real production config (exe paths,
+`--gcc-toolchain`, group settings, `compilerType`) without any AWS bootstrap.
+
+Two repos are involved:
+- **infra** (this repo): `bin/yaml/*.yaml` install config, run via `bin/ce_install`.
+- **compiler-explorer**: `etc/config/<lang>.amazon.properties` compiler definitions.
+
+Find both checkouts before starting. The CE checkout is usually a sibling
+(`../compiler-explorer`); a PR under test is often a `git worktree`.
+
+## Procedure
+
+### 1. Identify the targets
+From the CE properties PR, list the new compiler **ids** per language and the
+group(s) they belong to. From the infra PR, get the matching `ce_install`
+filter (e.g. `compilers/c++/aocc`). Confirm with:
+```bash
+uv run bin/ce_install list 'compilers/c++/aocc'
+```
+
+### 2. Install the compilers (+ toolchain deps)
+Default dest is `/opt/compiler-explorer` (must be writable). Install the group:
+```bash
+uv run bin/ce_install install 'compilers/c++/aocc'
+```
+**Resolve `--gcc-toolchain` deps.** Inspect the properties `options=` for the
+group: clang-based compilers usually pass
+`--gcc-toolchain=/opt/compiler-explorer/gcc-X.Y.Z`. That GCC must exist locally
+or `clang++` can't find libstdc++. Install it too:
+```bash
+uv run bin/ce_install install 'compilers/c++/x86/gcc 14.2.0'
+```
+Verify the expected binaries exist (`bin/clang`, `bin/clang++`, `bin/flang`,
+etc.) under each install dir before continuing.
+
+### 3. Extract local.properties (do NOT use `--env amazon`)
+`--env amazon` triggers AWS/instance bootstrap you don't want locally. Instead
+layer the relevant blocks as `local` properties (loaded last, highest
+precedence, gitignored). For each language, pull just the target group + its
+compiler entries out of the amazon file:
+```bash
+cd <ce-checkout>
+{ echo "compilers=&aocc"; echo "defaultCompiler=aocc520";
+  grep -E '^group\.aocc\.|^compiler\.aocc[0-9]' etc/config/c++.amazon.properties; } \
+  > etc/config/c++.local.properties
+```
+Repeat per language with the right group name (`aocc` / `caocc` / `aocc_flang`)
+and id prefix. These files are gitignored — they are throwaway.
+
+### 4. Launch CE locally
+Needs `node_modules` (run `npm ci` in the checkout/worktree if absent). Then:
+```bash
+nohup npm run dev -- --port 10240 > /tmp/ce_dev.log 2>&1 &
+```
+Wait for `Listening on http://localhost:10240/`. The log will say
+`Failed to create N out of M compilers` — that's expected (other languages'
+compilers aren't installed locally). Confirm your targets loaded:
+```bash
+curl -s "http://localhost:10240/api/compilers/c++?fields=id,name" \
+  -H "Accept: application/json" | python3 -c "import sys,json;[print(c['id']) for c in json.load(sys.stdin) if 'aocc' in c['id']]"
+```
+
+### 5. Compile-test every id
+Use the helper to POST a simple program to each compiler via the compile API
+and print a pass/fail table (exit code 0 + non-empty asm = OK):
+```bash
+python3 .claude/skills/verify-compilers-locally/compile_matrix.py \
+  --base http://localhost:10240 \
+  c++:aocc320 c++:aocc400 ... c:caocc320 ... fortran:aoccflang320 ...
+```
+Spot-check one real asm output to confirm it's genuine codegen, not a masked
+error.
+
+For languages that set `supportsExecute` (interpreters, `interpreted=true`),
+also run the **execution** path -- it's a separate code path from disassembly,
+so a compiler can disassemble fine yet fail to run (e.g. a misresolved
+interpreter). Add `--execute`; it checks `didExecute` + `execResult.code`:
+```bash
+python3 .claude/skills/verify-compilers-locally/compile_matrix.py --execute \
+  --base http://localhost:10240 lua:lua515 lua:lua550 ...
+```
+
+### 6. Teardown
+```bash
+pkill -f "app.ts --port 10240"
+rm -f <ce-checkout>/etc/config/*.local.properties   # so the next `npm run dev` isn't AOCC-only
+```
+Leave the `/opt/compiler-explorer` installs in place unless asked to remove
+them (they're slow to re-fetch). Report what was left installed.
+
+## Gotchas (hard-won)
+- **Never `--env amazon` locally** — it does AWS-side things. Use `local.properties`.
+- **Remove `local.properties` afterwards** or the user's next `npm run dev` shows only your test compilers.
+- **`--gcc-toolchain` GCC must be installed** or clang C/C++ fails to find the stdlib. Fortran/flang doesn't need it.
+- Compile API: `POST /api/compiler/<id>/compile`, JSON body, `Accept: application/json`; check `code==0` and a non-empty `asm` array.
+- **Disassembly passing does NOT mean execution works.** They're separate paths: the asm/listing comes from the compiler, execution runs a (possibly different) binary. A real bug shipped where every Lua version disassembled correctly but all executed with the wrong interpreter — the disassembly matrix was all-green. For `supportsExecute` languages, run `compile_matrix.py --execute` too and confirm `didExecute` + `execResult.code==0` (and the stdout looks right).
+- **`code==0` + non-empty asm is necessary, not sufficient.** A wrapper can exit 0 and emit a *placeholder* (e.g. "// No PTX was generated") that still counts as asm lines — a false pass. Always eyeball the actual output for at least one compiler per distinct line-count bucket; differing asm-line counts across versions usually means some produce real output and others a fallback.
+- Interpreted DSLs (cutedsl, triton): the source comes from `examples/<lang>/default.py`, not the built-in C snippet. Pass it with `--source-file <lang>=<path>` and usually `--args ""` (per-compiler flags like `--arch sm_90a` already come from config). Real output may live in the `devices` map (MLIR/SASS/PTX views), not just `asm`.
+- The CE properties repo uses **squash merges only**.

--- a/.claude/skills/verify-compilers-locally/compile_matrix.py
+++ b/.claude/skills/verify-compilers-locally/compile_matrix.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Compile (and optionally run) a simple program on each given CE compiler id and print a pass/fail table.
+
+Usage:
+    compile_matrix.py --base http://localhost:10240 LANG:ID [LANG:ID ...]
+    compile_matrix.py --execute --base http://localhost:10240 LANG:ID [LANG:ID ...]
+
+Each positional arg is `lang:compilerid`, e.g. `c++:aocc520`, `fortran:aoccflang500`.
+A simple per-language program is used (override with --source 'lang=...' or --source-file 'lang=path').
+
+Default mode checks the disassembly path: pass = compile code 0 and non-empty asm.
+--execute checks the execution path instead: pass = didExecute and execResult.code 0.
+These are separate code paths -- a compiler can disassemble fine yet fail to execute
+(e.g. a misresolved interpreter), so run both for languages that set supportsExecute.
+Exits non-zero if any case fails.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.request
+
+DEFAULT_SOURCES = {
+    "c++": "int square(int num) { return num * num; }\n",
+    "c": "int square(int num) { return num * num; }\n",
+    "fortran": ("integer function square(n)\n  integer, intent(in) :: n\n  square = n * n\nend function\n"),
+    "_default": "int square(int num) { return num * num; }\n",
+}
+
+
+def compile_one(base: str, lang: str, cid: str, src: str, args: str, execute: bool, timeout: int) -> dict:
+    options: dict[str, object] = {
+        "userArguments": args,
+        "filters": {
+            "labels": True,
+            "directives": True,
+            "comments": True,
+            "intel": True,
+            "demangle": True,
+            "execute": execute,
+        },
+        "compilerOptions": {},
+        "tools": [],
+    }
+    if execute:
+        options["executeParameters"] = {"args": [], "stdin": ""}
+    body = {"source": src, "compiler": cid, "lang": lang, "options": options}
+    req = urllib.request.Request(
+        f"{base}/api/compiler/{cid}/compile",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        res = json.load(resp)
+    asm = res.get("asm") or []
+    exec_res = res.get("execResult") or {}
+    exec_stdout = " ".join(x.get("text", "") for x in (exec_res.get("stdout") or [])).strip()
+    # The build/setup stderr (e.g. a failed interpreter spawn) surfaces at the top level.
+    setup_err = " ".join(x.get("text", "") for x in (res.get("stderr") or [])).strip()
+    return {
+        "code": res.get("code"),
+        "asm_lines": sum(1 for a in asm if (a.get("text") or "").strip()),
+        "did_execute": exec_res.get("didExecute"),
+        "exec_code": exec_res.get("code"),
+        "stdout": exec_stdout,
+        "setup_err": setup_err,
+    }
+
+
+def run_disassembly(cases: list[tuple[str, str]], sources: dict, opts: argparse.Namespace) -> bool:
+    print(f"{'lang':8} {'compiler':16} {'code':4} {'asmLines':8} note")
+    print("-" * 72)
+    all_ok = True
+    for lang, cid in cases:
+        src = sources.get(lang, sources["_default"])
+        try:
+            r = compile_one(opts.base, lang, cid, src, opts.args, False, opts.timeout)
+            ok = r["code"] == 0 and r["asm_lines"] > 0
+            note = "OK" if ok else f"FAIL: {r['setup_err'][:200]}"
+            print(f"{lang:8} {cid:16} {str(r['code']):4} {r['asm_lines']:<8} {note}")
+        except Exception as exc:  # noqa: BLE001 - report any failure per-row
+            ok = False
+            print(f"{lang:8} {cid:16} {'ERR':4} {'-':8} {exc}")
+        all_ok = all_ok and ok
+    return all_ok
+
+
+def run_execution(cases: list[tuple[str, str]], sources: dict, opts: argparse.Namespace) -> bool:
+    print(f"{'lang':8} {'compiler':16} {'didExec':7} {'exit':4} note")
+    print("-" * 72)
+    all_ok = True
+    for lang, cid in cases:
+        src = sources.get(lang, sources["_default"])
+        try:
+            r = compile_one(opts.base, lang, cid, src, opts.args, True, opts.timeout)
+            ok = r["did_execute"] is True and r["exec_code"] == 0
+            note = (f"stdout={r['stdout'][:60]!r}" if ok else f"FAIL: {r['setup_err'][:200]}").strip()
+            print(f"{lang:8} {cid:16} {str(r['did_execute']):7} {str(r['exec_code']):4} {note}")
+        except Exception as exc:  # noqa: BLE001 - report any failure per-row
+            ok = False
+            print(f"{lang:8} {cid:16} {'ERR':7} {'-':4} {exc}")
+        all_ok = all_ok and ok
+    return all_ok
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="http://localhost:10240")
+    parser.add_argument("--timeout", type=int, default=60)
+    parser.add_argument("--args", default="-O2", help="userArguments passed to every compile (default: -O2)")
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Check the execution path (didExecute + execResult.code) instead of disassembly",
+    )
+    parser.add_argument(
+        "--source",
+        action="append",
+        default=[],
+        metavar="LANG=SRC",
+        help="Override the inline source for a language",
+    )
+    parser.add_argument(
+        "--source-file",
+        action="append",
+        default=[],
+        metavar="LANG=PATH",
+        help="Read the source for a language from a file (e.g. an interpreted DSL example)",
+    )
+    parser.add_argument("cases", nargs="+", metavar="LANG:ID")
+    opts = parser.parse_args()
+
+    sources = dict(DEFAULT_SOURCES)
+    for override in opts.source:
+        lang, _, src = override.partition("=")
+        sources[lang] = src
+    for override in opts.source_file:
+        lang, _, path = override.partition("=")
+        with open(path, encoding="utf-8") as handle:
+            sources[lang] = handle.read()
+
+    cases = [(case.partition(":")[0], case.partition(":")[2]) for case in opts.cases]
+    all_ok = run_execution(cases, sources, opts) if opts.execute else run_disassembly(cases, sources, opts)
+    print("-" * 72)
+    print("ALL PASS" if all_ok else "SOME FAILED")
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
A Claude Code skill that captures the loop for vetting new compiler PRs: install the compilers locally (plus toolchain deps), run a local CE instance against the real config, compile-test every id, report a pass/fail table, then tear down.

## What's here
- `SKILL.md` -- the procedure and the hard-won gotchas (never `--env amazon` locally; layer config as `local.properties`; `--gcc-toolchain` GCC must be installed; disassembly passing != execution working).
- `compile_matrix.py` -- the reusable harness. Drives `POST /api/compiler/<id>/compile` across a list of `lang:id` cases and prints a table. Flags: `--source`/`--source-file` (interpreted DSLs whose source is an example file), `--args`, and `--execute` (checks `didExecute` + `execResult.code`, a separate path from disassembly).

## Why
Built and refined while adopting AOCC, CuTe DSL, and Lua. It earned its keep: it caught a CuTe DSL placeholder false-pass, and the `--execute` mode exists because every Lua version disassembled correctly while all executed with the wrong interpreter -- a disassembly-only check was all-green.

`make static-checks` passes.