### PR TITLE
ce admin cleanup: reap old opted-in AMIs, protect deliberate snapshots

### DIFF
--- a/bin/lib/ami_cleanup.py
+++ b/bin/lib/ami_cleanup.py
@@ -101,6 +101,14 @@ def is_ami_debris_snapshot(snapshot: dict) -> bool:
     return snapshot.get("Description", "").startswith("Created by CreateImage")
 
 
+def is_recent_snapshot(snapshot: dict, now: datetime.datetime, minimum_age: datetime.timedelta) -> bool:
+    """A snapshot from an in-flight CreateImage can exist before the pending AMI exposes
+    it in BlockDeviceMappings, so it briefly looks like unreferenced debris. Packer can
+    run at any time, so never touch young snapshots; real debris is old by definition
+    (its StartTime is when its long-gone AMI was built)."""
+    return now - snapshot["StartTime"] < minimum_age
+
+
 _AMI_ID_RE = re.compile(r"\bami-[0-9a-f]{8,17}\b")
 
 
@@ -110,14 +118,27 @@ def find_terraform_mentioned_image_ids(repo_root: Path | None = None) -> set[str
     singleton instance: launch-template/instance checks only protect it while the instance
     exists. Grepping can only over-protect (the checks are unioned), and it makes the
     "no stale AMI ids in terraform source, even in comments" rule self-enforcing:
-    writing an id down keeps the image alive; deleting the mention releases it."""
+    writing an id down keeps the image alive; deleting the mention releases it.
+
+    The admin node's checkout is pulled nightly at 00:00 and cleanup runs at 09:10, so a
+    pin committed mid-day isn't seen until the next run; accepted, since a freshly pinned
+    AMI is normally young or instance-referenced anyway."""
     if repo_root is None:
         repo_root = Path(__file__).resolve().parent.parent.parent
+    tf_files = [
+        tf_file
+        for tf_file in repo_root.rglob("*.tf")
+        # skip .terraform module/provider caches
+        if not any(part.startswith(".") for part in tf_file.relative_to(repo_root).parts)
+    ]
+    if not tf_files:
+        # This repo always contains terraform with AMI pins: finding none means we're
+        # looking in the wrong place, and returning an empty set would silently drop
+        # this protection. Fail closed instead (before anything gets deleted).
+        raise RuntimeError(f"no *.tf files found under {repo_root}; refusing to continue")
     mentioned = set()
-    for tf_file in repo_root.rglob("*.tf"):
-        if any(part.startswith(".") for part in tf_file.relative_to(repo_root).parts):
-            continue  # skip .terraform module/provider caches
-        mentioned.update(_AMI_ID_RE.findall(tf_file.read_text(encoding="utf-8")))
+    for tf_file in tf_files:
+        mentioned.update(_AMI_ID_RE.findall(tf_file.read_text(encoding="utf-8", errors="replace")))
     return mentioned
 
 

--- a/bin/lib/ami_cleanup.py
+++ b/bin/lib/ami_cleanup.py
@@ -11,7 +11,9 @@ roll back to; beyond that, rollback means rebuilding from packer.
 from __future__ import annotations
 
 import datetime
+import re
 from dataclasses import dataclass, field
+from pathlib import Path
 
 CLEANUP_TAG_KEY = "AmiCleanup"
 CLEANUP_TAG_VALUE = "auto"
@@ -70,6 +72,7 @@ def plan_ami_cleanup(
     referenced_image_ids: set[str],
     now: datetime.datetime,
     minimum_age_days: int = DEFAULT_MINIMUM_AGE_DAYS,
+    terraform_mentioned_image_ids: set[str] | None = None,
 ) -> CleanupPlan:
     plan = CleanupPlan()
     for image in sorted(images, key=lambda image: (image.creation_date, image.image_id)):
@@ -78,6 +81,8 @@ def plan_ami_cleanup(
         age = now - image.creation_date
         if image.image_id in referenced_image_ids:
             plan.kept[image.image_id] = "referenced by a launch template or live instance"
+        elif terraform_mentioned_image_ids and image.image_id in terraform_mentioned_image_ids:
+            plan.kept[image.image_id] = "mentioned in terraform source"
         elif age < datetime.timedelta(days=minimum_age_days):
             plan.kept[image.image_id] = f"only {age.days} days old (minimum {minimum_age_days})"
         else:
@@ -96,15 +101,30 @@ def is_ami_debris_snapshot(snapshot: dict) -> bool:
     return snapshot.get("Description", "").startswith("Created by CreateImage")
 
 
+_AMI_ID_RE = re.compile(r"\bami-[0-9a-f]{8,17}\b")
+
+
+def find_terraform_mentioned_image_ids(repo_root: Path | None = None) -> set[str]:
+    """Any AMI id literally written in a *.tf file in this repo is treated as referenced,
+    comments included. This closes the gap where terraform/ec2.tf pins an image id for a
+    singleton instance: launch-template/instance checks only protect it while the instance
+    exists. Grepping can only over-protect (the checks are unioned), and it makes the
+    "no stale AMI ids in terraform source, even in comments" rule self-enforcing:
+    writing an id down keeps the image alive; deleting the mention releases it."""
+    if repo_root is None:
+        repo_root = Path(__file__).resolve().parent.parent.parent
+    mentioned = set()
+    for tf_file in repo_root.rglob("*.tf"):
+        if any(part.startswith(".") for part in tf_file.relative_to(repo_root).parts):
+            continue  # skip .terraform module/provider caches
+        mentioned.update(_AMI_ID_RE.findall(tf_file.read_text(encoding="utf-8")))
+    return mentioned
+
+
 def find_referenced_image_ids(ec2_client) -> set[str]:
     """Image ids we must never delete: those a launch template's $Latest/$Default version
     points at (all our ASGs track $Latest), and those any non-terminated instance was
-    launched from.
-
-    Known gap, accepted: terraform/ec2.tf pins image ids for singleton instances. Those
-    are only protected here while their instance exists; if one were terminated and its
-    AMI aged past the minimum, we could delete an AMI terraform still references. Deemed
-    too narrow a window to justify querying terraform state from the cleanup cron."""
+    launched from. See also find_terraform_mentioned_image_ids."""
     referenced = set()
     paginator = ec2_client.get_paginator("describe_launch_templates")
     for page in paginator.paginate():

--- a/bin/lib/ami_cleanup.py
+++ b/bin/lib/ami_cleanup.py
@@ -1,0 +1,124 @@
+"""Planning logic for cleaning up old, unreferenced AMIs.
+
+See https://github.com/compiler-explorer/infra/issues/2220: packer rebuilds leave the
+previous AMI (and its snapshots) behind forever. Only AMIs explicitly opted in via the
+CLEANUP_TAG are ever considered; of those we keep anything still referenced by a launch
+template or a non-terminated instance, and anything younger than the minimum age. The
+minimum age is therefore also the window in which a superseded AMI remains available to
+roll back to; beyond that, rollback means rebuilding from packer.
+"""
+
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass, field
+
+CLEANUP_TAG_KEY = "AmiCleanup"
+CLEANUP_TAG_VALUE = "auto"
+DEFAULT_MINIMUM_AGE_DAYS = 30
+
+# Instances in any of these states pin their source AMI (a stopped instance may be
+# restarted; only termination releases the claim).
+_LIVE_INSTANCE_STATES = ["pending", "running", "shutting-down", "stopping", "stopped"]
+
+
+@dataclass(frozen=True)
+class AmiInfo:
+    image_id: str
+    name: str
+    creation_date: datetime.datetime
+    tags: dict[str, str]
+    snapshot_ids: tuple[str, ...]
+    size_gb: int
+
+    @property
+    def opted_in(self) -> bool:
+        return self.tags.get(CLEANUP_TAG_KEY) == CLEANUP_TAG_VALUE
+
+
+@dataclass
+class CleanupPlan:
+    to_delete: list[AmiInfo] = field(default_factory=list)
+    kept: dict[str, str] = field(default_factory=dict)  # image_id -> reason
+
+
+def ami_info_from_image(image: dict) -> AmiInfo:
+    snapshot_ids = []
+    size_gb = 0
+    for mapping in image.get("BlockDeviceMappings", []):
+        ebs = mapping.get("Ebs", {})
+        if "SnapshotId" in ebs:
+            snapshot_ids.append(ebs["SnapshotId"])
+            size_gb += ebs.get("VolumeSize", 0)
+    return AmiInfo(
+        image_id=image["ImageId"],
+        name=image.get("Name", image["ImageId"]),
+        creation_date=datetime.datetime.fromisoformat(image["CreationDate"]),
+        tags={tag["Key"]: tag["Value"] for tag in image.get("Tags", [])},
+        snapshot_ids=tuple(snapshot_ids),
+        size_gb=size_gb,
+    )
+
+
+def describe_own_images(ec2_client) -> list[dict]:
+    paginator = ec2_client.get_paginator("describe_images")
+    return [image for page in paginator.paginate(Owners=["self"]) for image in page["Images"]]
+
+
+def plan_ami_cleanup(
+    images: list[AmiInfo],
+    referenced_image_ids: set[str],
+    now: datetime.datetime,
+    minimum_age_days: int = DEFAULT_MINIMUM_AGE_DAYS,
+) -> CleanupPlan:
+    plan = CleanupPlan()
+    for image in sorted(images, key=lambda image: (image.creation_date, image.image_id)):
+        if not image.opted_in:
+            continue
+        age = now - image.creation_date
+        if image.image_id in referenced_image_ids:
+            plan.kept[image.image_id] = "referenced by a launch template or live instance"
+        elif age < datetime.timedelta(days=minimum_age_days):
+            plan.kept[image.image_id] = f"only {age.days} days old (minimum {minimum_age_days})"
+        else:
+            plan.to_delete.append(image)
+    return plan
+
+
+def is_backup_snapshot(snapshot: dict) -> bool:
+    return any(tag["Key"] == "aws:backup:source-resource" for tag in snapshot.get("Tags", []))
+
+
+def is_ami_debris_snapshot(snapshot: dict) -> bool:
+    """True for snapshots that only exist as a side effect of AMI creation; once no AMI
+    references them they are safe to delete. Anything else (e.g. a hand-taken
+    pre-migration safety snapshot of a volume) is deliberate and must be left alone."""
+    return snapshot.get("Description", "").startswith("Created by CreateImage")
+
+
+def find_referenced_image_ids(ec2_client) -> set[str]:
+    """Image ids we must never delete: those a launch template's $Latest/$Default version
+    points at (all our ASGs track $Latest), and those any non-terminated instance was
+    launched from.
+
+    Known gap, accepted: terraform/ec2.tf pins image ids for singleton instances. Those
+    are only protected here while their instance exists; if one were terminated and its
+    AMI aged past the minimum, we could delete an AMI terraform still references. Deemed
+    too narrow a window to justify querying terraform state from the cleanup cron."""
+    referenced = set()
+    paginator = ec2_client.get_paginator("describe_launch_templates")
+    for page in paginator.paginate():
+        for template in page["LaunchTemplates"]:
+            versions = ec2_client.describe_launch_template_versions(
+                LaunchTemplateId=template["LaunchTemplateId"], Versions=["$Latest", "$Default"]
+            )["LaunchTemplateVersions"]
+            for version in versions:
+                image_id = version["LaunchTemplateData"].get("ImageId")
+                if image_id:
+                    referenced.add(image_id)
+    paginator = ec2_client.get_paginator("describe_instances")
+    for page in paginator.paginate(Filters=[{"Name": "instance-state-name", "Values": _LIVE_INSTANCE_STATES}]):
+        for reservation in page["Reservations"]:
+            for instance in reservation["Instances"]:
+                referenced.add(instance["ImageId"])
+    return referenced

--- a/bin/lib/cli/admin.py
+++ b/bin/lib/cli/admin.py
@@ -55,17 +55,25 @@ def admin_gotty():
 _GONE_ERROR_CODES = {"InvalidAMIID.Unavailable", "InvalidAMIID.NotFound", "InvalidSnapshot.NotFound"}
 
 
-def _delete_ignoring_failures(what: str, delete: Callable[..., object], **kwargs: str) -> int:
+def delete_ignoring_failures(what: str, delete: Callable[..., object], in_use_ok: bool = False, **kwargs: str) -> int:
     """Runs a deletion, tolerating already-gone errors; returns the number of failures (0 or 1).
 
     A persistent per-item failure must not abort the whole run (the cron would then wedge
-    at the same point every day), so failures are reported to stderr and counted instead."""
+    at the same point every day), so failures are reported to stderr and counted instead.
+    in_use_ok treats InvalidSnapshot.InUse as benign: right after a deregister_image the
+    snapshot delete can transiently see the AMI as still registered; the next run's orphan
+    sweep mops it up, so it shouldn't fail the run (and mail) in the meantime."""
     try:
         delete(**kwargs)
     except ClientError as e:
-        if e.response["Error"]["Code"] not in _GONE_ERROR_CODES:
-            click.echo(f"Failed to remove {what}: {e}", err=True)
-            return 1
+        code = e.response["Error"]["Code"]
+        if code in _GONE_ERROR_CODES:
+            return 0
+        if in_use_ok and code == "InvalidSnapshot.InUse":
+            click.echo(f"Skipping {what}: still in use; a later orphan sweep will retry")
+            return 0
+        click.echo(f"Failed to remove {what}: {e}", err=True)
+        return 1
     return 0
 
 
@@ -108,12 +116,19 @@ def admin_cleanup(dry_run: bool, min_age_days: int):
         click.echo(f"Keeping {image_id}: {reason}")
     total_gb = 0
     for image in plan.to_delete:
-        click.echo(f"{would} {image.image_id} ({image.name}, {image.creation_date:%Y-%m-%d}, {image.size_gb} GB)")
+        click.echo(
+            f"{would} {image.image_id} ({image.name}, {image.creation_date:%Y-%m-%d}, {image.size_gb} GB, "
+            f"snapshots: {', '.join(image.snapshot_ids) or 'none'})"
+        )
         total_gb += image.size_gb
         if not dry_run:
-            failures += _delete_ignoring_failures(image.image_id, ec2_client.deregister_image, ImageId=image.image_id)
+            if delete_ignoring_failures(image.image_id, ec2_client.deregister_image, ImageId=image.image_id):
+                failures += 1
+                continue  # a registered AMI's snapshots can't be deleted; don't compound the failure
             for snapshot_id in image.snapshot_ids:
-                failures += _delete_ignoring_failures(snapshot_id, ec2_client.delete_snapshot, SnapshotId=snapshot_id)
+                failures += delete_ignoring_failures(
+                    snapshot_id, ec2_client.delete_snapshot, in_use_ok=True, SnapshotId=snapshot_id
+                )
     not_opted_in = len(images) - len(plan.to_delete) - len(plan.kept)
     click.echo(
         f"AMI summary: {len(plan.to_delete)} removed ({total_gb} GB of snapshots), "
@@ -135,12 +150,16 @@ def admin_cleanup(dry_run: bool, min_age_days: int):
             snapshot_id = snapshot["SnapshotId"]
             if ami_cleanup.is_backup_snapshot(snapshot) or snapshot_id in snapshots_in_use:
                 continue
+            if ami_cleanup.is_recent_snapshot(
+                snapshot, datetime.datetime.now(datetime.UTC), minimum_age=datetime.timedelta(days=1)
+            ):
+                continue  # may belong to an in-flight CreateImage (packer can run at any time)
             if not ami_cleanup.is_ami_debris_snapshot(snapshot):
                 click.echo(f"Keeping unreferenced snapshot {snapshot_id}: not AMI debris, assumed deliberate")
                 continue
             click.echo(f"{would} orphaned snapshot {snapshot_id}")
             if not dry_run:
-                failures += _delete_ignoring_failures(snapshot_id, ec2_client.delete_snapshot, SnapshotId=snapshot_id)
+                failures += delete_ignoring_failures(snapshot_id, ec2_client.delete_snapshot, SnapshotId=snapshot_id)
     if failures:
         click.echo(f"{failures} deletions failed", err=True)
         sys.exit(1)

--- a/bin/lib/cli/admin.py
+++ b/bin/lib/cli/admin.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import datetime
 import os
 import subprocess
+import sys
+from collections.abc import Callable
 
 import click
+from botocore.exceptions import ClientError
 
+from lib import ami_cleanup
 from lib.amazon import ec2_client
 from lib.cli import cli
 from lib.instance import AdminInstance
@@ -47,23 +52,73 @@ def admin_gotty():
     exec_remote_to_stdout(instance, ["./gotty", "--port", str(port), "tmux", "attach"])
 
 
-def _is_backup(snapshot: dict) -> bool:
-    if "Tags" not in snapshot:
-        return False
-    for tag in snapshot["Tags"]:
-        if tag["Key"] == "aws:backup:source-resource":
-            return True
-    return False
+_GONE_ERROR_CODES = {"InvalidAMIID.Unavailable", "InvalidAMIID.NotFound", "InvalidSnapshot.NotFound"}
+
+
+def _delete_ignoring_failures(what: str, delete: Callable[..., object], **kwargs: str) -> int:
+    """Runs a deletion, tolerating already-gone errors; returns the number of failures (0 or 1).
+
+    A persistent per-item failure must not abort the whole run (the cron would then wedge
+    at the same point every day), so failures are reported to stderr and counted instead."""
+    try:
+        delete(**kwargs)
+    except ClientError as e:
+        if e.response["Error"]["Code"] not in _GONE_ERROR_CODES:
+            click.echo(f"Failed to remove {what}: {e}", err=True)
+            return 1
+    return 0
 
 
 @admin.command(name="cleanup")
-def admin_cleanup():
-    """Runs a bunch of cleanup tasks."""
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=True,
+    show_default=True,
+    help="print what would be deleted without deleting anything",
+)
+@click.option(
+    "--min-age-days",
+    default=ami_cleanup.DEFAULT_MINIMUM_AGE_DAYS,
+    show_default=True,
+    help="never delete AMIs younger than this",
+)
+def admin_cleanup(dry_run: bool, min_age_days: int):
+    """Runs a bunch of cleanup tasks: old opted-in AMIs, then orphaned snapshots.
+
+    Only AMIs tagged AmiCleanup=auto are considered for deregistration; see
+    https://github.com/compiler-explorer/infra/issues/2220 for the policy.
+    """
+    would = "Would remove" if dry_run else "Removing"
+    failures = 0
+
+    click.echo("Finding image ids referenced by launch templates and instances...")
+    referenced = ami_cleanup.find_referenced_image_ids(ec2_client)
+    click.echo(f"Found {len(referenced)} referenced image ids")
+    images = [ami_cleanup.ami_info_from_image(image) for image in ami_cleanup.describe_own_images(ec2_client)]
+    plan = ami_cleanup.plan_ami_cleanup(
+        images, referenced, now=datetime.datetime.now(datetime.UTC), minimum_age_days=min_age_days
+    )
+    for image_id, reason in sorted(plan.kept.items()):
+        click.echo(f"Keeping {image_id}: {reason}")
+    total_gb = 0
+    for image in plan.to_delete:
+        click.echo(f"{would} {image.image_id} ({image.name}, {image.creation_date:%Y-%m-%d}, {image.size_gb} GB)")
+        total_gb += image.size_gb
+        if not dry_run:
+            failures += _delete_ignoring_failures(image.image_id, ec2_client.deregister_image, ImageId=image.image_id)
+            for snapshot_id in image.snapshot_ids:
+                failures += _delete_ignoring_failures(snapshot_id, ec2_client.delete_snapshot, SnapshotId=snapshot_id)
+    not_opted_in = len(images) - len(plan.to_delete) - len(plan.kept)
+    click.echo(
+        f"AMI summary: {len(plan.to_delete)} removed ({total_gb} GB of snapshots), "
+        f"{len(plan.kept)} kept, {not_opted_in} not opted in (no {ami_cleanup.CLEANUP_TAG_KEY} tag)"
+        f"{' [dry run: nothing deleted]' if dry_run else ''}"
+    )
+
     snapshots_in_use = set()
-    # todo fold in the AMI deregistration
     click.echo("Listing AMIs to find in-use snapshots")
-    for image in ec2_client.describe_images(Owners=["self"])["Images"]:
-        for mapping in image["BlockDeviceMappings"]:
+    for raw_image in ami_cleanup.describe_own_images(ec2_client):
+        for mapping in raw_image["BlockDeviceMappings"]:
             if "Ebs" in mapping and "SnapshotId" in mapping["Ebs"]:
                 snapshots_in_use.add(mapping["Ebs"]["SnapshotId"])
     click.echo(f"Found {len(snapshots_in_use)} snapshots in use")
@@ -72,10 +127,17 @@ def admin_cleanup():
     for page in paginator.paginate(OwnerIds=["self"]):
         for snapshot in page["Snapshots"]:
             snapshot_id = snapshot["SnapshotId"]
-            if _is_backup(snapshot) or snapshot_id in snapshots_in_use:
+            if ami_cleanup.is_backup_snapshot(snapshot) or snapshot_id in snapshots_in_use:
                 continue
-            click.echo(f"Snapshot {snapshot} not in use: removing")
-            ec2_client.delete_snapshot(SnapshotId=snapshot_id)
+            if not ami_cleanup.is_ami_debris_snapshot(snapshot):
+                click.echo(f"Keeping unreferenced snapshot {snapshot_id}: not AMI debris, assumed deliberate")
+                continue
+            click.echo(f"{would} orphaned snapshot {snapshot_id}")
+            if not dry_run:
+                failures += _delete_ignoring_failures(snapshot_id, ec2_client.delete_snapshot, SnapshotId=snapshot_id)
+    if failures:
+        click.echo(f"{failures} deletions failed", err=True)
+        sys.exit(1)
     click.echo("done")
 
 

--- a/bin/lib/cli/admin.py
+++ b/bin/lib/cli/admin.py
@@ -94,9 +94,15 @@ def admin_cleanup(dry_run: bool, min_age_days: int):
     click.echo("Finding image ids referenced by launch templates and instances...")
     referenced = ami_cleanup.find_referenced_image_ids(ec2_client)
     click.echo(f"Found {len(referenced)} referenced image ids")
+    tf_mentioned = ami_cleanup.find_terraform_mentioned_image_ids()
+    click.echo(f"Found {len(tf_mentioned)} image ids mentioned in terraform source")
     images = [ami_cleanup.ami_info_from_image(image) for image in ami_cleanup.describe_own_images(ec2_client)]
     plan = ami_cleanup.plan_ami_cleanup(
-        images, referenced, now=datetime.datetime.now(datetime.UTC), minimum_age_days=min_age_days
+        images,
+        referenced,
+        now=datetime.datetime.now(datetime.UTC),
+        minimum_age_days=min_age_days,
+        terraform_mentioned_image_ids=tf_mentioned,
     )
     for image_id, reason in sorted(plan.kept.items()):
         click.echo(f"Keeping {image_id}: {reason}")

--- a/bin/test/ami_cleanup_test.py
+++ b/bin/test/ami_cleanup_test.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 import datetime
 
-from lib.ami_cleanup import ami_info_from_image, is_ami_debris_snapshot, is_backup_snapshot, plan_ami_cleanup
+from lib.ami_cleanup import (
+    ami_info_from_image,
+    find_terraform_mentioned_image_ids,
+    is_ami_debris_snapshot,
+    is_backup_snapshot,
+    plan_ami_cleanup,
+)
 
 NOW = datetime.datetime(2026, 7, 10, tzinfo=datetime.UTC)
 
@@ -83,6 +89,30 @@ def test_deletions_are_oldest_first():
     ]
     plan = plan_ami_cleanup(images, set(), NOW)
     assert [image.image_id for image in plan.to_delete] == ["ami-a", "ami-b", "ami-c"]
+
+
+def test_terraform_mentioned_images_are_kept():
+    images = [make_image("ami-00000000000000001", "fam @ 1", 400), make_image("ami-00000000000000002", "fam @ 2", 400)]
+    plan = plan_ami_cleanup(images, set(), NOW, terraform_mentioned_image_ids={"ami-00000000000000001"})
+    assert plan.kept["ami-00000000000000001"] == "mentioned in terraform source"
+    assert [image.image_id for image in plan.to_delete] == ["ami-00000000000000002"]
+
+
+def test_terraform_scan_finds_ami_ids_even_in_comments(tmp_path):
+    (tmp_path / "ec2.tf").write_text(
+        'locals { runner_image_id = "ami-00000000000000001" }\n'
+        '//  ami = "ami-00000000000000002"  # commented-out resources still protect\n'
+    )
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "more.tf").write_text('image_id = "ami-0000000000000000f"')
+    (tmp_path / "README.md").write_text("ami-000000000000000aa not a tf file")
+    (tmp_path / ".terraform").mkdir()
+    (tmp_path / ".terraform" / "cached.tf").write_text('ami = "ami-000000000000000bb"')
+    assert find_terraform_mentioned_image_ids(tmp_path) == {
+        "ami-00000000000000001",
+        "ami-00000000000000002",
+        "ami-0000000000000000f",
+    }
 
 
 def test_backup_snapshots_are_recognised():

