### PR TITLE
Add bubblewrap to node AMI packages

### DIFF
--- a/setup-node.sh
+++ b/setup-node.sh
@@ -10,6 +10,8 @@ apt-get -y update
 apt-get -y install software-properties-common
 dpkg --add-architecture i386
 add-apt-repository ppa:deadsnakes/ppa
+# bubblewrap is not for the node itself: the GitHub runner boots this image,
+# and ce_install stages script-type installables inside bwrap under CEFS.
 apt-get install -y \
     binutils-multiarch \
     bison \

--- a/setup-node.sh
+++ b/setup-node.sh
@@ -13,6 +13,7 @@ add-apt-repository ppa:deadsnakes/ppa
 apt-get install -y \
     binutils-multiarch \
     bison \
+    bubblewrap \
     bzip2 \
     cgroup-tools \
     curl \


### PR DESCRIPTION
The "Install compiler(s)" workflow failed for the TI C29 toolchains (https://github.com/compiler-explorer/infra/actions/runs/29866227480) with `[Errno 2] No such file or directory: 'bwrap'`.

`ce_install` stages `script`-type installables inside bubblewrap when CEFS is enabled (`bin/lib/installable/script.py`), and the GitHub runner instance (`CERunner`, terraform/ec2.tf) boots the standard node AMI built from `setup-node.sh`. That package list never gained bubblewrap when CEFS introduced the dependency; `setup-admin.sh` has it, which is why admin-node installs work. Today was the first time the install workflow was asked to install a script-type compiler, so the gap had never been hit.

Not needed by CE nodes themselves, hence the comment in the script. Takes effect at the next node AMI rebuild; no runtime apt in the workflow by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)