### PR TITLE
feat(msvc): add MSVC 14.51 (VS 2026 18.6) to property generation

### DIFF
--- a/msvc-install/gen-props.py
+++ b/msvc-install/gen-props.py
@@ -39,6 +39,10 @@ minimum_install_req = [
     {"MSVersionSemver": "14.44.35207", "MSVSVer": "2022", "MSVSShortVer": "17.14.19", "ZIPFile": "14.44.35207-14.44.35219.0"},
     {"MSVersionSemver": "14.50.35717", "MSVSVer": "2026", "MSVSShortVer": "18.0.0", "ZIPFile": "14.50.35717-14.50.35717.0"},
     {"MSVersionSemver": "14.50.35723", "MSVSVer": "2026", "MSVSShortVer": "18.2.1", "ZIPFile": "14.50.35717-14.50.35723.0"},
+    # MSVC v14.51 shipped in Visual Studio 2026 18.6 (May 2026). cl.exe reports 14.51.36246.0.
+    # Packaged 2026-06-02 via gh-msvc-install.ps1.
+    # https://github.com/compiler-explorer/compiler-explorer/issues/8723
+    {"MSVersionSemver": "14.51.36231", "MSVSVer": "2026", "MSVSShortVer": "18.6.0", "ZIPFile": "14.51.36231-14.51.36246.0"},
 ]
 # fmt: on
 

--- a/msvc-install/gen-props.py
+++ b/msvc-install/gen-props.py
@@ -39,9 +39,6 @@ minimum_install_req = [
     {"MSVersionSemver": "14.44.35207", "MSVSVer": "2022", "MSVSShortVer": "17.14.19", "ZIPFile": "14.44.35207-14.44.35219.0"},
     {"MSVersionSemver": "14.50.35717", "MSVSVer": "2026", "MSVSShortVer": "18.0.0", "ZIPFile": "14.50.35717-14.50.35717.0"},
     {"MSVersionSemver": "14.50.35723", "MSVSVer": "2026", "MSVSShortVer": "18.2.1", "ZIPFile": "14.50.35717-14.50.35723.0"},
-    # MSVC v14.51 shipped in Visual Studio 2026 18.6 (May 2026). cl.exe reports 14.51.36246.0.
-    # Packaged 2026-06-02 via gh-msvc-install.ps1.
-    # https://github.com/compiler-explorer/compiler-explorer/issues/8723
     {"MSVersionSemver": "14.51.36231", "MSVSVer": "2026", "MSVSShortVer": "18.6.0", "ZIPFile": "14.51.36231-14.51.36246.0"},
 ]
 # fmt: on


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

Adds MSVC v14.51 (Visual Studio 2026 18.6, May 2026) to `msvc-install/gen-props.py`, updating the version table and advancing `latest` to v14.51.

The toolset was packaged on 2026-06-02 (run [26797911927](https://github.com/compiler-explorer/infra/actions/runs/26797911927)) producing zip `14.51.36231-14.51.36246.0` (cl.exe reports 14.51.36246.0).

Companion CE PR: compiler-explorer/compiler-explorer#8804

🤖 Generated by LLM (Claude, via OpenClaw)