### PR TITLE
Kokkos: Allow running with `Cuda C++`

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -3085,6 +3085,24 @@ libraries:
       targets:
       - 1.8.0
       type: github
+    kokkos_cuda:
+      build_type: cmake
+      lib_type: static
+      make_targets:
+      - all
+      extra_cmake_arg:
+      - -DKokkos_ENABLE_CUDA=ON
+      - -DKokkos_ARCH_TURING75=ON
+      package_install: true
+      repo: kokkos/kokkos
+      staticliblink:
+      - kokkoscore
+      - kokkoscontainers
+      - kokkossimd
+      targets:
+      - 4.7.04
+      - 5.1.1
+      type: github
     matx:
       check_file: README.md
       method: clone_branch
@@ -3170,26 +3188,6 @@ libraries:
       - 1.15.0
       - 1.16.0
       - 1.17.0
-      type: github
-  gpu:
-    kokkos:
-      subdir: gpu/kokkos
-      build_type: cmake
-      lib_type: static
-      make_targets:
-      - all
-      extra_cmake_arg:
-      - -DKokkos_ENABLE_CUDA=ON
-      - -DKokkos_ARCH_TURING75=ON
-      package_install: true
-      repo: kokkos/kokkos
-      staticliblink:
-      - kokkoscore
-      - kokkoscontainers
-      - kokkossimd
-      targets:
-      - 4.7.04
-      - 5.1.1
       type: github
   d:
     mir-algorithm:

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -3171,6 +3171,33 @@ libraries:
       - 1.16.0
       - 1.17.0
       type: github
+  kokkos:
+      build_type: cmake
+      lib_type: static
+      make_targets:
+      - all
+      extra_cmake_arg:
+      - -DCMAKE_BUILD_TYPE=Release -DKokkos_ENABLE_CUDA=ON
+      package_install: true
+      repo: kokkos/kokkos
+      staticliblink:
+      - kokkoscore
+      - kokkoscontainers
+      - kokkossimd
+      targets:
+      - 4.0.01
+      - 4.1.00
+      - 4.2.00
+      - 4.2.01
+      - 4.3.00
+      - 4.3.01
+      - 4.4.00
+      - 4.4.01
+      - 4.5.00
+      - 4.5.01
+      - 4.6.00
+      - 4.6.01
+      type: github
   d:
     mir-algorithm:
       check_file: README.md

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -3177,7 +3177,7 @@ libraries:
       make_targets:
       - all
       extra_cmake_arg:
-      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - -DKokkos_ENABLE_CUDA=ON
       - -DKokkos_ARCH_TURING75=ON
       package_install: true

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -3188,18 +3188,8 @@ libraries:
       - kokkoscontainers
       - kokkossimd
       targets:
-      - 4.0.01
-      - 4.1.00
-      - 4.2.00
-      - 4.2.01
-      - 4.3.00
-      - 4.3.01
-      - 4.4.00
-      - 4.4.01
-      - 4.5.00
-      - 4.5.01
-      - 4.6.00
-      - 4.6.01
+      - 4.7.04
+      - 5.1.1
       type: github
   d:
     mir-algorithm:

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -3177,7 +3177,6 @@ libraries:
       make_targets:
       - all
       extra_cmake_arg:
-      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - -DKokkos_ENABLE_CUDA=ON
       - -DKokkos_ARCH_TURING75=ON
       package_install: true

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -3171,7 +3171,9 @@ libraries:
       - 1.16.0
       - 1.17.0
       type: github
-  kokkos:
+  gpu:
+    kokkos:
+      subdir: gpu/kokkos
       build_type: cmake
       lib_type: static
       make_targets:

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -3177,7 +3177,8 @@ libraries:
       make_targets:
       - all
       extra_cmake_arg:
-      - -DCMAKE_BUILD_TYPE=Release -DKokkos_ENABLE_CUDA=ON
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DKokkos_ENABLE_CUDA=ON
       package_install: true
       repo: kokkos/kokkos
       staticliblink:

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -3179,6 +3179,7 @@ libraries:
       extra_cmake_arg:
       - -DCMAKE_BUILD_TYPE=Release
       - -DKokkos_ENABLE_CUDA=ON
+      - -DKokkos_ARCH_TURING75=ON
       package_install: true
       repo: kokkos/kokkos
       staticliblink:

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -3085,7 +3085,7 @@ libraries:
       targets:
       - 1.8.0
       type: github
-    kokkos_cuda:
+    kokkos-cuda:
       build_type: cmake
       lib_type: static
       make_targets:


### PR DESCRIPTION
New try at making this https://github.com/compiler-explorer/infra/pull/1666 work and a little cleaner.
Corresponds to https://github.com/compiler-explorer/compiler-explorer/pull/8808

Changes to the old PR:
- Reduced the version range which was quite excessive
- Moved it into the `cuda` section instead of the `gpu` section and renamed it into `kokkos-cuda`. That should avoid the conflict with existing host installations of `kokkos`