### PR TITLE
Make ce-conan survive resolver restarts during unattended-upgrades

### DIFF
--- a/init/ce-conan.service
+++ b/init/ce-conan.service
@@ -1,6 +1,14 @@
 [Unit]
 Description=CE Conan
-After=remote-fs.target
+# systemd-resolved ordering: the startup script does DNS-dependent work (git pull).
+# needrestart can bounce resolved and this unit together during unattended-upgrades;
+# ordering after resolved (Type=notify, so this waits until it can answer) avoids the
+# race when both restarts share a transaction. Restart=on-failure covers the case where
+# they don't -- a failed git pull retries once resolved is back.
+After=remote-fs.target systemd-resolved.service
+Wants=systemd-resolved.service
+StartLimitIntervalSec=300
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -11,6 +19,8 @@ ExecStart=/home/ubuntu/infra/init/start-conan.sh
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=ce-conan
+Restart=on-failure
+RestartSec=15
 
 [Install]
 WantedBy=multi-user.target

--- a/init/ce-conan.service
+++ b/init/ce-conan.service
@@ -5,8 +5,8 @@ Description=CE Conan
 # ordering after resolved (Type=notify, so this waits until it can answer) avoids the
 # race when both restarts share a transaction. Restart=on-failure covers the case where
 # they don't -- a failed git pull retries once resolved is back.
-After=remote-fs.target systemd-resolved.service
-Wants=systemd-resolved.service
+After=remote-fs.target systemd-resolved.service network-online.target
+Wants=systemd-resolved.service network-online.target
 StartLimitIntervalSec=300
 StartLimitBurst=5
 

--- a/setup-conan.sh
+++ b/setup-conan.sh
@@ -118,37 +118,6 @@ LOG_DEST_PORT=$(get_conf /compiler-explorer/logDestPort)
 PTRAIL='/etc/rsyslog.d/99-papertrail.conf'
 echo "*.*          @${LOG_DEST_HOST}:${LOG_DEST_PORT}" >"${PTRAIL}"
 service rsyslog restart
-pushd /tmp
-curl -sL 'https://github.com/papertrail/remote_syslog2/releases/download/v0.21/remote_syslog_linux_amd64.tar.gz' | tar zxf -
-cp remote_syslog/remote_syslog /usr/local/bin/
-popd
-
-cat >/etc/log_files.yml <<EOF
-files:
-    - /var/log/nginx/*.err
-destination:
-    host: ${LOG_DEST_HOST}
-    port: ${LOG_DEST_PORT}
-    protocol: tls
-EOF
-
-cat >/lib/systemd/system/remote-syslog.service <<EOF
-[Unit]
-Description=remote_syslog2
-Documentation=https://github.com/papertrail/remote_syslog2
-After=network-online.target
-
-[Service]
-ExecStartPre=/usr/bin/test -e /etc/log_files.yml
-ExecStart=/usr/local/bin/remote_syslog -D
-Restart=always
-User=root
-Group=root
-
-[Install]
-WantedBy=multi-user.target
-EOF
-systemctl enable remote-syslog
 
 # Install grafana-agent. Conan-node has a real data mount at
 # /home/ce/.conan_server, so override FS_IGNORE to let it through. We'd


### PR DESCRIPTION
Two changes to the conan AMI, both shipping in the next rebake.

## 1. Survive resolver restarts during unattended-upgrades

On 2026-06-04 conan.compiler-explorer.com 502'd. The box had been up 28 days, so this was not a boot.

Timeline (UTC, from the box journal):

```
06:15:33  ce-conan: Stopping              <- needrestart, during apt-daily-upgrade
06:15:34  ce-conan: Started -> git pull -> "Could not resolve host: github.com"
06:15:34  systemd-resolved: Stopped       <- needrestart bounced resolved in the same pass
06:15:34  ce-conan: Main process exited 1/FAILURE -> Failed
06:15:35  systemd-resolved: Started       <- back ~1s later, too late
13:11:42  ce-conan: Started               <- manual restart
```

Root cause: the nightly `apt-daily-upgrade` ran unattended-upgrades, and `needrestart` restarted both `ce-conan` and `systemd-resolved`. `ce-conan`'s startup `git pull` (in `start-conan.sh`, under `set -e`) lost a ~1s race against the resolver coming back. With no `Restart=` policy the unit failed and stayed down ~7h until a manual restart.

Fix (unit-file only, no script changes):

- `After=systemd-resolved.service` + `Wants=` -- resolved is `Type=notify`, so this orders ce-conan until resolved can actually answer. Covers the case where needrestart restarts both in one transaction.
- `Restart=on-failure` / `RestartSec=15` -- the real safety net for when the restarts are separate transactions (ordering only binds within a shared transaction). A failed startup retries once resolved is back.
- `StartLimitIntervalSec=300` / `StartLimitBurst=5` -- still fails a genuinely broken deploy hard instead of looping.
- `After/Wants=network-online.target` -- boot-time hygiene for the startup script's network I/O (does not affect the mid-life restart case; resolver ordering + Restart= are what fix the incident).

## 2. Drop dead remote_syslog2 logging

`setup-conan.sh` hand-copied the `remote_syslog2` block from `setup-common.sh`, including a `log_files.yml` that tails `/var/log/nginx/*.err`. The conan box has no nginx (gunicorn + node), so the daemon tails a file that never exists. rsyslog already ships `*.*` to Papertrail and grafana-agent is installed, so this was dead weight. Conan-only: `setup-conan.sh` does not source `setup-common.sh`.

The wider nginx-tailing cleanup on other non-web nodes (via `setup-common.sh`) is tracked in #2159.

## Deploy

AMI-baked (`setup-conan.sh` installs the unit + logging), so this lands via a conan AMI rebake + instance replacement.

## Monitoring: no gap (investigated, no action)

Initially suspected a ~4h detection lag. It was a timezone/human artifact, not a real gap: the Grafana SM alert fired ~06:1x UTC, within its 10m window of the 06:15 failure. The "5:22 AM Chicago" was when the alert was seen, not when it fired. CloudFront was also ruled out -- `/healthcheck` returns `x-cache: Miss` on repeated requests and the origin sends `no-store`, so it is never cached. Nothing to change on the alerting or CDN side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)