### PR TITLE
admin node: build on Ubuntu 24.04 (noble)

### DIFF
--- a/packer/admin.pkr.hcl
+++ b/packer/admin.pkr.hcl
@@ -17,10 +17,10 @@ variable "MY_SECRET_KEY" {
   default = ""
 }
 
-data "amazon-ami" "bionic" {
+data "amazon-ami" "ubuntu" {
   access_key = "${var.MY_ACCESS_KEY}"
   filters = {
-    name                = "ubuntu/images/*ubuntu-bionic-18.04-amd64-server-*"
+    name                = "ubuntu/images/*ubuntu-noble-24.04-amd64-server-*"
     root-device-type    = "ebs"
     virtualization-type = "hvm"
   }
@@ -32,9 +32,9 @@ data "amazon-ami" "bionic" {
 
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
-source "amazon-ebs" "bionic" {
+source "amazon-ebs" "ubuntu" {
   access_key = "${var.MY_ACCESS_KEY}"
-  ami_name                    = "compiler-explorer admin packer 18.04 @ ${local.timestamp}"
+  ami_name                    = "compiler-explorer admin packer 24.04 @ ${local.timestamp}"
   associate_public_ip_address = true
   iam_instance_profile        = "XaniaBlog"
   instance_type               = "t2.medium"
@@ -50,7 +50,7 @@ source "amazon-ebs" "bionic" {
   }
   secret_key        = "${var.MY_SECRET_KEY}"
   security_group_id = "sg-f53f9f80"
-  source_ami        = "${data.amazon-ami.bionic.id}"
+  source_ami        = "${data.amazon-ami.ubuntu.id}"
   ssh_username      = "ubuntu"
   subnet_id         = "subnet-1df1e135"
   tags = {
@@ -60,7 +60,7 @@ source "amazon-ebs" "bionic" {
 }
 
 build {
-  sources = ["source.amazon-ebs.bionic"]
+  sources = ["source.amazon-ebs.ubuntu"]
 
   provisioner "file" {
     destination = "/home/ubuntu/"

--- a/setup-admin.sh
+++ b/setup-admin.sh
@@ -14,6 +14,11 @@ fi
 
 env EXTRA_NFS_ARGS="" INSTALL_TYPE="admin" "${DIR}/setup-common.sh"
 
+# python3.8 is not in noble's repos; deadsnakes provides it (as on the build/runner nodes).
+apt-get -y install software-properties-common
+add-apt-repository -y ppa:deadsnakes/ppa
+apt-get -y update
+
 apt -y install \
   autojump \
   bubblewrap \


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

The admin packer recipe still built from **bionic 18.04** while the rest of the fleet moved to noble 24.04 (`node`, `aarch64-node`, `conan`, `ce-router`, `gpu-node`). A rebuild of the admin node would therefore come up badly out of date.

This makes a *rebuild* produce 24.04, without touching the running instance:

- `packer/admin.pkr.hcl`: base AMI bionic 18.04 -> noble 24.04, mirroring `node.pkr.hcl` (data source filter, source block name, `ami_name`).
- `setup-admin.sh`: add the deadsnakes PPA before the apt install so `python3.8`/`python3.8-venv` still resolve on noble, exactly as `setup-node.sh` already does.

Deliberately out of scope:
- No terraform change. `AdminNode.ami` is a hardcoded id and is left untouched, so `terraform apply` will not replace the live admin node. The new AMI id can be wired in at actual rebuild time.
- `python3.8` is kept (its exact purpose is unclear, so this preserves current behaviour rather than removing it).

This is recipe-only and does not build or deploy anything by itself.

🤖 Generated by LLM (Claude, via OpenClaw)