### PR TITLE
Add RazorForge compiler (0.0.4-alpha tarball install)

### DIFF
--- a/bin/yaml/razorforge.yaml
+++ b/bin/yaml/razorforge.yaml
@@ -9,4 +9,3 @@ compilers:
     check_exe: RazorForge version
     targets:
       - 0.0.4
-      

--- a/bin/yaml/razorforge.yaml
+++ b/bin/yaml/razorforge.yaml
@@ -1,0 +1,11 @@
+compilers:
+  razorforge:
+    type: tarballs
+    compression: gz
+    url: https://github.com/dj-lumiere/razorforge-suflae/releases/download/v{{name}}-alpha/razorforge-v{{name}}-alpha-linux-x64.tar.gz
+    create_untar_dir: true
+    strip_components: 1
+    dir: razorforge-{{name}}-alpha
+    check_exe: RazorForge version
+    targets:
+      - 0.0.4

--- a/bin/yaml/razorforge.yaml
+++ b/bin/yaml/razorforge.yaml
@@ -9,3 +9,4 @@ compilers:
     check_exe: RazorForge version
     targets:
       - 0.0.4
+      


### PR DESCRIPTION
  Install recipe for the RazorForge compiler, paired with
  compiler-explorer/compiler-explorer#8825.

  `bin/yaml/razorforge.yaml` pulls the Linux x64 release tarball from the project's GitHub
  releases and unpacks it under `razorforge-{version}`. The tarball contains a self-contained
  `RazorForge` executable plus the bundled `Standard/` library, so no build step is required.

  - Source: https://github.com/dj-lumiere/razorforge-suflae/releases
  - Initial target: `0.0.4-alpha`
  - `check_exe: RazorForge version`
