### PR TITLE
fix(sail): put bundled bin/ on PATH during install check so z3 is found

### DIFF
--- a/bin/yaml/sail.yaml
+++ b/bin/yaml/sail.yaml
@@ -4,6 +4,8 @@ compilers:
     compression: gz
     url: https://github.com/rems-project/sail/releases/download/{{name}}-linux-binary/sail.tar.gz
     check_exe: bin/sail --version
+    check_env:
+      - PATH=%PATH%/bin:/usr/bin:/bin
     dir: sail-{{name}}
     strip_components: 1
     create_untar_dir: true


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

## Problem

`sail --version` in 0.20.x fails with `SMT solver returned unexpected status 127 / z3: not found` during the post-install check.

Sail 0.20.2 bundles `bin/z3` inside the tarball, but the install check runs `sudo -u nobody bin/sail --version` without the install's `bin/` on PATH. So the bundled z3 is not found, and sail fails — even though sail itself installed correctly.

Sail 0.18 did not bundle z3 at all and apparently didn't need it at startup, so this is a 0.20.x change.

## Fix

Add `check_env` to put the install's `bin/` dir first on PATH, so the bundled z3 is found when sail invokes it during startup.

Companion to #2230.