### PR TITLE
Sync events-lambda package-lock.json to fix main static-checks

### DIFF
--- a/events-lambda/package-lock.json
+++ b/events-lambda/package-lock.json
@@ -1649,18 +1649,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@types/eslint": {
-      "version": "8.56.10",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
-      "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

`make static-checks` fails on a clean `main` at the `lint-events-lambda` pre-commit hook with `files were modified by this hook`. This is not an eslint failure — `eslint --max-warnings=0` exits 0. The hook runs `npm install && npm run lint`, and `npm install` prunes a stale optional peer dependency (`@types/eslint@8.56.10`) from the committed `events-lambda/package-lock.json`. pre-commit treats the resulting file mutation as a failure.

Committing the pruned lock file makes `npm install` a no-op, so the hook passes. After this change `make static-checks` is clean apart from `terraform validate`, which only fails locally when no terraform/opentofu binary is installed.

🤖 Generated by LLM (Claude, via OpenClaw)