### PR TITLE
Tag packer-built AMIs with AmiCleanup=auto for automated housekeeping

### DIFF
--- a/packer/aarch64-node.pkr.hcl
+++ b/packer/aarch64-node.pkr.hcl
@@ -38,7 +38,7 @@ data "amazon-ami" "noble" {
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
 source "amazon-ebs" "noble" {
-  access_key = "${var.MY_ACCESS_KEY}"
+  access_key                  = "${var.MY_ACCESS_KEY}"
   ami_name                    = "compiler-explorer aarch64 packer 24.04 @ ${local.timestamp}"
   associate_public_ip_address = true
   iam_instance_profile        = "XaniaBlog"
@@ -59,7 +59,8 @@ source "amazon-ebs" "noble" {
   ssh_username      = "ubuntu"
   subnet_id         = "subnet-1df1e135"
   tags = {
-    Site = "CompilerExplorer"
+    Site       = "CompilerExplorer"
+    AmiCleanup = "auto"
   }
   vpc_id = "vpc-17209172"
 }

--- a/packer/admin.pkr.hcl
+++ b/packer/admin.pkr.hcl
@@ -33,7 +33,7 @@ data "amazon-ami" "ubuntu" {
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
 source "amazon-ebs" "ubuntu" {
-  access_key = "${var.MY_ACCESS_KEY}"
+  access_key                  = "${var.MY_ACCESS_KEY}"
   ami_name                    = "compiler-explorer admin packer 24.04 @ ${local.timestamp}"
   associate_public_ip_address = true
   iam_instance_profile        = "XaniaBlog"
@@ -54,7 +54,8 @@ source "amazon-ebs" "ubuntu" {
   ssh_username      = "ubuntu"
   subnet_id         = "subnet-1df1e135"
   tags = {
-    Site = "CompilerExplorer"
+    Site       = "CompilerExplorer"
+    AmiCleanup = "auto"
   }
   vpc_id = "vpc-17209172"
 }

--- a/packer/builder.pkr.hcl
+++ b/packer/builder.pkr.hcl
@@ -38,7 +38,7 @@ data "amazon-ami" "ubuntu" {
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
 source "amazon-ebs" "ubuntu" {
-  access_key = "${var.MY_ACCESS_KEY}"
+  access_key                  = "${var.MY_ACCESS_KEY}"
   ami_name                    = "compiler-explorer builder packer @ ${local.timestamp}"
   associate_public_ip_address = true
   iam_instance_profile        = "XaniaBlog"
@@ -59,7 +59,8 @@ source "amazon-ebs" "ubuntu" {
   ssh_username      = "ubuntu"
   subnet_id         = "subnet-1df1e135"
   tags = {
-    Site = "CompilerExplorer"
+    Site       = "CompilerExplorer"
+    AmiCleanup = "auto"
   }
   vpc_id = "vpc-17209172"
 }

--- a/packer/ce-router.pkr.hcl
+++ b/packer/ce-router.pkr.hcl
@@ -38,7 +38,7 @@ data "amazon-ami" "noble" {
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
 source "amazon-ebs" "noble" {
-  access_key = "${var.MY_ACCESS_KEY}"
+  access_key                  = "${var.MY_ACCESS_KEY}"
   ami_name                    = "compiler-explorer ce-router 24.04 @ ${local.timestamp}"
   associate_public_ip_address = true
   iam_instance_profile        = "XaniaBlog"
@@ -59,7 +59,8 @@ source "amazon-ebs" "noble" {
   ssh_username      = "ubuntu"
   subnet_id         = "subnet-1df1e135"
   tags = {
-    Site = "CompilerExplorer"
+    Site       = "CompilerExplorer"
+    AmiCleanup = "auto"
   }
   vpc_id = "vpc-17209172"
 }

--- a/packer/conan.pkr.hcl
+++ b/packer/conan.pkr.hcl
@@ -33,7 +33,7 @@ data "amazon-ami" "noble" {
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
 source "amazon-ebs" "noble" {
-  access_key = "${var.MY_ACCESS_KEY}"
+  access_key                  = "${var.MY_ACCESS_KEY}"
   ami_name                    = "ce-conan packer 24.04 @ ${local.timestamp}"
   associate_public_ip_address = true
   iam_instance_profile        = "XaniaBlog"
@@ -51,7 +51,8 @@ source "amazon-ebs" "noble" {
   ssh_username      = "ubuntu"
   subnet_id         = "subnet-1df1e135"
   tags = {
-    Site = "CompilerExplorer"
+    Site       = "CompilerExplorer"
+    AmiCleanup = "auto"
   }
   vpc_id = "vpc-17209172"
 }

--- a/packer/gpu-node.pkr.hcl
+++ b/packer/gpu-node.pkr.hcl
@@ -38,7 +38,7 @@ data "amazon-ami" "ubuntu" {
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
 source "amazon-ebs" "ubuntu" {
-  access_key = "${var.MY_ACCESS_KEY}"
+  access_key                  = "${var.MY_ACCESS_KEY}"
   ami_name                    = "compiler-explorer gpu packer 24.04 @ ${local.timestamp}"
   associate_public_ip_address = true
   iam_instance_profile        = "XaniaBlog"
@@ -59,7 +59,8 @@ source "amazon-ebs" "ubuntu" {
   ssh_username      = "ubuntu"
   subnet_id         = "subnet-1df1e135"
   tags = {
-    Site = "CompilerExplorer"
+    Site       = "CompilerExplorer"
+    AmiCleanup = "auto"
   }
   vpc_id = "vpc-17209172"
 }

--- a/packer/node.pkr.hcl
+++ b/packer/node.pkr.hcl
@@ -38,7 +38,7 @@ data "amazon-ami" "ubuntu" {
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
 source "amazon-ebs" "ubuntu" {
-  access_key = "${var.MY_ACCESS_KEY}"
+  access_key                  = "${var.MY_ACCESS_KEY}"
   ami_name                    = "compiler-explorer packer 24.04 @ ${local.timestamp}"
   associate_public_ip_address = true
   iam_instance_profile        = "XaniaBlog"
@@ -59,7 +59,8 @@ source "amazon-ebs" "ubuntu" {
   ssh_username      = "ubuntu"
   subnet_id         = "subnet-1df1e135"
   tags = {
-    Site = "CompilerExplorer"
+    Site       = "CompilerExplorer"
+    AmiCleanup = "auto"
   }
   vpc_id = "vpc-17209172"
 }

--- a/packer/smb.pkr.hcl
+++ b/packer/smb.pkr.hcl
@@ -38,7 +38,7 @@ data "amazon-ami" "jammy" {
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
 source "amazon-ebs" "jammy" {
-  access_key = "${var.MY_ACCESS_KEY}"
+  access_key                  = "${var.MY_ACCESS_KEY}"
   ami_name                    = "ce-smb arm packer 22.04 @ ${local.timestamp}"
   associate_public_ip_address = true
   iam_instance_profile        = "XaniaBlog"
@@ -59,7 +59,8 @@ source "amazon-ebs" "jammy" {
   ssh_username      = "ubuntu"
   subnet_id         = "subnet-1df1e135"
   tags = {
-    Site = "CompilerExplorer"
+    Site       = "CompilerExplorer"
+    AmiCleanup = "auto"
   }
   vpc_id = "vpc-17209172"
 }

--- a/packer/win.pkr.hcl
+++ b/packer/win.pkr.hcl
@@ -45,11 +45,15 @@ source "amazon-ebs" "Server2022" {
   security_group_id    = "sg-f53f9f80"
   source_ami           = "${data.amazon-ami.Server2022.id}"
   subnet_id            = "subnet-1df1e135"
-  user_data_file       = "./packer/SetUpWinRM.ps1"
-  vpc_id               = "vpc-17209172"
-  winrm_insecure       = true
-  winrm_use_ssl        = true
-  winrm_username       = "Administrator"
+  tags = {
+    Site       = "CompilerExplorer"
+    AmiCleanup = "auto"
+  }
+  user_data_file = "./packer/SetUpWinRM.ps1"
+  vpc_id         = "vpc-17209172"
+  winrm_insecure = true
+  winrm_use_ssl  = true
+  winrm_username = "Administrator"
 }
 
 build {


### PR DESCRIPTION
Every AMI our packer templates build now carries `AmiCleanup = "auto"`, opting it into the automated AMI cleanup proposed in #2220. Merging this stops the flow of new untagged (and therefore never-cleaned) images; the cleanup logic itself lands in a follow-up PR.

`win.pkr.hcl` had no `tags` block at all — which is why Windows AMIs were entirely untagged — so it gains `Site = "CompilerExplorer"` too. `local`/`smb-local` are docker builds and don't produce AMIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)