### PR TITLE
Exempt source maps from the CDN immutable-hash check

### DIFF
--- a/bin/lib/cdn.py
+++ b/bin/lib/cdn.py
@@ -41,14 +41,7 @@ def hash_file_for_s3(f):
 
 
 def is_source_map(name: str) -> bool:
-    """Source maps (``*.map``) are debug-only, not code.
-
-    Named after the asset's hash (``<asset>.map``), they can still change for
-    byte-identical JS/CSS (a toolchain bump regenerates the map), reusing a name
-    with new bytes. So we exempt them from the immutable-hash check (which guards
-    against publishing different *code* at one hash), overwrite them on deploy,
-    and serve them uncached so debugging always matches the deployed asset.
-    """
+    """True for source-map sidecar files (``*.map``)."""
     return name.endswith(".map")
 
 
@@ -270,6 +263,10 @@ class DeploymentJob:
             files_with_mismatch = []
             for f in executor.map(self._check_s3_hash, files):
                 if f["exists"]:
+                    # Source maps are exempt from the immutable-content guarantee:
+                    # unlike code, a map's bytes can change for a byte-identical
+                    # asset (a toolchain bump regenerates it), so its content-derived
+                    # name legitimately holds new bytes — not a collision.
                     if f["mismatch"] and not is_source_map(f["name"]):
                         files_with_mismatch.append(f)
 

--- a/bin/lib/cdn.py
+++ b/bin/lib/cdn.py
@@ -40,6 +40,18 @@ def hash_file_for_s3(f):
         return dict(hash=sha256, **f)
 
 
+def is_source_map(name: str) -> bool:
+    """Source maps (``*.map``) are debug-only, not code.
+
+    Named after the asset's hash (``<asset>.map``), they can still change for
+    byte-identical JS/CSS (a toolchain bump regenerates the map), reusing a name
+    with new bytes. So we exempt them from the immutable-hash check (which guards
+    against publishing different *code* at one hash), overwrite them on deploy,
+    and serve them uncached so debugging always matches the deployed asset.
+    """
+    return name.endswith(".map")
+
+
 def get_directory_contents(basedir):
     for f in Path(basedir).rglob("*"):
         if not f.is_file():
@@ -215,7 +227,11 @@ class DeploymentJob:
         if guessed_type is not None:
             extra_args["ContentType"] = guessed_type
 
-        if self.cache_control is not None:
+        if is_source_map(file["name"]):
+            # Revalidate (cheap 304s) rather than cache for a year: a map's bytes
+            # can change under a stable name, and debugging must see the current one.
+            extra_args["CacheControl"] = "no-cache"
+        elif self.cache_control is not None:
             extra_args["CacheControl"] = self.cache_control
 
         # upload file to s3
@@ -254,7 +270,7 @@ class DeploymentJob:
             files_with_mismatch = []
             for f in executor.map(self._check_s3_hash, files):
                 if f["exists"]:
-                    if f["mismatch"]:
+                    if f["mismatch"] and not is_source_map(f["name"]):
                         files_with_mismatch.append(f)
 
             if files_with_mismatch:
@@ -285,7 +301,11 @@ class DeploymentJob:
             for f in executor.map(self._check_s3_hash, files):
                 if f["exists"]:
                     if f["mismatch"]:
-                        files_with_mismatch.append(f)
+                        if is_source_map(f["name"]):
+                            # Not a code collision: overwrite rather than abort.
+                            files_to_upload.append(f)
+                        else:
+                            files_with_mismatch.append(f)
                     else:
                         files_to_update.append(f)
                 else:

