### PR TITLE
[CUDA] add scale's nvcc compiler 

### DIFF
--- a/bin/yaml/cuda.yaml
+++ b/bin/yaml/cuda.yaml
@@ -1,101 +1,111 @@
 compilers:
   cuda:
-    type: script
-    dir: cuda/{{name}}
-    check_exe: bin/nvcc --version && bin/nvrtc_cli --version
-    depends:
-      - compilers/c++/x86/gcc 13.4.0
-    fetch:
-      - https://developer.download.nvidia.com/compute/cuda/{{name}}/local_installers/cuda_{{name}}_{{build}}_linux.run combined.sh
-      - https://raw.githubusercontent.com/cliffburdick/jitify/refs/heads/patch-3/nvrtc_cli.cpp nvrtc_cli.cpp
-    script: |
-      mkdir -p cuda/{{name}}
-      sh combined.sh --silent --toolkit --toolkitpath=$(pwd)/cuda/{{name}}
-      /opt/compiler-explorer/gcc-13.4.0/bin/g++ nvrtc_cli.cpp -o cuda/{{name}}/bin/nvrtc_cli -O3 -Wall -Wextra -std=c++11 -Icuda/{{name}}/include -Lcuda/{{name}}/lib64 -lnvrtc -Wl,--disable-new-dtags,-rpath,'$ORIGIN/../lib64'
-    targets:
-      - name: 11.0.2
-        build: 450.51.05
-      - name: 11.0.3
-        build: 450.51.06
-      - name: 11.1.0
-        build: 455.23.05
-      - name: 11.1.1
-        build: 455.32.00
-      - name: 11.2.0
-        build: 460.27.04
-      - name: 11.2.1
-        build: 460.32.03
-      - name: 11.2.2
-        build: 460.32.03
-      - name: 11.3.0
-        build: 465.19.01
-      - name: 11.3.1
-        build: 465.19.01
-      - name: 11.4.0
-        build: 470.42.01
-      - name: 11.4.1
-        build: 470.57.02
-      - name: 11.4.2
-        build: 470.57.02
-      - name: 11.4.3
-        build: 470.82.01
-      - name: 11.4.4
-        build: 470.82.01
-      - name: 11.5.0
-        build: 495.29.05
-      - name: 11.5.1
-        build: 495.29.05
-      - name: 11.5.2
-        build: 495.29.05
-      - name: 11.6.0
-        build: 510.39.01
-      - name: 11.6.1
-        build: 510.47.03
-      - name: 11.6.2
-        build: 510.47.03
-      - name: 11.7.0
-        build: 515.43.04
-      - name: 11.7.1
-        build: 515.65.01
-      - name: 11.8.0
-        build: 520.61.05
-      - name: 12.0.0
-        build: 525.60.13
-      - name: 12.0.1
-        build: 525.85.12
-      - name: 12.1.0
-        build: 530.30.02
-      - name: 12.2.1
-        build: 535.86.10
-      - name: 12.3.1
-        build: 545.23.08
-      - name: 12.4.1
-        build: 550.54.15
-      - name: 12.5.0
-        build: 555.42.02
-      - name: 12.5.1
-        build: 555.42.06
-      - name: 12.6.1
-        build: 560.35.03
-      - name: 12.6.2
-        build: 560.35.03
-      - name: 12.8.1
-        build: 570.124.06
-      - name: 12.9.0
-        build: 575.51.03
-      - name: 12.9.1
-        build: 575.57.08
-      - name: 13.0.0
-        build: 580.65.06
-      - name: 13.0.1
-        build: 580.82.07
-      - name: 13.0.2
-        build: 580.95.05
-      - name: 13.1.0
-        build: 590.44.01
-      - name: 13.1.1
-        build: 590.48.01
-      - name: 13.2.0
-        build: 595.45.04
-      - name: 13.3.0
-        build: 610.43.02
+    nvcc:
+      type: script
+      dir: cuda/{{name}}
+      check_exe: bin/nvcc --version && bin/nvrtc_cli --version
+      depends:
+        - compilers/c++/x86/gcc 13.4.0
+      fetch:
+        - https://developer.download.nvidia.com/compute/cuda/{{name}}/local_installers/cuda_{{name}}_{{build}}_linux.run combined.sh
+        - https://raw.githubusercontent.com/cliffburdick/jitify/refs/heads/patch-3/nvrtc_cli.cpp nvrtc_cli.cpp
+      script: |
+        mkdir -p cuda/{{name}}
+        sh combined.sh --silent --toolkit --toolkitpath=$(pwd)/cuda/{{name}}
+        /opt/compiler-explorer/gcc-13.4.0/bin/g++ nvrtc_cli.cpp -o cuda/{{name}}/bin/nvrtc_cli -O3 -Wall -Wextra -std=c++11 -Icuda/{{name}}/include -Lcuda/{{name}}/lib64 -lnvrtc -Wl,--disable-new-dtags,-rpath,'$ORIGIN/../lib64'
+      targets:
+        - name: 11.0.2
+          build: 450.51.05
+        - name: 11.0.3
+          build: 450.51.06
+        - name: 11.1.0
+          build: 455.23.05
+        - name: 11.1.1
+          build: 455.32.00
+        - name: 11.2.0
+          build: 460.27.04
+        - name: 11.2.1
+          build: 460.32.03
+        - name: 11.2.2
+          build: 460.32.03
+        - name: 11.3.0
+          build: 465.19.01
+        - name: 11.3.1
+          build: 465.19.01
+        - name: 11.4.0
+          build: 470.42.01
+        - name: 11.4.1
+          build: 470.57.02
+        - name: 11.4.2
+          build: 470.57.02
+        - name: 11.4.3
+          build: 470.82.01
+        - name: 11.4.4
+          build: 470.82.01
+        - name: 11.5.0
+          build: 495.29.05
+        - name: 11.5.1
+          build: 495.29.05
+        - name: 11.5.2
+          build: 495.29.05
+        - name: 11.6.0
+          build: 510.39.01
+        - name: 11.6.1
+          build: 510.47.03
+        - name: 11.6.2
+          build: 510.47.03
+        - name: 11.7.0
+          build: 515.43.04
+        - name: 11.7.1
+          build: 515.65.01
+        - name: 11.8.0
+          build: 520.61.05
+        - name: 12.0.0
+          build: 525.60.13
+        - name: 12.0.1
+          build: 525.85.12
+        - name: 12.1.0
+          build: 530.30.02
+        - name: 12.2.1
+          build: 535.86.10
+        - name: 12.3.1
+          build: 545.23.08
+        - name: 12.4.1
+          build: 550.54.15
+        - name: 12.5.0
+          build: 555.42.02
+        - name: 12.5.1
+          build: 555.42.06
+        - name: 12.6.1
+          build: 560.35.03
+        - name: 12.6.2
+          build: 560.35.03
+        - name: 12.8.1
+          build: 570.124.06
+        - name: 12.9.0
+          build: 575.51.03
+        - name: 12.9.1
+          build: 575.57.08
+        - name: 13.0.0
+          build: 580.65.06
+        - name: 13.0.1
+          build: 580.82.07
+        - name: 13.0.2
+          build: 580.95.05
+        - name: 13.1.0
+          build: 590.44.01
+        - name: 13.1.1
+          build: 590.48.01
+        - name: 13.2.0
+          build: 595.45.04
+        - name: 13.3.0
+          build: 610.43.02
+    scale:
+      type: tarballs
+      compression: xz
+      dir: scale/{{name}}
+      url: https://pkgs.scale-lang.com/tar/scale-{{name}}-amd64.tar.xz
+      check_exe: llvm/bin/nvcc --version
+      untar_dir: scale-{{name}}-Linux
+      targets:
+        - 1.7.1

--- a/init/settings.yml
+++ b/init/settings.yml
@@ -45,6 +45,12 @@ compiler:
     nvcc:
         version: ANY
         libcxx: ANY
+    scale-nvcc-nvidia:
+        version: ANY
+        libcxx: ANY
+    scale-nvcc-amd:
+        version: ANY
+        libcxx: ANY
     fortran:
         version: ANY
         libcxx: ANY


### PR DESCRIPTION
Hello !

This adds the installation (via tarball download) of [the scale compiler](https://docs.scale-lang.com/stable/) to the infra.

Please let me know if this breaks anything as I had to indent Nvidia's nvcc bloc to create a new one for scale, since it is a CUDA compiler

Regards

CE PR: https://github.com/compiler-explorer/compiler-explorer/pull/8849
Issue: https://github.com/compiler-explorer/compiler-explorer/issues/8865
