### PR TITLE
Add missing Beman libraries for trunk deployment

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1521,7 +1521,16 @@ libraries:
         beman_any_view:
           targets:
           - main
+        beman_at_most:
+          targets:
+          - main
+        beman_bounds_test:
+          targets:
+          - main
         beman_cache_latest:
+          targets:
+          - main
+        beman_closed_view:
           targets:
           - main
         beman_copyable_function:
@@ -1530,16 +1539,31 @@ libraries:
         beman_cstring_view:
           targets:
           - main
+        beman_cycle:
+          targets:
+          - main
+        beman_elide:
+          targets:
+          - main
         beman_execution:
           targets:
           - main
         beman_exemplar:
           targets:
           - main
+        beman_gates:
+          targets:
+          - main
         beman_indices_view:
           targets:
           - main
+        beman_indirect:
+          targets:
+          - main
         beman_inplace_vector:
+          targets:
+          - main
+        beman_integer_division:
           targets:
           - main
         beman_iterator_interface:
@@ -1566,6 +1590,9 @@ libraries:
         beman_optional:
           targets:
           - main
+        beman_range_searcher:
+          targets:
+          - main
         beman_scan_view:
           targets:
           - main
@@ -1573,6 +1600,9 @@ libraries:
           targets:
           - main
         beman_span:
+          targets:
+          - main
+        beman_str_split:
           targets:
           - main
         beman_take_before:


### PR DESCRIPTION
## Summary

- Add nightly trunk deployment entries for 10 missing Beman libraries in `bin/yaml/libraries.yaml`.

## Libraries (trunk)

- beman.at_most
- beman.bounds_test
- beman.closed_view
- beman.cycle
- beman.elide
- beman.gates
- beman.indirect
- beman.integer_division
- beman.range_searcher
- beman.str_split

## Tracking

- Compiler Explorer issue: https://github.com/compiler-explorer/compiler-explorer/issues/8908
- compiler-explorer PR (merge after this): https://github.com/compiler-explorer/compiler-explorer/pull/8909

## Test plan

- [ ] CE owners review and merge infra PR first
- [ ] Nightly deployment installs the new libraries successfully