### PR TITLE
Fix venv path: .env -> .venv (post-uv migration)

### DIFF
--- a/crontab.admin
+++ b/crontab.admin
@@ -1,5 +1,5 @@
 MAILTO=compiler-explorer-admin@googlegroups.com
-PATH=/home/ubuntu/infra/.env/bin:/home/ubuntu/infra/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+PATH=/home/ubuntu/infra/.venv/bin:/home/ubuntu/infra/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # m h  dom mon dow   command
 00 00 * * * cronic bash -c "git -C /home/ubuntu/infra pull -q && make -C /home/ubuntu/infra ce"

--- a/crontab.builder
+++ b/crontab.builder
@@ -1,4 +1,4 @@
 MAILTO=compiler-explorer-admin@googlegroups.com
-PATH=/home/ubuntu/infra/.env/bin:/home/ubuntu/infra/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+PATH=/home/ubuntu/infra/.venv/bin:/home/ubuntu/infra/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # m h  dom mon dow   command

--- a/crontab.root.admin
+++ b/crontab.root.admin
@@ -1,5 +1,5 @@
 MAILTO=compiler-explorer-admin@googlegroups.com
-PATH=/home/ubuntu/infra/.env/bin:/home/ubuntu/infra/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+PATH=/home/ubuntu/infra/.venv/bin:/home/ubuntu/infra/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # m h  dom mon dow   command
 10 00 * * * cronic bash -c "/home/ubuntu/infra/update_compilers/install_libraries.sh nightly"

--- a/setup.fish
+++ b/setup.fish
@@ -14,8 +14,8 @@ echo     source \$AUTOJUMP_PATH >> ~/.config/fish/config.fish
 echo   end >> ~/.config/fish/config.fish
 echo end >> ~/.config/fish/config.fish
 echo set VIRTUAL_ENV_DISABLE_PROMPT yes >> ~/.config/fish/config.fish
-echo if test -e ~/infra/.env/bin/activate.fish >> ~/.config/fish/config.fish
-echo   source ~/infra/.env/bin/activate.fish >> ~/.config/fish/config.fish
+echo if test -e ~/infra/.venv/bin/activate.fish >> ~/.config/fish/config.fish
+echo   source ~/infra/.venv/bin/activate.fish >> ~/.config/fish/config.fish
 echo end >> ~/.config/fish/config.fish
 mkdir -p ~/.fish/functions/
 echo -e 'function fish_greeting\nend\n' > ~/.fish/functions/fish_greeting


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

`make ce` (uv) builds the virtualenv at `.venv`, but `setup.fish` and the admin/builder crontabs still point at the pre-uv `.env` path:

- `crontab.admin`, `crontab.root.admin`, `crontab.builder`: `PATH=/home/ubuntu/infra/.env/bin:...`
- `setup.fish`: sources `~/infra/.env/bin/activate.fish`

The uv migration (#1635) updated the Makefile but not these. On the long-running admin node a stale `.env` from the poetry era still exists, so it limps along; but a fresh packer rebuild only ever creates `.venv`, so cron jobs and the interactive shell would come up without the venv (no `ce` / system python). There's also a current bug: the daily `make ce` refreshes `.venv` while cron runs from `.env`, so the admin's deps aren't updated where the jobs use them.

Point all references at `.venv` to match the Makefile. No logic change.

🤖 Generated by LLM (Claude, via OpenClaw)