### PR TITLE
Add LCC and Rust compilers for E2K

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1863,3 +1863,183 @@ compilers:
           vername: v1500
         - name: 15.0.7
           vername: v1507
+    mcst-lcc:
+      if: non-free
+      type: tarballs
+      compression: xz
+      # strip opt/mcst/
+      strip_components: 2
+      dir: "lcc-{{vername}}"
+      check_exe: bin/l++ --version
+      # Archive file name prefix, usually cross-sp or cross-sp-rel.
+      prefix: ""
+      # Host arch:
+      #   _32 - x86 (i686)
+      #   _64 - x86-64 (amd64)
+      suffix: _64
+      # A1batross's personal archive of MCST LCC compilers.
+      # See https://setwd.ws/sp/README.txt
+      url: "https://setwd.ws/sp/{{tree}}/{{name}}/{{prefix}}-{{vername}}{{suffix}}.tar.xz"
+      e2k:
+        # A default ISA target for compiling. The distributed minimal sysroot
+        # compiled for this target.
+        #
+        # Format:
+        #   generic - alias for v2
+        #   vN - ISA version (-march)
+        #   vN.CPU - CPU specific (-mtune)
+        #
+        # Examples:
+        #   v3 (any elbrus-v3 cpu)
+        #   v3.4c (only elbrus-4c cpu)
+        #   v4
+        #   v4.8c
+        #   v4.1c+
+        #   v5
+        #   v5.8c2
+        #   v6
+        #   v6.16c
+        #   v6.2c3
+        #
+        # Almost all available cross-compilers have v4 version with a few
+        # exceptions and it's a good choice for an emulator because
+        # sysroot libraries compiled for this target.
+        isa: v4
+        vername: "{{name}}.e2k-{{isa}}.{{kernel}}"
+        after_stage_script:
+          - "{{yaml_dir}}/mcst-lcc/setup.sh {{dir}}"
+        lcc119:
+          type: script
+          tree: "1.19"
+          kernel: "2.6.33"
+          isa: generic
+          fetch:
+            - https://setwd.ws/sp/{{tree}}/{{name}}/lcc-e2k-cross_1.1_i386.deb lcc-e2k-cross_1.1_i386.deb
+          script: |
+            dpkg-deb -x lcc-e2k-cross_1.1_i386.deb extracted
+            mv extracted/opt/mcst {{dir}}
+            {{yaml_dir}}/mcst-lcc/setup.sh {{dir}}
+          targets:
+            - 1.19.11
+        lcc120:
+          strip_components: 0
+          tree: "1.20"
+          kernel: "3.14"
+          isa: generic
+          prefix: lcc
+          suffix: ""
+          targets:
+            - 1.20.17
+        lcc123:
+          tree: "1.23"
+          kernel: "4.9"
+          prefix: cross-sp-rel
+          targets:
+            - name: 1.23.19
+              prefix: ed-cross-sp
+              after_stage_script:
+                - "{{yaml_dir}}/mcst-lcc/setup.sh {{dir}}"
+                - ln -srf {{dir}}/fs/lib/e2k-linux-gnu/ld-linux.so.2
+                          {{dir}}/fs/lib64/ld-linux.so.2
+            - name: 1.23.22
+            - name: 1.23.25
+              prefix: cross-sp
+            - name: 1.23.28
+              suffix: _32
+        lcc124:
+          tree: "1.24"
+          kernel: "4.19"
+          prefix: cross-sp
+          targets:
+            - 1.24.10
+        lcc125:
+          tree: "1.25"
+          kernel: "5.4"
+          prefix: cross-sp
+          targets:
+            - 1.25.12
+            - 1.25.14
+            - 1.25.15
+            - 1.25.16
+            - 1.25.17
+            - 1.25.18
+            - 1.25.19
+            - name: 1.25.20
+              prefix: cross-sp-rel
+            - 1.25.22
+            - name: 1.25.23
+              prefix: cross-sp-rel
+            - name: 1.25.24
+              prefix: cross-sp-rel
+            - name: 1.25.25
+              prefix: cross-sp-rel
+            - name: 1.25.26
+              prefix: cross-sp-rel
+            - name: 1.25.27
+              prefix: cross-sp-rel
+        lcc126:
+          tree: "1.26"
+          kernel: "5.4"
+          prefix: cross-sp-rel
+          targets:
+            - name: 1.26.04
+              prefix: cross-sp
+            - name: 1.26.06
+              isa: v5
+            - 1.26.09
+            - name: 1.26.10
+              prefix: cross-sp
+            - name: 1.26.11
+              prefix: cross-sp
+            - 1.26.12
+            - 1.26.14
+            - 1.26.15
+            - 1.26.16
+            - 1.26.17
+            - 1.26.18
+            - 1.26.19
+            - 1.26.20
+            - 1.26.21
+            - 1.26.22
+        lcc127:
+          tree: "1.27"
+          kernel: "5.10"
+          prefix: cross-sp-rel
+          targets:
+            - name: 1.27.04
+              kernel: "5.4"
+            - name: 1.27.05
+              kernel: "5.4"
+            - name: 1.27.06
+              kernel: "5.4"
+            - 1.27.08
+            - 1.27.09
+            - 1.27.10
+            - 1.27.11
+            - 1.27.12
+            - 1.27.14
+            - name: 1.27.17
+              prefix: cross-sp
+            - 1.27.21
+            - name: 1.27.23
+              # cross-sp-rel without fortran.
+              prefix: cross-sp
+        lcc128:
+          tree: "1.28"
+          kernel: "6.1"
+          prefix: cross-sp-rel
+          targets:
+            - 1.28.07
+            - 1.28.09
+        lcc129:
+          tree: "1.29"
+          kernel: linux-6.1
+          prefix: cross-sp
+          targets:
+            - name: 1.29.08
+              isa: v4.8c
+            - 1.29.11
+            - 1.29.12
+            - 1.29.14
+            - 1.29.15
+            - 1.29.16

