### PR TITLE
bespoke-build: add aburi to builder image choices

### DIFF
--- a/.github/workflows/bespoke-build.yaml
+++ b/.github/workflows/bespoke-build.yaml
@@ -17,6 +17,7 @@ on:
         - clang
         - misc
         # rest in alphabetical order
+        - aburi
         - archiesdk
         - bloaty
         - clad


### PR DESCRIPTION
Adds `aburi` to the `bespoke-build.yaml` image choice list so the aburi compiler artifact can be built and uploaded to S3.

### Context
Adding the Aburi compiler (compiler-explorer/compiler-explorer#8871) spans three PRs:
- misc-builder#136 (merged) — builds & pushes `compilerexplorer/aburi-builder`
- #2202 (open) — the `s3tarballs` installable, which needs `aburi-atta-mills.tar.xz` in S3
- compiler-explorer#8872 (open) — properties + compiler class

The builder image exists, but `aburi` wasn't a selectable `image` in `bespoke-build`, so there was no way to dispatch the build that produces the S3 artifact #2202 depends on. This adds it (alphabetically, in the sorted section).

After this merges: `gh workflow run bespoke-build.yaml -f image=aburi -f version=atta-mills -f command=build.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)