--- a/bin/test/ami_cleanup_test.py
+++ b/bin/test/ami_cleanup_test.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import datetime
 
+import pytest
 from lib.ami_cleanup import (
     ami_info_from_image,
     find_terraform_mentioned_image_ids,
     is_ami_debris_snapshot,
     is_backup_snapshot,
+    is_recent_snapshot,
     plan_ami_cleanup,
 )
 
@@ -19,7 +21,7 @@ def make_image(
     age_days: int,
     opted_in: bool = True,
     snapshot_ids: tuple[str, ...] = (),
-    size_gb: int = 8,
+    size_gb_per_snapshot: int = 8,
 ):
     created = NOW - datetime.timedelta(days=age_days)
     return ami_info_from_image({
@@ -28,7 +30,7 @@ def make_image(
         "CreationDate": created.isoformat(),
         "Tags": [{"Key": "AmiCleanup", "Value": "auto"}] if opted_in else [{"Key": "Site", "Value": "CE"}],
         "BlockDeviceMappings": [
-            {"Ebs": {"SnapshotId": snapshot_id, "VolumeSize": size_gb}} for snapshot_id in snapshot_ids
+            {"Ebs": {"SnapshotId": snapshot_id, "VolumeSize": size_gb_per_snapshot}} for snapshot_id in snapshot_ids
         ],
     })
 
@@ -113,6 +115,18 @@ def test_terraform_scan_finds_ami_ids_even_in_comments(tmp_path):
         "ami-00000000000000002",
         "ami-0000000000000000f",
     }
