### PR TITLE
Address compiler-explorer/issues/8780

### DIFF
--- a/bin/yaml/shader-explorer.yaml
+++ b/bin/yaml/shader-explorer.yaml
@@ -9,4 +9,4 @@ compilers:
       create_untar_dir: true
       check_exe: bin/shader_explorer --version
       targets:
-        - "0.1.2"
+        - "0.1.3"


### PR DESCRIPTION
I attempt to fix the issue described in https://github.com/compiler-explorer/compiler-explorer/issues/8780. I used the following to test & reproduce the issue locally:

```
user@archlinux ~/D/shader_explorer-0.1.3-linux-x86_64> prlimit --fsize=1073741824:1073741824 -- bin/shader_explorer --lang glsl --target asm --no-color --gpu intel-lnl test_shader/mat_mul.glsl --target info
device.name=Intel(R) Graphics (LNL)
device.vendor_id=32902
device.device_id=25760
device.api_version=1.4.348
limits.max_compute_shared_memory_size=49152
limits.max_compute_work_group_invocations=1024
limits.max_compute_work_group_size=1024,1024,1024
user@archlinux ~/D/shader_explorer-0.1.3-linux-x86_64> prlimit --fsize=1048576:1048576 -- bin/shader_explorer --lang glsl --target asm --no-color --gpu intel-lnl test_shader/mat_mul.glsl --target info
internal child failure while collecting device info: child terminated by signal (25)

```

The issue was that the driver allocated 4GB of vram as shared memory and shared memory counts against the RLIMIT_FSIZE limit. The shader cache theory is likely false because we have to disable it either way because otherwise the driver will not compile the code and thus we don't have any assembly to print.

About problem 1: I ensured that the error messages are clear and list the GPUs to choose from, so the rest is simply visual presentation. Making it a hidden default option definitely hurts discoverability. So the only other option is to have a default   parameter in the "Compiler Options..." field, but I don't know how to do that. On top of that I don't have a preference for a specific GPU.

Given that this doesn't solve problem 1, I don't know if this PR should close that issue, and in general we should check if the sandbox contains more surprises for me.