### PR TITLE
Add actionlint to pre-commit; fix what it found

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,19 @@
+self-hosted-runner:
+  # Labels of our self-hosted runners (see the ce-ci repository), plus the
+  # admin node which is registered as a repo runner directly.
+  labels:
+    - ce
+    - small
+    - medium
+    - admin
+    - lin-builder
+    - win-builder
+
+# Enforce shellcheck errors and warnings in embedded run: scripts, but not
+# info/style — matching the shellcheck pre-commit hook's severity gating.
+paths:
+  .github/workflows/**/*.yml:
+    ignore: &shellcheck-info-style
+      - 'shellcheck reported issue in this script: SC\d+:(info|style):'
+  .github/workflows/**/*.yaml:
+    ignore: *shellcheck-info-style

--- a/.github/workflows/bespoke-build-arm64.yaml
+++ b/.github/workflows/bespoke-build-arm64.yaml
@@ -7,7 +7,7 @@ on:
       image:
         type: choice
         description: Which docker image to use
-        default: gcc
+        default: heaptrack
         required: true
         options:
         - heaptrack
@@ -32,7 +32,7 @@ jobs:
           mkdir dist
           chmod og+w dist # some builds don't run as root, so let anyone write here
           echo ::group::Docker build
-          docker run -v$(pwd)/dist:/dist --rm compilerexplorer/${{ github.event.inputs.image }}-builder:latest-arm64 \
+          docker run -v"$(pwd)/dist:/dist" --rm compilerexplorer/${{ github.event.inputs.image }}-builder:latest-arm64 \
             bash ${{ github.event.inputs.command }} ${{ github.event.inputs.version }} \
             /dist | tee output.log
           echo ::endgroup::
@@ -44,8 +44,8 @@ jobs:
         if: ${{ steps.build.outputs.status == 'OK' }}
         id: filenames
         run: |
-          echo source=$(pwd)/dist/$(basename ${{ steps.build.outputs.output }}) >> "${GITHUB_OUTPUT}"
-          echo s3dest=s3://compiler-explorer/opt/$(basename ${{ steps.build.outputs.output }}) >> "${GITHUB_OUTPUT}"
+          echo "source=$(pwd)/dist/$(basename ${{ steps.build.outputs.output }})" >> "${GITHUB_OUTPUT}"
+          echo "s3dest=s3://compiler-explorer/opt/$(basename ${{ steps.build.outputs.output }})" >> "${GITHUB_OUTPUT}"
       - name: Copy output to S3
         if: ${{ steps.build.outputs.status == 'OK' }}
         run: aws s3 cp "${{ steps.filenames.outputs.source }}" "${{ steps.filenames.outputs.s3dest }}" --no-progress

--- a/.github/workflows/bespoke-build.yaml
+++ b/.github/workflows/bespoke-build.yaml
@@ -76,7 +76,7 @@ jobs:
           mkdir dist
           chmod og+w dist # some builds don't run as root, so let anyone write here
           echo ::group::Docker build
-          docker run -v$(pwd)/dist:/dist --rm compilerexplorer/${{ github.event.inputs.image }}-builder \
+          docker run -v"$(pwd)/dist:/dist" --rm compilerexplorer/${{ github.event.inputs.image }}-builder \
             bash ${{ github.event.inputs.command }} ${{ github.event.inputs.version }} \
             /dist | tee output.log
           echo ::endgroup::
@@ -88,8 +88,8 @@ jobs:
         if: ${{ steps.build.outputs.status == 'OK' }}
         id: filenames
         run: |
-          echo source=$(pwd)/dist/$(basename ${{ steps.build.outputs.output }}) >> "${GITHUB_OUTPUT}"
-          echo s3dest=s3://compiler-explorer/opt/$(basename ${{ steps.build.outputs.output }}) >> "${GITHUB_OUTPUT}"
+          echo "source=$(pwd)/dist/$(basename ${{ steps.build.outputs.output }})" >> "${GITHUB_OUTPUT}"
+          echo "s3dest=s3://compiler-explorer/opt/$(basename ${{ steps.build.outputs.output }})" >> "${GITHUB_OUTPUT}"
       - name: Copy output to S3
         if: ${{ steps.build.outputs.status == 'OK' }}
         run: aws s3 cp "${{ steps.filenames.outputs.source }}" "${{ steps.filenames.outputs.s3dest }}" --no-progress

--- a/.github/workflows/lin-lib-build.yaml
+++ b/.github/workflows/lin-lib-build.yaml
@@ -19,12 +19,10 @@ on:
         inputs:
             library:
                 description: 'Library'
-                default: 'all'
                 required: true
                 type: string
             compiler:
                 description: 'Compiler'
-                default: 'popular-compilers-only'
                 required: true
                 type: string
             branch:

--- a/.github/workflows/win-lib-build.yaml
+++ b/.github/workflows/win-lib-build.yaml
@@ -15,12 +15,10 @@ on:
         inputs:
             library:
                 description: 'Library'
-                default: 'all'
                 required: true
                 type: string
             compiler:
                 description: 'Compiler'
-                default: 'popular-compilers-only'
                 required: true
                 type: string
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,10 @@ repos:
       - id: shellcheck
         # severity is CLI-only (not a valid .shellcheckrc directive); gate on errors.
         args: ["--severity=error"]
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.106.0
     hooks:


### PR DESCRIPTION
Part of the actionlint rollout across CE repos (compiler-explorer/compiler-workflows#68 was first). actionlint statically checks workflow files for schema errors, expression-context mistakes (e.g. an `if:` referencing an input or job output that doesn't exist), `workflow_call` input wiring, unknown runner labels, and runs shellcheck over embedded `run:` scripts.

## Setup

- Pre-commit hook (`rhysd/actionlint` v1.7.12; pre-commit auto-provisions Go).
- `.github/actionlint.yaml` declares our self-hosted labels (`ce`, `small`, `medium`, `admin`, `lin-builder`, `win-builder`).
- Embedded-script shellcheck is gated to **errors + warnings**; info/style are ignored via config, consistent with (slightly stricter than) the repo's existing `shellcheck --severity=error` hook policy. That silenced 20 info/style nits rather than churning working scripts.

## Real findings fixed

- **`bespoke-build-arm64.yaml`: latent bug** — the `image` choice input defaulted to `gcc`, which isn't in its options list (only `heaptrack` is built for arm64). A `gh`/API dispatch relying on the default would try to run a nonexistent `compilerexplorer/gcc-builder:latest-arm64` image. Default now `heaptrack`.
- **`bespoke-build{,-arm64}.yaml`**: quoted `$(pwd)`/`$(basename …)` command substitutions (SC2046, warning level).
- **`lin-lib-build.yaml` / `win-lib-build.yaml`**: removed `default:` from *required* `workflow_call` inputs — GitHub never uses a default on a required input, so this was dead config; all existing callers pass both values explicitly and are unaffected.

Pre-commit passes on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)