+
+
+def test_terraform_scan_fails_closed_when_no_tf_files_found(tmp_path):
+    with pytest.raises(RuntimeError, match="no .*tf files found"):
+        find_terraform_mentioned_image_ids(tmp_path)
+
+
+def test_recent_snapshots_are_recognised():
+    fresh = {"StartTime": NOW - datetime.timedelta(hours=2)}
+    old = {"StartTime": NOW - datetime.timedelta(days=400)}
+    assert is_recent_snapshot(fresh, NOW, minimum_age=datetime.timedelta(days=1))
+    assert not is_recent_snapshot(old, NOW, minimum_age=datetime.timedelta(days=1))
 
 
 def test_backup_snapshots_are_recognised():

--- a/bin/test/ami_cleanup_test.py
+++ b/bin/test/ami_cleanup_test.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import datetime
+
+from lib.ami_cleanup import ami_info_from_image, is_ami_debris_snapshot, is_backup_snapshot, plan_ami_cleanup
+
+NOW = datetime.datetime(2026, 7, 10, tzinfo=datetime.UTC)
+
+
+def make_image(
+    image_id: str,
+    name: str,
+    age_days: int,
+    opted_in: bool = True,
+    snapshot_ids: tuple[str, ...] = (),
+    size_gb: int = 8,
+):
+    created = NOW - datetime.timedelta(days=age_days)
+    return ami_info_from_image({
+        "ImageId": image_id,
+        "Name": name,
+        "CreationDate": created.isoformat(),
+        "Tags": [{"Key": "AmiCleanup", "Value": "auto"}] if opted_in else [{"Key": "Site", "Value": "CE"}],
+        "BlockDeviceMappings": [
+            {"Ebs": {"SnapshotId": snapshot_id, "VolumeSize": size_gb}} for snapshot_id in snapshot_ids
+        ],
+    })
+
+
+def test_ami_info_parses_image_fields():
+    image = make_image("ami-1", "compiler-explorer packer 24.04 @ 20250806151308", 100, snapshot_ids=("snap-1",))
+    assert image.opted_in
+    assert image.snapshot_ids == ("snap-1",)
+    assert image.size_gb == 8
+
+
+def test_ami_info_parses_the_creation_date_format_aws_actually_returns():
+    image = ami_info_from_image({"ImageId": "ami-1", "CreationDate": "2025-08-06T15:13:08.000Z"})
+    assert image.creation_date == datetime.datetime(2025, 8, 6, 15, 13, 8, tzinfo=datetime.UTC)
+    assert NOW - image.creation_date > datetime.timedelta(days=300)  # aware maths must work
+
+
+def test_untagged_images_are_never_touched():
+    images = [make_image("ami-1", "fam @ 1", 400, opted_in=False)]
+    plan = plan_ami_cleanup(images, set(), NOW)
+    assert not plan.to_delete
+    assert not plan.kept  # not even reported: it never opted in
+
+
+def test_referenced_images_are_kept():
+    images = [make_image("ami-1", "fam @ 1", 400), make_image("ami-2", "fam @ 2", 200)]
+    plan = plan_ami_cleanup(images, {"ami-1"}, NOW)
+    assert plan.kept["ami-1"] == "referenced by a launch template or live instance"
+    assert [image.image_id for image in plan.to_delete] == ["ami-2"]
+
+
+def test_young_images_are_kept():
+    images = [make_image("ami-1", "fam @ 1", 10), make_image("ami-2", "fam @ 2", 29)]
+    plan = plan_ami_cleanup(images, set(), NOW)
+    assert not plan.to_delete
+    assert plan.kept["ami-1"] == "only 10 days old (minimum 30)"
+    assert plan.kept["ami-2"] == "only 29 days old (minimum 30)"
+
+
+def test_old_unreferenced_images_are_deleted_even_the_newest():
+    images = [make_image("ami-old", "fam @ 1", 400), make_image("ami-new", "fam @ 2", 31)]
+    plan = plan_ami_cleanup(images, set(), NOW)
+    assert [image.image_id for image in plan.to_delete] == ["ami-old", "ami-new"]
+    assert not plan.kept
+
+
+def test_minimum_age_is_configurable():
+    images = [make_image("ami-1", "fam @ 1", 10), make_image("ami-2", "fam @ 2", 5)]
+    plan = plan_ami_cleanup(images, set(), NOW, minimum_age_days=7)
+    assert [image.image_id for image in plan.to_delete] == ["ami-1"]
+
+
+def test_deletions_are_oldest_first():
+    images = [
+        make_image("ami-b", "fam @ 2", 200),
+        make_image("ami-a", "fam @ 1", 400),
+        make_image("ami-c", "fam @ 3", 100),
+    ]
+    plan = plan_ami_cleanup(images, set(), NOW)
+    assert [image.image_id for image in plan.to_delete] == ["ami-a", "ami-b", "ami-c"]
+
+
+def test_backup_snapshots_are_recognised():
+    assert is_backup_snapshot({"Tags": [{"Key": "aws:backup:source-resource", "Value": "x"}]})
+    assert not is_backup_snapshot({"Tags": [{"Key": "Name", "Value": "conan-pre-noble-cutover"}]})
+    assert not is_backup_snapshot({})
+
+
+def test_only_createimage_debris_snapshots_are_deletable():
+    assert is_ami_debris_snapshot({"Description": "Created by CreateImage(i-123) for ami-456"})
+    assert not is_ami_debris_snapshot({"Description": "Pre-storage-migration snapshot 2026-05-07T01:57:07Z"})
+    assert not is_ami_debris_snapshot({"Description": ""})
+    assert not is_ami_debris_snapshot({})

