### PR TITLE
Stop forwarding rsyslog local-write-failure spam to Papertrail

### DIFF
--- a/setup-common.sh
+++ b/setup-common.sh
@@ -72,7 +72,15 @@ LOG_DEST_PORT_PARAM="${LOG_DEST_PORT_PARAM:-/compiler-explorer/logDestPort}"
 LOG_DEST_HOST=$(get_conf "${LOG_DEST_HOST_PARAM}")
 LOG_DEST_PORT=$(get_conf "${LOG_DEST_PORT_PARAM}")
 PTRAIL='/etc/rsyslog.d/99-papertrail.conf'
-echo "*.*          @${LOG_DEST_HOST}:${LOG_DEST_PORT}" >"${PTRAIL}"
+cat >"${PTRAIL}" <<RSYSLOG_EOF
+# Don't forward rsyslog's own local-write-failure messages. With a full disk,
+# every failed write to /var/log/* generates more of them (including for the
+# failures they themselves cause), flooding the remote destination at hundreds
+# of thousands of messages per minute and exhausting the log quota.
+# See https://github.com/compiler-explorer/compiler-explorer/issues/8811
+if \$programname == 'rsyslogd' and (\$msg contains 'write error' or \$msg contains 'message lost') then stop
+*.*          @${LOG_DEST_HOST}:${LOG_DEST_PORT}
+RSYSLOG_EOF
 service rsyslog restart
 pushd /tmp
 

--- a/setup-common.sh
+++ b/setup-common.sh
@@ -78,7 +78,7 @@ cat >"${PTRAIL}" <<RSYSLOG_EOF
 # failures they themselves cause), flooding the remote destination at hundreds
 # of thousands of messages per minute and exhausting the log quota.
 # See https://github.com/compiler-explorer/compiler-explorer/issues/8811
-if \$programname == 'rsyslogd' and (\$msg contains 'write error' or \$msg contains 'message lost') then stop
+if \$programname == 'rsyslogd' and (\$msg contains 'write error' or \$msg contains 'message lost' or \$msg contains 'messages lost') then stop
 *.*          @${LOG_DEST_HOST}:${LOG_DEST_PORT}
 RSYSLOG_EOF
 service rsyslog restart

--- a/setup-conan.sh
+++ b/setup-conan.sh
@@ -122,7 +122,7 @@ cat >"${PTRAIL}" <<RSYSLOG_EOF
 # failures they themselves cause), flooding the remote destination at hundreds
 # of thousands of messages per minute and exhausting the log quota.
 # See https://github.com/compiler-explorer/compiler-explorer/issues/8811
-if \$programname == 'rsyslogd' and (\$msg contains 'write error' or \$msg contains 'message lost') then stop
+if \$programname == 'rsyslogd' and (\$msg contains 'write error' or \$msg contains 'message lost' or \$msg contains 'messages lost') then stop
 *.*          @${LOG_DEST_HOST}:${LOG_DEST_PORT}
 RSYSLOG_EOF
 service rsyslog restart

--- a/setup-conan.sh
+++ b/setup-conan.sh
@@ -116,7 +116,15 @@ get_conf() {
 LOG_DEST_HOST=$(get_conf /compiler-explorer/logDestHost)
 LOG_DEST_PORT=$(get_conf /compiler-explorer/logDestPort)
 PTRAIL='/etc/rsyslog.d/99-papertrail.conf'
-echo "*.*          @${LOG_DEST_HOST}:${LOG_DEST_PORT}" >"${PTRAIL}"
+cat >"${PTRAIL}" <<RSYSLOG_EOF
+# Don't forward rsyslog's own local-write-failure messages. With a full disk,
+# every failed write to /var/log/* generates more of them (including for the
+# failures they themselves cause), flooding the remote destination at hundreds
+# of thousands of messages per minute and exhausting the log quota.
+# See https://github.com/compiler-explorer/compiler-explorer/issues/8811
+if \$programname == 'rsyslogd' and (\$msg contains 'write error' or \$msg contains 'message lost') then stop
+*.*          @${LOG_DEST_HOST}:${LOG_DEST_PORT}
+RSYSLOG_EOF
 service rsyslog restart
 
 # Install grafana-agent. Conan-node has a real data mount at


### PR DESCRIPTION
Companion to compiler-explorer/compiler-explorer#8811 (production disk-full incident).

When a disk fills, rsyslog's local `omfile` action fails for every message, and each failure emits internal error messages (`write error` / `message lost`). These were matched by `*.*` and forwarded to Papertrail — including the errors generated by failing to locally write the *previous* errors, a self-sustaining feedback loop. During the incident this shipped **~290k messages/min for 95 minutes** (~27M messages), exhausting the log subscription quota (315% of allowance) and cutting off Papertrail ingestion for the entire fleet.

This drops those two specific internal messages just before the forwarding rule in `/etc/rsyslog.d/99-papertrail.conf` (written by both `setup-common.sh` and `setup-conan.sh`). Rationale for a plain drop rather than sampling: these messages are by definition about the local disk, recur once per failed local write, and carry no novel information remotely — and disk-full visibility is now covered by Grafana disk metrics and the free-space healthcheck (compiler-explorer/compiler-explorer#8814). Local rules (processed before this file) are unaffected.

Note: I couldn't run `rsyslogd -N1` locally (AppArmor confines it to its standard config paths); worth a quick `sudo rsyslogd -N1 -f <generated file>` sanity check on any instance before the next AMI bake. The filter is standard RainerScript and validates by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)