### PR TITLE
Changes for NVIDIA HPC SDK 26.5

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1719,6 +1719,14 @@ compilers:
           ctk_ver: "13.1"
           fetch:
             - https://developer.download.nvidia.com/hpc-sdk/{{version}}/nvhpc_{{year}}_{{dot_removed_version}}_Linux_{{arch}}_cuda_{{ctk_ver}}.tar.gz nvhpc_sdk_{{version}}_{{arch}}.tar.gz
+        - name: x86_64_26_5
+          arch: x86_64
+          version: "26.5"
+          dot_removed_version: "265"
+          year: "2026"
+          ctk_ver: "13.2"
+          fetch:
+            - https://developer.download.nvidia.com/hpc-sdk/{{version}}/nvhpc_{{year}}_{{dot_removed_version}}_Linux_{{arch}}_cuda_{{ctk_ver}}.tar.gz nvhpc_sdk_{{version}}_{{arch}}.tar.gz
     nightly:
       if: nightly
       gcc:


### PR DESCRIPTION
Add HPC SDK 26.5 to bin/yaml/cpp.yaml
