### PR TITLE
Add MCST LCC (eLbrus Compiler Collection) compilers

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1723,3 +1723,24 @@ compilers:
           vername: v1500
         - name: 15.0.7
           vername: v1507
+    # MCST LCC - eLbrus Compiler Collection developed by MCST (https://mcst.ru/LCC).
+    #
+    # Do not be confused with https://en.wikipedia.org/wiki/LCC_(compiler).
+    mcst-lcc:
+      if: non-free
+      type: tarballs
+      compression: gz
+      # strip opt/mcst/
+      strip_components: 2
+      dir: "lcc-{{vername}}"
+      check_exe: bin/l++ --version
+      url: "https://dev.mcst.ru/downloads/{{date}}/cross-sp-public-osl-{{vername}}_64.tgz"
+      e2k:
+        vername: "{{name}}.e2k-v4.{{kernel}}"
+        after_stage_script:
+          - "{{yaml_dir}}/mcst-lcc/setup.sh {{dir}}"
+        lcc129:
+          kernel: linux-6.1
+          targets:
+            - name: 1.29.16
+              date: 2026-03-13

--- a/bin/yaml/mcst-lcc/setup.sh
+++ b/bin/yaml/mcst-lcc/setup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DIR="${1:?lcc root required}"
+
+# Replace broken absolute symlinks to /opt/mcst with relative symlinks.
+find "$DIR" -type l \! -exec test -e {} \; \
+  -exec sh -c 'target="$(readlink "{}" | sed "s@^/opt/mcst/@$CE_STAGING_DIR/@")"; ln -srf "$target" "{}"' \;
+
+# By default compilers can be executed only from /opt/mcst/$DIR. Create a wrapper
+# script to execute compilers from any directory.
+cat >"$DIR"/bin/wrapper <<EOF
+#!/bin/bash
+name=\$(basename "\$0")
+wrapper=\$(readlink -f "\$0")
+root="\${wrapper%/bin/wrapper}"
+exec "\$root/bin/\$name.orig" \\
+  -set-home-dir "\$root/lcc-home" \\
+  -set-binutils-dir "\$root/binutils" \\
+  --sysroot "\$root/fs" "\$@"
+EOF
+
+chmod +x "$DIR"/bin/wrapper
+
+# Create symlinks to the wrapper script.
+for name in {lcc,l++}; do
+  mv "$DIR"/bin/$name{,.orig}
+  ln -s wrapper "$DIR"/bin/$name
+done

--- a/update_compilers/install_nonfree_compilers.sh
+++ b/update_compilers/install_nonfree_compilers.sh
@@ -133,3 +133,7 @@ install_cuda https://developer.nvidia.com/compute/cuda/10.1/Prod/local_installer
 install_cuda https://developer.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.168_418.67_linux.run 10.1.168
 install_cuda https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.243_418.87.00_linux.run 10.1.243
 install_cuda https://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run 10.2.89
+
+##################################
+# MCST LCC (eLbrus Compiler Collection) compilers for E2K
+ce_install compilers/c++/mcst-lcc/e2k


### PR DESCRIPTION
Second attempt for https://github.com/compiler-explorer/infra/pull/2205.

Changes:

* Just a single compiler version instead of all available.
* The compiler downloaded from the official archive.
* No workarounds for old compilers.
* No Rust compilers.
* No `rm`.
* No `/opt/mcst`.