### PR TITLE
Add `clang-cl` to `init/settings.yml`

### DIFF
--- a/init/settings.yml
+++ b/init/settings.yml
@@ -60,6 +60,9 @@ compiler:
     win32-mingw-clang:
         version: ANY
         libcxx: ANY
+    clang-cl:
+        version: ANY
+        libcxx: ANY
     lfortran:
         version: ANY
         libcxx: ANY


### PR DESCRIPTION
As suggested in https://github.com/compiler-explorer/compiler-explorer/pull/8796#issuecomment-4638015463, this adds `clang-cl` as a compiler in the list.