### PR TITLE
setup: use drop-in conffiles for sysctl and cloud-init

### DIFF
--- a/setup-admin.sh
+++ b/setup-admin.sh
@@ -65,7 +65,9 @@ crontab -u ubuntu crontab.admin
 echo admin-node >/etc/hostname
 hostname admin-node
 sed -i "/127.0.0.1/c 127.0.0.1 localhost admin-node" /etc/hosts
+mkdir -p /etc/cloud/cloud.cfg.d
 echo "preserve_hostname: true" >/etc/cloud/cloud.cfg.d/99-ce.cfg
 
+mkdir -p /etc/sysctl.d
 echo "vm.min_free_kbytes=65536" >/etc/sysctl.d/99-ce.conf
-sysctl --system
+sysctl -p /etc/sysctl.d/99-ce.conf

--- a/setup-admin.sh
+++ b/setup-admin.sh
@@ -65,9 +65,7 @@ crontab -u ubuntu crontab.admin
 echo admin-node >/etc/hostname
 hostname admin-node
 sed -i "/127.0.0.1/c 127.0.0.1 localhost admin-node" /etc/hosts
-sed -i "/preserve_hostname/c preserve_hostname: true" /etc/cloud/cloud.cfg
+echo "preserve_hostname: true" >/etc/cloud/cloud.cfg.d/99-ce.cfg
 
-if ! grep vm.min_free_kbytes /etc/sysctl.conf; then
-  echo "vm.min_free_kbytes=65536" >>/etc/sysctl.conf
-  sysctl -p
-fi
+echo "vm.min_free_kbytes=65536" >/etc/sysctl.d/99-ce.conf
+sysctl --system

--- a/setup-builder.sh
+++ b/setup-builder.sh
@@ -23,7 +23,7 @@ crontab -u ubuntu crontab.builder
 echo builder >/etc/hostname
 hostname builder
 sed -i "/127.0.0.1/c 127.0.0.1 localhost builder" /etc/hosts
-sed -i "/preserve_hostname/c preserve_hostname: true" /etc/cloud/cloud.cfg
+echo "preserve_hostname: true" >/etc/cloud/cloud.cfg.d/99-ce.cfg
 
 mv /infra /home/ubuntu/infra
 chown -R ubuntu:ubuntu /home/ubuntu/infra

--- a/setup-builder.sh
+++ b/setup-builder.sh
@@ -23,6 +23,7 @@ crontab -u ubuntu crontab.builder
 echo builder >/etc/hostname
 hostname builder
 sed -i "/127.0.0.1/c 127.0.0.1 localhost builder" /etc/hosts
+mkdir -p /etc/cloud/cloud.cfg.d
 echo "preserve_hostname: true" >/etc/cloud/cloud.cfg.d/99-ce.cfg
 
 mv /infra /home/ubuntu/infra

--- a/setup-ce-router.sh
+++ b/setup-ce-router.sh
@@ -52,6 +52,7 @@ echo -e "[default]\nregion=us-east-1" > /home/ce/.aws/config
 chown -R ce:ce /home/ce/.aws
 
 # Memory and network optimizations
+mkdir -p /etc/sysctl.d
 cat >/etc/sysctl.d/99-ce.conf <<EOF
 vm.min_free_kbytes=65536
 net.core.rmem_max=268435456
@@ -59,4 +60,4 @@ net.core.wmem_max=268435456
 net.ipv4.tcp_rmem=4096 65536 268435456
 net.ipv4.tcp_wmem=4096 65536 268435456
 EOF
-sysctl --system
+sysctl -p /etc/sysctl.d/99-ce.conf

--- a/setup-ce-router.sh
+++ b/setup-ce-router.sh
@@ -52,13 +52,11 @@ echo -e "[default]\nregion=us-east-1" > /home/ce/.aws/config
 chown -R ce:ce /home/ce/.aws
 
 # Memory and network optimizations
-if ! grep vm.min_free_kbytes /etc/sysctl.conf; then
-  {
-    echo "vm.min_free_kbytes=65536"
-    echo "net.core.rmem_max=268435456"
-    echo "net.core.wmem_max=268435456"
-    echo "net.ipv4.tcp_rmem=4096 65536 268435456"
-    echo "net.ipv4.tcp_wmem=4096 65536 268435456"
-  } >>/etc/sysctl.conf
-  sysctl -p
-fi
+cat >/etc/sysctl.d/99-ce.conf <<EOF
+vm.min_free_kbytes=65536
+net.core.rmem_max=268435456
+net.core.wmem_max=268435456
+net.ipv4.tcp_rmem=4096 65536 268435456
+net.ipv4.tcp_wmem=4096 65536 268435456
+EOF
+sysctl --system

--- a/setup-conan.sh
+++ b/setup-conan.sh
@@ -161,4 +161,5 @@ chown -R ubuntu:ubuntu /home/ubuntu/infra
 echo conan-node > /etc/hostname
 hostname conan-node
 sed -i "/127.0.0.1/c 127.0.0.1 localhost conan-node" /etc/hosts
+mkdir -p /etc/cloud/cloud.cfg.d
 echo "preserve_hostname: true" >/etc/cloud/cloud.cfg.d/99-ce.cfg

--- a/setup-conan.sh
+++ b/setup-conan.sh
@@ -161,4 +161,4 @@ chown -R ubuntu:ubuntu /home/ubuntu/infra
 echo conan-node > /etc/hostname
 hostname conan-node
 sed -i "/127.0.0.1/c 127.0.0.1 localhost conan-node" /etc/hosts
-sed -i "/preserve_hostname/c preserve_hostname: true" /etc/cloud/cloud.cfg
+echo "preserve_hostname: true" >/etc/cloud/cloud.cfg.d/99-ce.cfg


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

Follow-up to the admin 24.04 work. While upgrading the admin node in place, dpkg prompted about `/etc/sysctl.conf` because our setup appends to it; the same antipattern exists in a few setup scripts.

Modifying a package-shipped conffile in place (a) triggers dpkg conffile prompts on dist-upgrade and (b) is fragile across rebuilds. Switch to drop-ins, which the packages support and which leave the distro files untouched:

- `vm.min_free_kbytes` (+ ce-router's net tunables) `>> /etc/sysctl.conf` -> `/etc/sysctl.d/99-ce.conf`, applied with `sysctl --system`. Affects `setup-admin.sh`, `setup-ce-router.sh`.
- `sed ... preserve_hostname /etc/cloud/cloud.cfg` -> `/etc/cloud/cloud.cfg.d/99-ce.cfg`. Affects `setup-admin.sh`, `setup-builder.sh`, `setup-conan.sh`.

Drop-ins are overwrite-idempotent, so the old `grep`-guards are gone.

Scope notes:
- Left alone deliberately: `/etc/fstab` appends, `/etc/hostname` writes, and the `/etc/hosts` localhost-line `sed` are not dpkg conffile-prompt cases. Files CE fully owns (`apt.conf.d/`, apparmor profiles, `docker/daemon.json`, autofs maps) are already fine.
- No behaviour change to the resulting kernel/cloud-init settings; only where they are written.

🤖 Generated by LLM (Claude, via OpenClaw)