### PR TITLE
init support for sfpi

### DIFF
--- a/bin/yaml/sfpi.yaml
+++ b/bin/yaml/sfpi.yaml
@@ -1,0 +1,10 @@
+compilers:
+  sfpi:
+    type: tarballs
+    compression: xz
+    dir: sfpi-{{name}}
+    untar_dir: sfpi
+    check_exe: compiler/bin/riscv-tt-elf-g++ --version
+    targets:
+      - name: 7.55.0
+        url: https://github.com/tenstorrent/sfpi/releases/download/{{name}}/sfpi_{{name}}_x86_64_debian.txz

--- a/bin/yaml/sfpi.yaml
+++ b/bin/yaml/sfpi.yaml
@@ -6,6 +6,25 @@ compilers:
     untar_dir: sfpi
     check_exe: compiler/bin/riscv-tt-elf-g++ --version
     url: https://github.com/tenstorrent/sfpi/releases/download/{{name}}/sfpi_{{name}}_x86_64_debian.txz
+    depends:
+      - tools/tt-metal-headers {{tt_metal_version}}
+    after_stage_script:
+      - mkdir -p sfpi/build/sfpi sfpi/tt_metal
+      - cp -a sfpi/include sfpi/build/sfpi/
+      - mkdir -p sfpi/tt_metal/hw sfpi/tt_metal/tt-llk sfpi/tt_metal/hw/ckernels
+      - cp -a %DEP0%/tt_metal/hw/inc sfpi/tt_metal/hw/
+      - cp -a %DEP0%/tt_metal/tt-llk/common sfpi/tt_metal/tt-llk/
+      - mkdir -p sfpi/tt_metal/tt-llk/tests/helpers
+      - cp -a %DEP0%/tt_metal/tt-llk/tests/helpers/include sfpi/tt_metal/tt-llk/tests/helpers/
+      - cp -a %DEP0%/tt_metal/tt-llk/tt_llk_wormhole_b0 sfpi/tt_metal/tt-llk/
+      - cp -a %DEP0%/tt_metal/tt-llk/tt_llk_blackhole sfpi/tt_metal/tt-llk/
+      - mkdir -p sfpi/tt_metal/hw/ckernels/wormhole_b0/metal
+      - mkdir -p sfpi/tt_metal/hw/ckernels/blackhole/metal
+      - cp -a %DEP0%/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api sfpi/tt_metal/hw/ckernels/wormhole_b0/metal/
+      - cp -a %DEP0%/tt_metal/hw/ckernels/blackhole/metal/llk_api sfpi/tt_metal/hw/ckernels/blackhole/metal/
     targets:
-      - 7.54.0
-      - 7.55.0
+      - name: 7.54.0
+        # Confirm the exact matching tt-metal tag if 7.54.0 needs a stricter pairing.
+        tt_metal_version: v0.71.2
+      - name: 7.55.0
+        tt_metal_version: v0.71.2

--- a/bin/yaml/sfpi.yaml
+++ b/bin/yaml/sfpi.yaml
@@ -9,19 +9,7 @@ compilers:
     depends:
       - tools/tt-metal-headers {{tt_metal_version}}
     after_stage_script:
-      - mkdir -p sfpi/build/sfpi sfpi/tt_metal
-      - cp -a sfpi/include sfpi/build/sfpi/
-      - mkdir -p sfpi/tt_metal/hw sfpi/tt_metal/tt-llk sfpi/tt_metal/hw/ckernels
-      - cp -a %DEP0%/tt_metal/hw/inc sfpi/tt_metal/hw/
-      - cp -a %DEP0%/tt_metal/tt-llk/common sfpi/tt_metal/tt-llk/
-      - mkdir -p sfpi/tt_metal/tt-llk/tests/helpers
-      - cp -a %DEP0%/tt_metal/tt-llk/tests/helpers/include sfpi/tt_metal/tt-llk/tests/helpers/
-      - cp -a %DEP0%/tt_metal/tt-llk/tt_llk_wormhole_b0 sfpi/tt_metal/tt-llk/
-      - cp -a %DEP0%/tt_metal/tt-llk/tt_llk_blackhole sfpi/tt_metal/tt-llk/
-      - mkdir -p sfpi/tt_metal/hw/ckernels/wormhole_b0/metal
-      - mkdir -p sfpi/tt_metal/hw/ckernels/blackhole/metal
-      - cp -a %DEP0%/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api sfpi/tt_metal/hw/ckernels/wormhole_b0/metal/
-      - cp -a %DEP0%/tt_metal/hw/ckernels/blackhole/metal/llk_api sfpi/tt_metal/hw/ckernels/blackhole/metal/
+      - "{{yaml_dir}}/sfpi/prepare-headers.sh {{name}} %DEP0% sfpi"
     targets:
       - name: 7.54.0
         # Confirm the exact matching tt-metal tag if 7.54.0 needs a stricter pairing.

