### PR TITLE
Add TunnelPascal 1.9.1 (x86-64 bleeding-edge)

### DIFF
--- a/bin/yaml/pascal.yaml
+++ b/bin/yaml/pascal.yaml
@@ -27,6 +27,15 @@ compilers:
         - name: 3.2.0
           dir: fpc-{{name}}-x86_64-linux
         - 3.2.2
+    tunnelpascal:
+      type: tarballs
+      compression: gz
+      create_untar_dir: true
+      dir: tunnel-pascal-{{name}}.x86_64-linux
+      url: https://github.com/partouf/tunnelpascal/releases/download/v{{name}}/tunnel-pascal-bleeding-edge.x86_64-linux.tar.gz
+      check_exe: bin/fpc -iV
+      targets:
+        - "1.9.1"
     nightly:
       if: nightly
       madpas-compiler:


### PR DESCRIPTION
Adds [TunnelPascal](https://github.com/partouf/tunnelpascal) 1.9.1 — a Free Pascal (FPC 3.3.1) fork that adds Delphi language features — as an x86-64 compiler.

Installs the bleeding-edge `x86_64-linux` release tarball. It extracts into a self-contained layout (`bin/fpc`, `lib/fpc/3.3.1/...`) and ships its own relocatable `fpc.cfg` (resolves unit paths relative to `$FPCBINDIR`), so no extra config file or install script is required — hence no `after_stage_script`.

Verified: `ce_install --dry-run install pascal/tunnelpascal` stages cleanly, and after a real install `bin/fpc -iV` reports `3.3.1` and drives the bundled compiler (compiles Delphi-specific code such as the inline-`if` expression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)