### PR TITLE
Add gcc-old bespoke-build image option

### DIFF
--- a/.github/workflows/bespoke-build.yaml
+++ b/.github/workflows/bespoke-build.yaml
@@ -12,6 +12,7 @@ on:
         options:
         # main ones
         - gcc
+        - gcc-old
         - gcc-cross
         - clang
         - misc


### PR DESCRIPTION
Adds `gcc-old` as a `bespoke-build` image choice, selecting the new
`compilerexplorer/gcc-old-builder` image (Ubuntu 18.04 / glibc 2.27,
added in gcc-builder).

Old gcc versions (<= 9.x) don't build on the default 22.04 image: their
libsanitizer and libgo assume glibc internals (ipc_perm.mode, SIGSTKSZ,
sys/ustat.h) that changed in glibc 2.28-2.34. Building them on glibc 2.27
sidesteps the whole cascade, and bionic's gnat (<= 9) bootstraps Ada, so
the full language set is retained. The compilers bundle binutils 2.38 so
their ld works against Ubuntu 24.04's glibc (SHT_RELR).

Validated: gcc-9.3.0 rebuilt via this image, verified gccgo/go/gnat/gdc
present with a real binutils-2.38 ld, and confirmed end-to-end against a
glibc-2.39 `.relr.dyn` host.

Context: compiler-explorer/infra#1736