--- a/bin/test/cli/admin_test.py
+++ b/bin/test/cli/admin_test.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+from botocore.exceptions import ClientError
+from lib.cli.admin import delete_ignoring_failures
+
+
+def _raiser(code: str):
+    def delete(**_kwargs):
+        raise ClientError({"Error": {"Code": code, "Message": "boom"}}, "DeleteSnapshot")
+
+    return delete
+
+
+def test_success_counts_no_failures():
+    assert delete_ignoring_failures("snap-1", lambda **_kwargs: None) == 0
+
+
+def test_already_gone_errors_are_tolerated():
+    assert delete_ignoring_failures("ami-1", _raiser("InvalidAMIID.Unavailable")) == 0
+    assert delete_ignoring_failures("ami-1", _raiser("InvalidAMIID.NotFound")) == 0
+    assert delete_ignoring_failures("snap-1", _raiser("InvalidSnapshot.NotFound")) == 0
+
+
+def test_other_errors_are_counted_and_reported(capsys):
+    assert delete_ignoring_failures("snap-1", _raiser("UnauthorizedOperation")) == 1
+    assert "Failed to remove snap-1" in capsys.readouterr().err
+
+
+def test_in_use_is_a_failure_by_default(capsys):
+    assert delete_ignoring_failures("snap-1", _raiser("InvalidSnapshot.InUse")) == 1
+    assert "Failed to remove snap-1" in capsys.readouterr().err
+
+
+def test_in_use_is_benign_when_tolerated(capsys):
+    assert delete_ignoring_failures("snap-1", _raiser("InvalidSnapshot.InUse"), in_use_ok=True) == 0
+    output = capsys.readouterr()
+    assert "orphan sweep will retry" in output.out
+    assert not output.err
+
+
+def test_non_client_errors_propagate():
+    def delete(**_kwargs):
+        raise ValueError("not an AWS error")
+
+    with pytest.raises(ValueError):
+        delete_ignoring_failures("snap-1", delete)

