### PR TITLE
Add C++ library proxy 4.1.0

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -2553,10 +2553,12 @@ libraries:
     proxy:
       build_type: cmake
       check_file: README.md
+      subdir: proxy
       ngcpp:
         repo: ngcpp/proxy
         targets:
         - 4.0.2
+        - 4.1.0
       microsoft:
         repo: microsoft/proxy
         targets:


### PR DESCRIPTION
Also added `subdir` so that `include` can find the right path.

See [Proxy 4.1.0 Release](https://github.com/ngcpp/proxy/releases/tag/4.1.0)