### PR TITLE
Enable the daily AMI/snapshot cleanup cron

### DIFF
--- a/crontab.admin
+++ b/crontab.admin
@@ -10,5 +10,5 @@ PATH=/home/ubuntu/infra/.venv/bin:/home/ubuntu/infra/bin:/usr/local/sbin:/usr/lo
 30 01 * * * cronic bash -c "/home/ubuntu/infra/admin-daily-builds.sh"
 00 09 * * * cronic bash -c "/home/ubuntu/infra/remove_old_compilers.sh"
 05 09 * * * cronic bash -c "ce builds rm_old 7"
-# AMI/snapshot cleanup (see #2220); deliberately not yet enabled — uncomment in its own PR for an easy revert
-#10 09 * * * cronic bash -c "ce admin cleanup --no-dry-run"
+# AMI/snapshot cleanup (see #2220)
+10 09 * * * cronic bash -c "ce admin cleanup --no-dry-run"


### PR DESCRIPTION
Uncomments the `crontab.admin` line from #2223, turning on the daily 09:10 `ce admin cleanup --no-dry-run` (see #2220 for the whole saga). The admin node reinstalls its crontab from the repo nightly at 00:05, so this goes live the day after merging.

The first supervised real run (2026-07-10) was clean: 115 AMIs / 1,918 GB reclaimed, exit 0, zero failures, deletions matching the reviewed dry-run plan exactly. Steady-state runs should delete nothing most days; `cronic` mails compiler-explorer-admin on any failure.

Kept deliberately separate from #2223 so switching this off is a one-commit revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)