--- a/bin/yaml/mcst-lcc/setup.sh
+++ b/bin/yaml/mcst-lcc/setup.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DIR="${1:?lcc root required}"
+
+if [ ${CE_MCST_LCC_KEEP_GDB-"0"} == "0" ]; then
+  # Remove unused files to save disk space.
+  rm -rf "$DIR"/gdb
+fi
+
+# Replace broken absolute symlinks to /opt/mcst with relative symlinks.
+find "$DIR" -type l \! -exec test -e {} \; \
+  -exec sh -c 'target="$(readlink "{}" | sed "s@^/opt/mcst/@$CE_STAGING_DIR/@")"; ln -srf "$target" "{}"' \;
+
+# Create a wrapper script to execute compilers from any directory.
+#
+# Does not fully work with 1.19 and 1.20 versions. Required symlinks for binary support:
+#   /opt/mcst/fs -> /opt/compiler-explorer/lcc-1.19.11.e2k-generic.2.6.33/fs
+#   /opt/mcst/lcc-1.20.17.e2k-generic.3.14 -> /opt/compiler-explorer/lcc-1.20.17.e2k-generic.3.14
+#
+# This symlink will fix warning in --help:
+#   /opt/mcst/lcc-home -> /opt/compiler-explorer/lcc-1.19.11.e2k-generic.2.6.33/lcc-home
+#
+# Workarounds for output encodings.
+case "$DIR" in
+  *lcc-1.19.*|*lcc-1.20.*)
+    # These versions generate a very buggy output. It's better to get output in
+    # Russian than some random garbage.
+    cat >"$DIR"/bin/wrapper <<EOF
+#!/bin/bash
+name=\$(basename "\$0")
+wrapper=\$(readlink -f "\$0")
+root="\${wrapper%/bin/wrapper}"
+exec env LC_MESSAGES=ru_RU.UTF-8 "\$root/bin/\$name.orig" \\
+  -set-home-dir "\$root/lcc-home" \\
+  -set-binutils-dir "\$root/binutils" \\
+  -set-fs-dir "\$root/fs" "\$@"
+EOF
+    ;;
+  *lcc-1.23.*)
+    # These versions generate output in KOI8-R for --help and some error messages.
+    cat >"$DIR"/bin/wrapper <<EOF
+#!/bin/bash
+name=\$(basename "\$0")
+wrapper=\$(readlink -f "\$0")
+root="\${wrapper%/bin/wrapper}"
+{ { exec env LC_MESSAGES=en_US.UTF-8 "\$root/bin/\$name.orig" \\
+      -set-home-dir "\$root/lcc-home" \\
+      -set-binutils-dir "\$root/binutils" \\
+      --sysroot "\$root/fs" "\$@" 2>&3 \\
+  | iconv -f KOI8-R -t UTF-8; } 3>&1 1>&2 \\
+  | iconv -f KOI8-R -t UTF-8; } 3>&2 2>&1 1>&3
+EOF
+    ;;
+  *)
+    cat >"$DIR"/bin/wrapper <<EOF
+#!/bin/bash
+name=\$(basename "\$0")
+wrapper=\$(readlink -f "\$0")
+root="\${wrapper%/bin/wrapper}"
+exec "\$root/bin/\$name.orig" \\
+  -set-home-dir "\$root/lcc-home" \\
+  -set-binutils-dir "\$root/binutils" \\
+  --sysroot "\$root/fs" "\$@"
+EOF
+    ;;
+esac
+
+chmod +x "$DIR"/bin/wrapper
+
+# Create symlinks to the wrapper script.
+for name in {lcc,l++,lfortran}; do
+  if [ -e "$DIR"/bin/$name ]; then
+    if [ -L "$DIR"/bin/$name ]; then
+      ln -s lcc.orig "$DIR"/bin/$name.orig
+      ln -sf wrapper "$DIR"/bin/$name
+    else
+      mv "$DIR"/bin/$name{,.orig}
+      ln -s wrapper "$DIR"/bin/$name
+    fi
+  fi
+done

