### PR TITLE
Add SDCC 4.6.0

### DIFF
--- a/bin/yaml/c.yaml
+++ b/bin/yaml/c.yaml
@@ -71,6 +71,7 @@ compilers:
         - 4.3.0
         - 4.4.0
         - 4.5.0
+        - 4.6.0
     z88dk:
       type: s3tarballs
       check_exe: bin/zcc -h


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

Adds SDCC 4.6.0 to the install config. This is the first C compiler release to support the `_Optional` type qualifier, which is why it was requested.

Installs from the same SourceForge tarball pattern as prior versions. Tested locally:

```
bin/ce_install --dest ~/opt/compiler-explorer install 'compilers/c/sdcc 4.6.0'
1 packages installed OK, 0 skipped, and 0 failed installation
```

`bin/sdcc --version` reports `4.6.0 #16555 (Linux)`, and a `_Optional int *p;` test compiles cleanly.

Companion compiler-explorer PR (properties) to follow once this lands.

🤖 Generated by LLM (Claude, via OpenClaw)