--- a/crontab.admin
+++ b/crontab.admin
@@ -10,3 +10,5 @@ PATH=/home/ubuntu/infra/.venv/bin:/home/ubuntu/infra/bin:/usr/local/sbin:/usr/lo
 30 01 * * * cronic bash -c "/home/ubuntu/infra/admin-daily-builds.sh"
 00 09 * * * cronic bash -c "/home/ubuntu/infra/remove_old_compilers.sh"
 05 09 * * * cronic bash -c "ce builds rm_old 7"
+# AMI/snapshot cleanup (see #2220); deliberately not yet enabled — uncomment in its own PR for an easy revert
+#10 09 * * * cronic bash -c "ce admin cleanup --no-dry-run"

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -1,10 +1,9 @@
 locals {
-  runner_image_id        = "ami-05d4fb32368117b54"
-  gpu_runner_image_id    = "ami-05df317ba6d2893be"
-  conan_image_id         = "ami-0c7129c233b1564dd"
-  smbserver_image_id     = "ami-01e7c7963a9c4755d"
-  smbtestserver_image_id = "ami-0284c821376912369"
-  admin_subnet           = module.ce_network.subnet["1a"].id
+  runner_image_id     = "ami-05d4fb32368117b54"
+  gpu_runner_image_id = "ami-05df317ba6d2893be"
+  conan_image_id      = "ami-0c7129c233b1564dd"
+  smbserver_image_id  = "ami-01e7c7963a9c4755d"
+  admin_subnet        = module.ce_network.subnet["1a"].id
 }
 
 resource "aws_instance" "AdminNode" {
@@ -226,7 +225,7 @@ resource "aws_instance" "CESMBServer" {
 }
 
 //resource "aws_instance" "CESMBTestServer" {
-//  ami                         = local.smbtestserver_image_id
+//  ami                         = "<build a fresh smb AMI (make packer-smb) and put its id here>"
 //  iam_instance_profile        = aws_iam_instance_profile.CompilerExplorerRole.name
 //  ebs_optimized               = false
 //  instance_type               = "t4g.micro"


### PR DESCRIPTION
Implements the cleanup half of #2220 (#2222 added the build-time tags).

## AMI pass (new — finishes the 2023 `# todo fold in the AMI deregistration`)

Only AMIs tagged `AmiCleanup=auto` are ever considered. Of those, we keep:
- anything referenced by any launch template's `$Latest`/`$Default` version or by any non-terminated instance (this protects the terraform-pinned singleton AMIs via their instances, and the 2018 admin AMI via the running admin node),
- anything whose id is literally written in a `*.tf` file in this repo, comments included — so a terraform pin protects its AMI even if the instance is briefly terminated, and "no stale AMI ids in terraform source, even in comments" is self-enforcing (writing an id down keeps the image alive; deleting the mention releases it — hence the companion commit dropping the dead `smbtestserver_image_id` pin),
- anything younger than `--min-age-days` (default 30) — which is therefore also the window in which a superseded AMI remains available to roll back to; beyond that, rollback means rebuilding from packer.

Everything else is deregistered and its snapshots deleted. There is deliberately **no keep-newest-per-family rule**: review showed it protected nothing the age gate doesn't (the deployed AMI is both referenced and newest, so the "spare" slot was always wasted on it) while making the last AMI of every retired family immortal, and it was the only thing coupling cleanup to AMI naming conventions.

Deletion is per-item fault-tolerant: already-gone errors are ignored, `InvalidSnapshot.InUse` immediately after a deregister is treated as "the next orphan sweep will retry" (eventual consistency), a failed deregister skips that AMI's doomed snapshot deletes, and anything else is reported to stderr with a non-zero exit at the end so cronic still mails — one bad item can't wedge the daily cron at the same point forever. The terraform scan **fails closed**: zero `.tf` files found means the repo root is wrong, and the run aborts before deleting anything rather than silently dropping that protection. The orphan sweep ignores snapshots younger than a day, since an in-flight `CreateImage` (packer can run at any time) briefly owns an unreferenced-looking snapshot.

`--dry-run` is the **default**; deletion requires an explicit `--no-dry-run`.

## Snapshot sweep (behaviour fix)

The old logic deleted any unreferenced non-AWS-Backup snapshot — which would have included the deliberate `conan-pre-noble-cutover` / `conan-pre-1.66-migration` safety snapshots (500 GB each, May 2026). The sweep now only deletes snapshots AWS itself created as `CreateImage` side effects; everything else is kept and reported as assumed-deliberate.

## Scheduling

The `crontab.admin` line is included **commented out** — merging this PR changes no scheduled behaviour. Enabling it is a one-line uncomment in its own PR, so turning it on (and reverting) stays trivial.

## Validation

Historic AMIs were back-tagged and a live `--dry-run` compared against the audit list in #2220: it would delete 115 AMIs (1,918 GB) — a strict subset of the audit's 116, the sole exclusions being 5 AMIs under min-age, 2 owned by ce-ci's housekeeper, and the admin/runner AMIs protected by live or stopped instances. The terraform-source scan finds 13 ids, all already instance-protected, so it changes nothing today — pure insurance. Both conan safety snapshots are kept. 20 unit tests cover the planning logic and fault-tolerance semantics; `describe_images` is paginated throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