--- a/bin/yaml/sfpi.yaml
+++ b/bin/yaml/sfpi.yaml
@@ -5,6 +5,7 @@ compilers:
     dir: sfpi-{{name}}
     untar_dir: sfpi
     check_exe: compiler/bin/riscv-tt-elf-g++ --version
+    url: https://github.com/tenstorrent/sfpi/releases/download/{{name}}/sfpi_{{name}}_x86_64_debian.txz
     targets:
-      - name: 7.55.0
-        url: https://github.com/tenstorrent/sfpi/releases/download/{{name}}/sfpi_{{name}}_x86_64_debian.txz
+      - 7.54.0
+      - 7.55.0

--- a/bin/yaml/sfpi/prepare-headers.sh
+++ b/bin/yaml/sfpi/prepare-headers.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sfpi_version="${1:?sfpi version required}"
+tt_metal_dep="${2:?tt-metal headers path required}"
+sfpi_root="${3:?sfpi root required}"
+
+mkdir -p "${sfpi_root}/build/sfpi" "${sfpi_root}/tt_metal"
+cp -a "${sfpi_root}/include" "${sfpi_root}/build/sfpi/"
+
+mkdir -p "${sfpi_root}/tt_metal/hw" "${sfpi_root}/tt_metal/tt-llk" "${sfpi_root}/tt_metal/hw/ckernels"
+cp -a "${tt_metal_dep}/tt_metal/hw/inc" "${sfpi_root}/tt_metal/hw/"
+cp -a "${tt_metal_dep}/tt_metal/tt-llk/common" "${sfpi_root}/tt_metal/tt-llk/"
+mkdir -p "${sfpi_root}/tt_metal/tt-llk/tests/helpers"
+cp -a "${tt_metal_dep}/tt_metal/tt-llk/tests/helpers/include" "${sfpi_root}/tt_metal/tt-llk/tests/helpers/"
+cp -a "${tt_metal_dep}/tt_metal/tt-llk/tt_llk_wormhole_b0" "${sfpi_root}/tt_metal/tt-llk/"
+cp -a "${tt_metal_dep}/tt_metal/tt-llk/tt_llk_blackhole" "${sfpi_root}/tt_metal/tt-llk/"
+mkdir -p "${sfpi_root}/tt_metal/hw/ckernels/wormhole_b0/metal"
+mkdir -p "${sfpi_root}/tt_metal/hw/ckernels/blackhole/metal"
+cp -a "${tt_metal_dep}/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api" \
+  "${sfpi_root}/tt_metal/hw/ckernels/wormhole_b0/metal/"
+cp -a "${tt_metal_dep}/tt_metal/hw/ckernels/blackhole/metal/llk_api" \
+  "${sfpi_root}/tt_metal/hw/ckernels/blackhole/metal/"
+
+case "${sfpi_version}" in
+  7.55.0)
+    cat > "${sfpi_root}/include/ce_sfpi_compat.h" <<'HEADER_EOF'
+#pragma once
+
+#include <cstdint>
+
+#include "internal/risc_attribs.h"
+
+#if defined(__riscv_xtttensixbh)
+#include "internal/tt-1xx/blackhole/tensix.h"
+#elif defined(__riscv_xtttensixwh)
+#include "internal/tt-1xx/wormhole/tensix.h"
+#else
+#error "Unsupported SFPI architecture for instrn_buffer compatibility shim"
+#endif
+
+namespace ckernel {
+inline volatile tt_reg_ptr std::uint32_t *const instrn_buffer =
+    reinterpret_cast<volatile std::uint32_t *>(INSTRN_BUF_BASE);
+}
+HEADER_EOF
+    ;;
+  *)
+    echo "Unsupported SFPI version: ${sfpi_version}" >&2
+    exit 1
+    ;;
+esac

--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -136,6 +136,16 @@ tools:
         url: https://github.com/rust-lang/rustfmt/releases/download/v1.4.36/rustfmt_linux-x86_64_v1.4.36.tar.gz
         strip_components: 1
         create_untar_dir: true
+  tt-metal-headers:
+    type: tarballs
+    compression: gz
+    url: https://github.com/tenstorrent/tt-metal/archive/refs/tags/{{name}}.tar.gz
+    dir: tt-metal-headers-{{name}}
+    create_untar_dir: true
+    strip_components: 1
+    check_file: tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu_math.h
+    targets:
+      - v0.71.2
   mmbutils:
     if: nightly
     type: github


### PR DESCRIPTION
Start of sfpi support for compiler explorer. Infra part 

Edit: This is for sfpi which is the gcc compiler for tenstorrent devices. This particular support can be thought of as tenstorrent version of device kernel in cuda.
There is some intro information here: https://github.com/tenstorrent/tt-metal/blob/main/METALIUM_GUIDE.md