### PR TITLE
Add mojo 1.0.0b2

### DIFF
--- a/bin/yaml/mojo.yaml
+++ b/bin/yaml/mojo.yaml
@@ -14,6 +14,7 @@ compilers:
       - 0.26.1.0
       - 0.26.2.0
       - 1.0.0b1
+      - 1.0.0b2
     nightly:
       if: nightly
       install_always: true


### PR DESCRIPTION
Adds the `1.0.0b2` target to the mojo installer so it gets built and appears on the public site.

Companion to the compiler-explorer PR adding the matching compiler properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)