### PR TITLE
events-lambda: respond to ping with pong

### DIFF
--- a/events-lambda/events-sendmessage.js
+++ b/events-lambda/events-sendmessage.js
@@ -102,6 +102,8 @@ async function handle_text_message(apiGwClient, connectionId, message) {
     } else if (message.startsWith('ack: ')) {
         const guid = message.substring(5);
         await handle_ack_message(apiGwClient, connectionId, guid);
+    } else if (message === 'ping') {
+        await send_message(apiGwClient, connectionId, 'pong');
     } else {
         await send_message(apiGwClient, connectionId, 'unknown text message');
     }

--- a/events-lambda/events-sendmessage.test.js
+++ b/events-lambda/events-sendmessage.test.js
@@ -52,6 +52,20 @@ test('an object message with no subscribers returns 501', async t => {
     assert.equal(res.statusCode, 501);
 });
 
+test('a ping message replies with pong to the sender', async t => {
+    const posted = [];
+    t.mock.method(DynamoDBClient.prototype, 'send', async () => ({}));
+    t.mock.method(ApiGatewayManagementApiClient.prototype, 'send', async cmd => {
+        posted.push(cmd);
+        return {};
+    });
+    const res = await handler(event('ping'));
+    assert.equal(res.statusCode, 200);
+    assert.equal(posted.length, 1);
+    assert.equal(posted[0].input.ConnectionId, 'sender-conn');
+    assert.equal(posted[0].input.Data, 'pong');
+});
+
 test('an unknown text message is echoed back to the sender', async t => {
     const posted = [];
     t.mock.method(DynamoDBClient.prototype, 'send', async () => ({}));


### PR DESCRIPTION
The websocket lambda's `$default` handler ignored application-level `ping` messages, replying `"unknown text message"`. This adds a `ping`/`pong` branch in `handle_text_message` so clients can do an application-level keepalive or health check over the connection.

Note: this is separate from WebSocket protocol-level ping/pong control frames, which API Gateway handles and which never reach the lambda. Nothing in the client sends this today; the branch just makes the behavior available.

Includes a test asserting a `ping` replies `pong` to the sender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)