### PR TITLE
fix: use -b 0 in journalctl to avoid stale boot entries in runner_start

### DIFF
--- a/bin/lib/cli/gpu_runner.py
+++ b/bin/lib/cli/gpu_runner.py
@@ -89,7 +89,7 @@ def gpu_runner_start():
 
     for _ in range(60):
         try:
-            r = exec_remote(instance, ["journalctl", "-u", "compiler-explorer", "-r", "-n", "5", "-q"])
+            r = exec_remote(instance, ["journalctl", "-b", "0", "-u", "compiler-explorer", "-r", "-n", "5", "-q"])
             if (
                 "compiler-explorer.service: Deactivated successfully." in r  # 22.04
                 or "compiler-explorer.service: Succeeded." in r  # 20.04

--- a/bin/lib/cli/runner.py
+++ b/bin/lib/cli/runner.py
@@ -156,7 +156,7 @@ def runner_start():
 
     for _ in range(60):
         try:
-            r = exec_remote(instance, ["journalctl", "-u", "compiler-explorer", "-r", "-n", "5", "-q"])
+            r = exec_remote(instance, ["journalctl", "-b", "0", "-u", "compiler-explorer", "-r", "-n", "5", "-q"])
             if (
                 "compiler-explorer.service: Deactivated successfully." in r  # 22.04
                 or "compiler-explorer.service: Succeeded." in r  # 20.04


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

## Problem

`ce runner discovery` fails intermittently with:
```
chown: changing ownership of './node_modules/@fortawesome/fontawesome-free/svgs/solid/sheet-plastic.svg': No such file or directory
RuntimeError: Remote command execution failed with status 1
```

The failure always occurs on the first discovery run after a new build against a freshly-started runner, and always succeeds on retry. This is a race condition, not a transient I/O error.

## Root Cause

In `runner_start` (and `gpu_runner_start`), the code waits for the compiler-explorer systemd service to complete before proceeding:

```python
r = exec_remote(instance, ["journalctl", "-u", "compiler-explorer", "-r", "-n", "5", "-q"])
if (
    "compiler-explorer.service: Deactivated successfully." in r
    or "compiler-explorer.service: Succeeded." in r
):
    break
```

The `journalctl` call has no `-b 0` flag, so it reads the **entire journal history**, including entries from previous boots. When the runner is started from a stopped state, the very first check finds the old `Deactivated successfully` entry from the *last* time the service ran and immediately declares the runner ready — while `start.sh` is still executing on the current boot.

## The Race

Both `start.sh` (systemd, on boot) and `do-discovery.sh` (called by the discovery workflow) invoke `update_code()`, which does:

```bash
rm -rf "${DEPLOY_DIR}"
get_released_code "${DEPLOY_DIR}" "${S3_KEY}"
```

`get_released_code` writes `s3_key` **before** starting `tar Jxf -`. If the discovery workflow's `update_code` runs between `start.sh`'s `rm -rf` and the new `s3_key` being written, it finds no `s3_key`, performs its own `rm -rf` + extraction — now two concurrent `tar` processes are writing and deleting files in the same `/infra/.deploy` directory. The result is a file that was successfully extracted getting deleted by the other process before `chown` can reach it.

## Evidence

- Failed run [27276415143](https://github.com/compiler-explorer/infra/actions/runs/27276415143): log shows `CUR_S3_KEY` still pointing at the old build when discovery ran, proving `start.sh`'s `update_code` was mid-flight
- Successful retry [27276609964](https://github.com/compiler-explorer/infra/actions/runs/27276609964): immediately hit `Build ... already checked out`, skipped extraction entirely
- Same failure pattern observed in multiple prior runs

## Fix

Add `-b 0` to `journalctl` in both `runner.py` and `gpu_runner.py` so the wait loop only considers journal entries from the **current boot**. This ensures `runner_start` only proceeds once `start.sh` has actually finished on this boot, closing the race window entirely.