### PR TITLE
Clean the install workspace with sudo, and guard the path

### DIFF
--- a/.github/workflows/cefs-gc.yml
+++ b/.github/workflows/cefs-gc.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ['admin']
     steps:
       - name: Clean workspace
-        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
+        run: sudo find "${GITHUB_WORKSPACE:?}" -mindepth 1 -delete
       - uses: actions/checkout@v7
       - name: Set up environment
         run: make ce

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -12,7 +12,9 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Clean workspace
-        run: find "$GITHUB_WORKSPACE" -mindepth 1 -delete
+        # ce_install runs under sudo and leaves root-owned __pycache__ behind, which a
+        # non-sudo clean can't remove, breaking the next run on that runner.
+        run: sudo find "${GITHUB_WORKSPACE:?}" -mindepth 1 -delete
       - uses: actions/checkout@v7
       - name: Set up environment
         run: make ce

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Clean workspace
-        # ce_install runs under sudo and leaves root-owned __pycache__ behind, which a
-        # non-sudo clean can't remove, breaking the next run on that runner.
         run: sudo find "${GITHUB_WORKSPACE:?}" -mindepth 1 -delete
       - uses: actions/checkout@v7
       - name: Set up environment


### PR DESCRIPTION
`install.yml` runs `sudo bin/ce_install`, which leaves root-owned `__pycache__` files in the checkout. The next job to land on that runner then fails in "Clean workspace", because the non-sudo `find` can't delete them:

```
find: cannot delete '.../bin/lib/cli/__pycache__/admin.cpython-312.pyc': Permission denied
find: cannot delete '.../bin/lib/cli/__pycache__': Directory not empty
##[error]Process completed with exit code 1
```

This is usually invisible: the runners are ephemeral and installs are infrequent, so a poisoned runner is normally recycled before the next one. Three back-to-back installs today (c3, perl, dxc) surfaced it. The perl install ran on `ce-x64-small_i-0c596e...972a5` and succeeded; the dxc install landed on that same runner and failed before `ce_install` ever ran. A rerun failed identically, and by then both small runners were poisoned.

`cefs-gc.yml` already cleans with `sudo`, so this follows that pattern.

### On the `${...:?}` guard

`sudo` widens the blast radius, so the path is now expanded with `${GITHUB_WORKSPACE:?}`, which aborts the step if the variable is ever unset or empty rather than letting `find` run.

The current quoted form is already safe on its own (`find ""` errors out, exit 1, deletes nothing), so this isn't fixing a live hole. It guards the failure mode where someone later drops the quotes: GNU `find` with no path argument defaults to `.`, so it would silently delete the working directory's contents and exit 0. Verified under the same `bash -e` that Actions uses:

| | quoted, unset | `${VAR:?}`, unset | `${VAR:?}`, empty | unquoted, unset |
|---|---|---|---|---|
| exit | 1 | 1 | 1 | 0 |
| deleted | nothing | nothing | nothing | **cwd contents** |

The same guard is applied to the existing `sudo` clean in `cefs-gc.yml`, since it carries the identical risk. The five non-sudo `Clean workspace` steps are left alone.

Worth noting `bespoke-build.yaml` has a related latent version of this: it `docker run`s as root against a bind-mounted `dist/`. It hasn't bitten, so it's not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
