### PR TITLE
Fix missing nvidia-smi by explicitly installing nvidia-utils

### DIFF
--- a/setup-gpu-node.sh
+++ b/setup-gpu-node.sh
@@ -26,6 +26,7 @@ DRIVER_VERSION=580
 CUDA_VERSION=13-0
 apt install -y \
     nvidia-headless-${DRIVER_VERSION}-open \
+    nvidia-utils-${DRIVER_VERSION} \
     nvidia-driver-assistant \
     cuda-compiler-${CUDA_VERSION} \
     cuda-runtime-${CUDA_VERSION}


### PR DESCRIPTION
Resolves issue #2190

After testing the `apt` cache on clean Ubuntu 22.04 and 24.04 environments, it seems `nvidia-utils-595` is not in the `nvidia-headless-595-open` dependency tree. Explicitly installing the `nvidia-utils` package should restore `nvidia-smi` and protect against possible dependency changes in the future.