### PR TITLE
Bump RazorForge to 0.1.0, 0.1.1, and 0.2.0

### DIFF
--- a/bin/yaml/razorforge.yaml
+++ b/bin/yaml/razorforge.yaml
@@ -10,3 +10,4 @@ compilers:
     targets:
       - 0.1.0
       - 0.1.1
+      - 0.2.0

--- a/bin/yaml/razorforge.yaml
+++ b/bin/yaml/razorforge.yaml
@@ -9,3 +9,4 @@ compilers:
     check_exe: RazorForge version
     targets:
       - 0.1.0
+      - 0.1.1

--- a/bin/yaml/razorforge.yaml
+++ b/bin/yaml/razorforge.yaml
@@ -2,10 +2,10 @@ compilers:
   razorforge:
     type: tarballs
     compression: gz
-    url: https://github.com/dj-lumiere/razorforge-suflae/releases/download/v{{name}}-alpha/razorforge-v{{name}}-alpha-linux-x64.tar.gz
+    url: https://github.com/dj-lumiere/razorforge-suflae/releases/download/v{{name}}/razorforge-v{{name}}-linux-x64.tar.gz
     create_untar_dir: true
     strip_components: 1
-    dir: razorforge-{{name}}-alpha
+    dir: razorforge-{{name}}
     check_exe: RazorForge version
     targets:
-      - 0.0.4
+      - 0.1.0


### PR DESCRIPTION
Bumps the RazorForge install recipe from `0.0.4-alpha` to the `0.1.0` release.

v0.1.0 is the first stable (non-`-alpha`) tag, so the release URL and install dir drop the `-alpha` suffix:

- URL: `https://github.com/dj-lumiere/razorforge-suflae/releases/download/v0.1.0/razorforge-v0.1.0-linux-x64.tar.gz` (verified `200`)
- dir: `razorforge-0.1.0`

Follow-up to #2177 (initial `0.0.4-alpha` install). The matching compiler-explorer config bump (exe path `razorforge-0.0.4-alpha` → `razorforge-0.1.0`) is in a companion PR.