### PR TITLE
Add cmake 4.4.2

### DIFF
--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -17,7 +17,8 @@ tools:
       - 3.29.2
       - 3.30.7
       - 3.31.5
-      - name: 4.1.2
+      - 4.1.2
+      - name: 4.4.2
         symlink: cmake  # The one distinguished cmake we use for "cmake" on the site
     experimental:
       type: tarballs

--- a/bin/yaml/windows.yaml
+++ b/bin/yaml/windows.yaml
@@ -66,6 +66,7 @@ windows:
         - 3.30.7
         - 3.31.5
         - 4.1.2
+        - 4.4.2
     ninja:
       type: ziparchive
       url: https://github.com/compiler-explorer/ninja/releases/download/v{{name}}/ninja-win.zip


### PR DESCRIPTION
Adds CMake 4.4.2 (latest stable, released 2026-07-31) for Linux and Windows, and moves the distinguished `cmake` symlink from 4.1.2 to it.

Both release assets verified present, and `ce_install list` resolves `tools/cmake 4.4.2` and `windows/tools/cmake 4.4.2`.

The 3.x -> 4.x compatibility cliff (pre-3.5 `cmake_minimum_required` is a hard error) was already crossed when the symlink moved to 4.1.2. 4.4's new policies (CMP0211/0212/0217/0219) default to OLD unless a project raises its minimum, so this should be a quiet bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)