### PR TITLE
Quote version in generated bespoke-build commands

### DIFF
--- a/bin/lib/build_check.py
+++ b/bin/lib/build_check.py
@@ -7,6 +7,7 @@ CE to build artifacts before they can be deployed.
 from __future__ import annotations
 
 import re
+import shlex
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -170,9 +171,16 @@ class Addition:
         if not params:
             return None
 
-        return (
-            f"gh workflow run bespoke-build.yaml "
-            f"-f image={params.image} -f version={params.version} -f command={params.command}"
+        # Quote each -f argument: cross-compiler versions contain a space (e.g.
+        # "msp430 14.4.0"), which would otherwise be word-split by the shell so
+        # only the architecture reaches the workflow.
+        return "gh workflow run bespoke-build.yaml " + " ".join(
+            f"-f {shlex.quote(f'{key}={value}')}"
+            for key, value in (
+                ("image", params.image),
+                ("version", params.version),
+                ("command", params.command),
+            )
         )
 
 

--- a/bin/test/build_check_test.py
+++ b/bin/test/build_check_test.py
@@ -300,6 +300,21 @@ class TestBuildParams:
         assert "-f image=clad" in cmd
         assert "-f version=2.1-clang-21.1.0" in cmd
 
+    def test_get_build_command_quotes_cross_version(self):
+        """Cross-compiler versions contain a space and must be shell-quoted so the
+        whole "arch version" reaches the workflow rather than being word-split."""
+        addition = Addition(
+            yaml_file="cpp.yaml",
+            context=["compilers", "c++", "cross", "gcc", "msp430"],
+            target="14.4.0",
+            installer_type="s3tarballs",
+        )
+        available_images = {"gcc", "gcc-cross", "clang"}
+        cmd = addition.get_build_command(available_images)
+        assert cmd is not None
+        assert "-f image=gcc-cross" in cmd
+        assert "-f 'version=msp430 14.4.0'" in cmd
+
     def test_get_build_params_prefers_compound_image(self):
         """Test that gcc-cross is matched for cross-compiler context with arch in version."""
         addition = Addition(


### PR DESCRIPTION
## Problem

The **Build Required** bot comment generates `gh workflow run` lines for each artifact that needs building. For cross-compilers it produced:

```bash
gh workflow run bespoke-build.yaml -f image=gcc-cross -f version=msp430 14.4.0 -f command=build.sh
```

The `bespoke-build` workflow runs `bash ${command} ${version} /dist`, so a cross version is *deliberately* two words (`arch version`) that docker word-splits into two args. That part is fine.

The bug is in the generated command itself: `-f version=msp430 14.4.0` is split by the **shell** before `gh` sees it, so `gh` gets `version=msp430` plus a stray positional `14.4.0` (dropped). The workflow then builds `msp430` with no version and fails — e.g. [this msp430 run](https://github.com/compiler-explorer/infra/actions/runs/28582334676/job/84745409133) from #2203.

## Fix

`shlex.quote` each `-f key=value` token in `get_build_command`, so a version with a space is emitted as `-f 'version=msp430 14.4.0'`. Simple versions (the common case) are unchanged, so the comment format and existing tests are unaffected. Added a regression test for the cross-compiler case.

The two msp430 builds from #2203 have been re-triggered manually with the corrected quoting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)