### PR TITLE
Disable Circle compiler install - download URLs are 404

### DIFF
--- a/bin/yaml/circle.yaml
+++ b/bin/yaml/circle.yaml
@@ -1,18 +1,21 @@
-compilers:
-  circle:
-    type: tarballs
-    compression: gz
-    check_exe: circle --version
-    create_untar_dir: true
-    strip: true
-    url: https://circle-lang.org/linux/build_{{name}}.tgz
-    dir: circle-{{name}}
-    targets:
-      - '128'
-      - '129'
-      - '131'
-    nightly:
-      if: nightly
-      install_always: true
-      targets:
-        - latest
+# Circle compiler appears to have been discontinued. The download URLs at
+# circle-lang.org/linux/build_*.tgz all return 404. Commented out 2026-07-30.
+# See: https://www.circle-lang.org/ (download page removed)
+#compilers:
+#  circle:
+#    type: tarballs
+#    compression: gz
+#    check_exe: circle --version
+#    create_untar_dir: true
+#    strip: true
+#    url: https://circle-lang.org/linux/build_{{name}}.tgz
+#    dir: circle-{{name}}
+#    targets:
+#      - '128'
+#      - '129'
+#      - '131'
+#    nightly:
+#      if: nightly
+#      install_always: true
+#      targets:
+#        - latest


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

The Circle compiler (circle-lang.org) appears to have been discontinued or at least stopped distributing builds. Investigation findings:

- `https://www.circle-lang.org/download/` returns 404
- All tarball URLs (`circle-lang.org/linux/build_*.tgz`) return 404
- The website still exists but Sean Baxter has pivoted to Safe C++ proposal work (P3390/P3444) rather than releasing new Circle builds
- Last build was 131

This comments out the install config to stop broken install attempts. The existing binaries on CE nodes are unaffected — this just prevents future install/update runs from failing.