### PR TITLE
Add Fortran versions 0.60.0 to 0.64.0

### DIFF
--- a/bin/yaml/fortran.yaml
+++ b/bin/yaml/fortran.yaml
@@ -108,6 +108,11 @@ compilers:
         - 0.57.0
         - 0.58.0
         - 0.59.0
+        - 0.60.0
+        - 0.61.0
+        - 0.62.0
+        - 0.63.0
+        - 0.64.0
     llvmflang:
       - type: s3tarballs
         check_exe: bin/flang-new --version


### PR DESCRIPTION
Last supported version 0.59 was from January 2026. This now adds six months worth of patches and bug fixes.