### PR TITLE
Add RazorForge install recipe

### DIFF
--- a/bin/yaml/razorforge.yaml
+++ b/bin/yaml/razorforge.yaml
@@ -1,0 +1,11 @@
+compilers:
+  razorforge:
+    type: tarballs
+    compression: gz
+    dir: razorforge-{{name}}
+    strip_components: 1
+    create_untar_dir: true
+    check_exe: RazorForge version
+    url: https://github.com/dj-lumiere/razorforge-suflae/releases/download/v{{name}}/razorforge-v{{name}}-linux-x64.tar.gz
+    targets:
+      - 0.0.3-alpha


### PR DESCRIPTION
  Install recipe for the RazorForge compiler, paired with
  compiler-explorer/compiler-explorer#8825.

  `bin/yaml/razorforge.yaml` pulls the Linux x64 release tarball from the project's GitHub
  releases and unpacks it under `razorforge-{version}`. The tarball contains a self-contained
  `RazorForge` executable plus the bundled `Standard/` library, so no build step is required.

  - Source: https://github.com/dj-lumiere/razorforge-suflae/releases
  - Initial target: `0.0.4-alpha`
  - `check_exe: RazorForge version`