--- a/bin/yaml/rust.yaml
+++ b/bin/yaml/rust.yaml
@@ -139,3 +139,43 @@ compilers:
     check_file: rust/libkernel.rmeta
     targets:
     - '6.3'
+  e2k:
+    rust:
+      if: non-free
+      type: script
+      check_exe: "bin/rustc --version --verbose"
+      dir: e2k-rust-{{name}}
+      # rustc sources:
+      #   https://github.com/helce/rust
+      # llvm sources is not published, repo contains only binaries for e2k:
+      #   https://git.openelbrus.ru/unipro/llvm-e2k
+      fetch:
+        - https://setwd.ws/rust/{{date}}/rustc-{{vername}}-x86_64-unknown-linux-gnu.tar.xz rustc-{{vername}}-x86_64-unknown-linux-gnu.tar.xz
+        - https://setwd.ws/rust/{{date}}/rust-std-{{vername}}-e2kv3-unknown-linux-gnu.tar.xz rust-std-{{vername}}-e2kv3-unknown-linux-gnu.tar.xz
+        - https://setwd.ws/rust/{{date}}/rust-std-{{vername}}-e2kv4-unknown-linux-gnu.tar.xz rust-std-{{vername}}-e2kv4-unknown-linux-gnu.tar.xz
+        - https://setwd.ws/rust/{{date}}/rust-std-{{vername}}-e2kv5-unknown-linux-gnu.tar.xz rust-std-{{vername}}-e2kv5-unknown-linux-gnu.tar.xz
+        - https://setwd.ws/rust/{{date}}/rust-std-{{vername}}-e2kv6-unknown-linux-gnu.tar.xz rust-std-{{vername}}-e2kv6-unknown-linux-gnu.tar.xz
+      script: |
+        for archive in *.tar.*; do
+          echo "extracting $archive"
+          tar xf "$archive"
+        done
+        mkdir "{{dir}}"
+        for components in */components; do
+          root=$(dirname "$components")
+          for component in $(cat "$components"); do
+            echo "installing $component"
+            cp -a "$root/$component/." "{{dir}}/"
+          done
+        done
+        rm "{{dir}}/manifest.in"
+      depends:
+        - compilers/c++/mcst-lcc/e2k/lcc129 1.29.16
+      targets:
+        - name: 1.78.0
+          vername: 1.78.0
+          date: 2025-04-14
+        - name: 1.87.0
+          # rustc-1.87.0 archive is broken and cannot compile for e2k targets.
+          vername: nightly
+          date: 2025-06-16

--- a/start-support.sh
+++ b/start-support.sh
@@ -37,6 +37,9 @@ mount_opt() {
 
     [ -f /opt/.health ] || touch /opt/.health
     mountpoint /opt/.health || mount --bind /efs/.health /opt/.health
+
+    # Used only for symlinks if path cannot be changed.
+    mkdir -p /opt/mcst
 }
 
 get_discovered_compilers() {

--- a/update_compilers/install_nonfree_compilers.sh
+++ b/update_compilers/install_nonfree_compilers.sh
@@ -133,3 +133,14 @@ install_cuda https://developer.nvidia.com/compute/cuda/10.1/Prod/local_installer
 install_cuda https://developer.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.168_418.67_linux.run 10.1.168
 install_cuda https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.243_418.87.00_linux.run 10.1.243
 install_cuda https://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run 10.2.89
+
+##################################
+# MCST LCC compilers for E2K
+ce_install compilers/c++/mcst-lcc/e2k
+
+# Fixed paths in lcc-1.19.11.
+ln -s "${OPT}"/lcc-1.19.11.e2k-generic.2.6.33/fs /opt/mcst/fs
+ln -s "${OPT}"/lcc-1.19.11.e2k-generic.2.6.33/lcc-home /opt/mcst/lcc-home
+
+# Fixed paths in lcc-1.20.17.
+ln -s "${OPT}"/lcc-1.20.17.e2k-generic.3.14 /opt/mcst/lcc-1.20.17.e2k-generic.3.14

--- a/update_compilers/install_nonfree_compilers.sh
+++ b/update_compilers/install_nonfree_compilers.sh
@@ -144,3 +144,7 @@ ln -s "${OPT}"/lcc-1.19.11.e2k-generic.2.6.33/lcc-home /opt/mcst/lcc-home
 
 # Fixed paths in lcc-1.20.17.
 ln -s "${OPT}"/lcc-1.20.17.e2k-generic.3.14 /opt/mcst/lcc-1.20.17.e2k-generic.3.14
+
+##################################
+# Rust compilers for E2K
+ce_install compilers/e2k/rust


### PR DESCRIPTION
E2K is a VLIW ISA for CPUs. [Brief information][info] (Russian) about the architecture.

Compilers are downloaded from @a1batross [personal archive][setwd]. There is the [public official archive from MCST][mcst] but it contains only few LCC versions.

Latest QEMU is downloaded from the [MCST archive][mcst].

[setwd]: https://setwd.ws/
[mcst]: https://dev.mcst.ru/download/
[info]: https://www.mcst.ru/doc/elbrus_prog/html/chapter4.html