--- a/bin/test/cdn_test.py
+++ b/bin/test/cdn_test.py
@@ -1,0 +1,101 @@
+"""Tests for source-map handling in the CDN deployment job."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from lib.cdn import DeploymentJob, is_source_map
+
+
+class TestIsSourceMap(unittest.TestCase):
+    def test_matches_maps(self):
+        assert is_source_map("noscript.v69.abcdef.js.map")
+        assert is_source_map("noscript.v69.abcdef.css.map")
+
+    def test_rejects_code(self):
+        assert not is_source_map("noscript.v69.abcdef.js")
+        assert not is_source_map("noscript.v69.abcdef.css")
+        assert not is_source_map("image.map.png")
+
+
+class TestUploadCacheControl(unittest.TestCase):
+    def _upload_and_capture(self, name):
+        cc = "public, max-age=31536000"
+        job = DeploymentJob("dummy.tar", "bucket", cache_control=cc)
+        with patch("lib.cdn.s3_client") as mock_s3:
+            job._upload_file({"name": name, "hash": "deadbeef", "path": Path("/tmp/x")})
+        # ExtraArgs is the keyword passed to s3_client.upload_file
+        _, kwargs = mock_s3.upload_file.call_args
+        return kwargs["ExtraArgs"]["CacheControl"]
+
+    def test_map_is_uncached(self):
+        assert self._upload_and_capture("noscript.v69.abcdef.js.map") == "no-cache"
+
+    def test_code_keeps_immutable_policy(self):
+        assert self._upload_and_capture("noscript.v69.abcdef.js") == "public, max-age=31536000"
+
+
+class TestRunMapMismatch(unittest.TestCase):
+    """A map mismatch must overwrite (upload) rather than abort the deploy,
+    while a genuine code mismatch must still abort."""
+
+    def _run_with(self, mismatch_name):
+        job = DeploymentJob("dummy.tar", "bucket")
+        files = [
+            {"name": "app.ABC.js", "path": Path("/tmp/js")},
+            {"name": "app.ABC.js.map", "path": Path("/tmp/map")},
+        ]
+
+        def fake_check(f):
+            return {**f, "exists": True, "mismatch": f["name"] == mismatch_name, "s3hash": "old"}
+
+        with (
+            patch.object(DeploymentJob, "_DeploymentJob__unpack_tar", return_value=files),
+            patch("lib.cdn.hash_file_for_s3", side_effect=lambda f: {**f, "hash": "new"}),
+            patch.object(job, "_check_s3_hash", side_effect=fake_check),
+            patch.object(job, "_upload_file", side_effect=lambda f: f) as mock_upload,
+            patch.object(job, "_update_tags", side_effect=lambda f: f),
+        ):
+            result = job.run()
+        uploaded = {c.args[0]["name"] for c in mock_upload.call_args_list}
+        return result, uploaded
+
+    def test_map_mismatch_overwrites_and_succeeds(self):
+        result, uploaded = self._run_with("app.ABC.js.map")
+        assert result is True
+        assert "app.ABC.js.map" in uploaded
+
+    def test_code_mismatch_still_aborts(self):
+        result, uploaded = self._run_with("app.ABC.js")
+        assert result is False
+
+
+class TestCheckHashesMapExempt(unittest.TestCase):
+    def _check_with(self, mismatch_name):
+        job = DeploymentJob("dummy.tar", "bucket")
+        files = [
+            {"name": "app.ABC.js", "path": Path("/tmp/js")},
+            {"name": "app.ABC.js.map", "path": Path("/tmp/map")},
+        ]
+
+        def fake_check(f):
+            return {**f, "exists": True, "mismatch": f["name"] == mismatch_name, "s3hash": "old"}
+
+        with (
+            patch.object(DeploymentJob, "_DeploymentJob__unpack_tar", return_value=files),
+            patch("lib.cdn.hash_file_for_s3", side_effect=lambda f: {**f, "hash": "new"}),
+            patch.object(job, "_check_s3_hash", side_effect=fake_check),
+        ):
+            return job.check_hashes()
+
+    def test_map_mismatch_passes(self):
+        assert self._check_with("app.ABC.js.map") is True
+
+    def test_code_mismatch_fails(self):
+        assert self._check_with("app.ABC.js") is False
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

CDN static files are served with a one-year immutable cache, and `ce ... builds check_hashes` verifies (via S3 `sha256` metadata) that a given filename never changes content. Source maps are named after their **asset's** content hash (`<asset>.map`), so a toolchain bump (terser/webpack) that regenerates a map for **byte-identical** JS/CSS reuses the same `.map` filename with different bytes:

```
ERROR:ce-cdn:1 files have mismatching hashes
ERROR:ce-cdn:noscript.vNN.<hash>.js.map: expected hash ... != ...
New webpackJsHack version number required to deploy static files to cdn
```

The workaround has been to manually bump a `webpackJsHack` constant in `webpack.config.esm.ts` every time we spot this, which renames every asset to dodge the collision.

Reproduced locally: renaming a local variable (mangled away by terser) leaves the minified JS byte-identical — same `.js` name and content — while the `.js.map` content changes under the **same** name, which is exactly the collision.

## Fix

Source maps are debug-only metadata, not code. The real invariant we care about is "never publish different *code* at the same hash", which content-hashed `.js`/`.css` filenames already guarantee. So treat maps accordingly:

- `check_hashes`: skip `*.map` (code stays strictly checked)
- `run`: overwrite a mismatched `*.map` instead of aborting
- `_upload_file`: serve `*.map` with `Cache-Control: no-cache` so debugging always gets the current map. The `static.ce-cdn.net` CloudFront behaviour uses legacy `forwarded_values` with `min_ttl=0`, so it honours the origin header — no Terraform change needed.

This is purely permissive against today's webpack output (it can only stop a false-alarm, never break a deploy) and removes the need to ever bump `webpackJsHack` again.

## Follow-up

Once this is deployed, the now-dead `webpackJsHack` constant + uses can be deleted from `webpack.config.esm.ts` (separate compiler-explorer PR).

## Tests

New `bin/test/cdn_test.py` (8 tests) covering the helper, cache-control selection, and the run/check categorisation. Full suite: 722 passed, 1 skipped; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)