### PR TITLE
sfpi: install from our misc-builder S3 build (7.55.0)

### DIFF
--- a/bin/yaml/sfpi.yaml
+++ b/bin/yaml/sfpi.yaml
@@ -1,20 +1,14 @@
 compilers:
   sfpi:
-    type: tarballs
+    type: s3tarballs
     compression: xz
     dir: sfpi-{{name}}
-    untar_dir: sfpi
-    check_exe: compiler/bin/riscv-tt-elf-g++ --version
-    url: https://github.com/tenstorrent/sfpi/releases/download/{{name}}/sfpi_{{name}}_x86_64_debian.txz
-#    depends:
-#      - tools/tt-metal-headers {{tt_metal_version}}
-#    after_stage_script:
-#      - "{{yaml_dir}}/sfpi/prepare-headers.sh {{name}} %DEP0% sfpi"
-#    targets:
-        # Disabled as we get "Invalid version 7.54.0"
-#      - name: 7.54.0
-#        # Confirm the exact matching tt-metal tag if 7.54.0 needs a stricter pairing.
-#        tt_metal_version: v0.71.2
-#      ... this one is fine but needs the tt-metal-headers which fail
-#      - name: 7.55.0
-#        tt_metal_version: v0.71.2
+    check_exe: compiler/libexec/gcc/riscv-tt-elf/{{gcc_version}}/cc1plus --version
+    depends:
+      - tools/tt-metal-headers {{tt_metal_version}}
+    after_stage_script:
+      - "{{yaml_dir}}/sfpi/prepare-headers.sh {{name}} %DEP0% sfpi-{{name}}"
+    targets:
+      - name: 7.55.0
+        gcc_version: 15.1.0
+        tt_metal_version: v0.71.2

--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -136,16 +136,16 @@ tools:
         url: https://github.com/rust-lang/rustfmt/releases/download/v1.4.36/rustfmt_linux-x86_64_v1.4.36.tar.gz
         strip_components: 1
         create_untar_dir: true
-  #tt-metal-headers:
-  #  type: tarballs
-  #  compression: gz
-  #  url: https://github.com/tenstorrent/tt-metal/archive/refs/tags/{{name}}.tar.gz
-  #  dir: tt-metal-headers-{{name}}
-  #  create_untar_dir: true
-  #  strip_components: 1
-  #  check_file: tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu_math.h
-  #  targets:
-  #    - v0.71.2
+  tt-metal-headers:
+    type: tarballs
+    compression: gz
+    url: https://github.com/tenstorrent/tt-metal/archive/refs/tags/{{name}}.tar.gz
+    dir: tt-metal-headers-{{name}}
+    create_untar_dir: true
+    strip_components: 1
+    check_file: tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu.h
+    targets:
+      - v0.71.2
   mmbutils:
     if: nightly
     type: github


### PR DESCRIPTION
Switches sfpi from the public tenstorrent release tarball to our misc-builder-produced S3 package (compiler-explorer/misc-builder#133).

## Why

The misc-builder build bundles the non-glibc runtime libs (libgmp/libmpfr/libmpc) and fixes the `cc1plus` rpath, so the compiler runs without depending on whatever happens to be on the CE host. This supersedes the inline-patching approach.

## Headers are still needed

The S3 tarball ships only `compiler/` and sfpi's own `include/`. The CE sfpi driver (`lib/compilers/sfpi.ts`) injects ~13 `-I` paths into every compile, pointing into `build/sfpi/include` and a `tt_metal/...` tree that only exists if we assemble it. So this PR:

- re-enables the `tt-metal-headers` tool (tt-metal v0.71.2)
- keeps `prepare-headers.sh` as an after-stage step to build the include tree and generate the `ce_sfpi_compat.h` shim that the default examples include

In other words: misc-builder#133 solved the runtime *library* problem; the *header* problem still needs the tt-metal headers at compile time.

## Scope

Ships 7.55.0 only. 7.54.0 is left out for now: `prepare-headers.sh` only generates `ce_sfpi_compat.h` for 7.55.0, and the matching tt-metal tag for 7.54.0 was never confirmed.

## Verification

Installed locally end-to-end (pulls the tt-metal-headers dependency, runs the after-stage script, builds the full include tree + compat shim). Compiled the CE default example (`examples/sfpi/default.cpp`) with the driver's flags/include paths and got correct SFPU output (`SFPLOAD`/`SFPMAD`/`SFPSTORE`).

This overlaps with #2183 by @mert-kurttutan, which took the same approach — @mert-kurttutan, does this look right to you, and anything special needed to bring 7.54.0 along later?

🤖 Generated with [Claude Code](https://claude.com/claude-code)