### PR TITLE
Add dependabot version updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Version updates for the actions used in .github/workflows. This does not
+# change security-update behaviour, and no other ecosystem (npm, pip) gets
+# version updates from this file.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    # One rolled-up PR per interval instead of a PR per action.
+    groups:
+      github-actions:
+        patterns: ["*"]
+    # Don't propose a release until it has been public for a week, the window
+    # in which compromised releases tend to be caught and yanked.
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Companion to compiler-explorer#8937 (and follow-up to the node20 action-version sweep in compiler-explorer#8936). Action version pins have no automated bumping today: dependabot security updates need no config file but don't cover action versions, and version updates only run for ecosystems listed in `.github/dependabot.yml`.

Minimal config, scoped to `github-actions` only: monthly schedule, all bumps grouped into a single rolled-up PR, and a 7-day cooldown so a freshly-published (and potentially compromised) release isn't proposed until it has survived a week in the wild. npm/pip version updates stay off and security updates are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)