### PR TITLE
kokkos: build kokkos in language mode

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -3088,12 +3088,12 @@ libraries:
     kokkos-cuda:
       build_type: cmake
       lib_type: static
-      cxx_compiler_wrapper: bin/nvcc_wrapper
       make_targets:
       - all
       extra_cmake_arg:
       - -DKokkos_ENABLE_CUDA=ON
       - -DKokkos_ARCH_TURING75=ON
+      - -DKokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON
       package_install: true
       repo: kokkos/kokkos
       staticliblink:


### PR DESCRIPTION
Currently Kokkos is using a launcher, but we also have an option to be usable in the `CUDA` language mode.
I hope this makes things easier. Followup to #2172 and #2182 