### PR TITLE
Add SystemC and QuantLib C++ libraries

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -2663,6 +2663,35 @@ libraries:
         url: https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtbase-everywhere-src-6.11.0.tar.xz
       type: tarballs
       untar_dir: qtbase-everywhere-src-{{name}}
+    quantlib:
+      build_type: cmake
+      check_file: CMakeLists.txt
+      depends:
+      - libraries/c++/boost 1.84.0
+      extra_cmake_arg:
+      # QuantLib's public headers include boost/, and CMake 4 dropped the FindBoost
+      # module in favour of config mode; our boost installable is headers only and
+      # ships no BoostConfig.cmake, so ask for the old module and point it at the tree.
+      - -DCMAKE_POLICY_DEFAULT_CMP0167=OLD
+      - -DBoost_NO_BOOST_CMAKE=ON
+      - -DBoost_NO_SYSTEM_PATHS=ON
+      - -DBOOST_ROOT=/opt/compiler-explorer/libs/boost_1_84_0
+      - -DBUILD_SHARED_LIBS=OFF
+      - -DQL_BUILD_EXAMPLES=OFF
+      - -DQL_BUILD_TEST_SUITE=OFF
+      - -DQL_INSTALL_EXAMPLES=OFF
+      - -DQL_INSTALL_TEST_SUITE=OFF
+      - -DQL_INSTALL_BENCHMARK=OFF
+      lib_type: static
+      make_utility: ninja
+      package_install: true
+      repo: lballabio/QuantLib
+      staticliblink:
+      - QuantLib
+      target_prefix: v
+      targets:
+      - '1.43'
+      type: github
     quill:
       build_type: none
       check_file: README.md
@@ -2888,6 +2917,24 @@ libraries:
       - '3'
       - '2'
       - '1'
+      type: github
+    systemc:
+      build_type: cmake
+      check_file: NOTICE
+      extra_cmake_arg:
+      - -DBUILD_SHARED_LIBS=OFF
+      - -DENABLE_EXAMPLES=OFF
+      - -DENABLE_REGRESSION=OFF
+      lib_type: static
+      make_utility: ninja
+      package_install: true
+      repo: accellera-official/systemc
+      staticliblink:
+      - systemc
+      targets:
+      - 3.0.0
+      - 3.0.1
+      - 3.0.2
       type: github
     tbb:
       build_type: make


### PR DESCRIPTION
Adds SystemC (3.0.0, 3.0.1, 3.0.2) and QuantLib (1.43) as static C++ libraries.

SystemC was requested in compiler-explorer/compiler-explorer#8291; QuantLib was requested directly by @vickoza alongside it and has no issue of its own.

Both use `package_install: true` so the conan package carries the install tree: SystemC restructures its headers from `src/` into `include/` at install time, and QuantLib installs `include/ql`.

### The Boost wrinkle in QuantLib

QuantLib needs Boost to build, and its *public* headers include `boost/` too (34 distinct headers: `boost/math/distributions/*`, `boost/accumulators/*`, `boost/shared_ptr.hpp`, ...).

QuantLib asks for it with a bare `find_package(Boost ${QL_BOOST_VERSION} REQUIRED)`, with no `MODULE` keyword. Under CMake 4 (the builders run 4.1.2, since `/opt/compiler-explorer/cmake/bin` leads `PATH` in `init/start-builder.sh`) that does not reliably resolve to our `boost` installable, which is headers-only and ships no `BoostConfig.cmake`. So the build forces module mode and points it straight at the installed tree:

```yaml
- -DCMAKE_POLICY_DEFAULT_CMP0167=OLD
- -DBoost_NO_BOOST_CMAKE=ON
- -DBoost_NO_SYSTEM_PATHS=ON
- -DBOOST_ROOT=/opt/compiler-explorer/libs/boost_1_84_0
```

`FindBoost.cmake` is still shipped in CMake 4, just gated behind `CMP0167`. `Boost_NO_SYSTEM_PATHS` additionally keeps it off any system boost, so what gets compiled against is the same tree the properties put on the include path.

This is specific to how QuantLib calls `find_package`; `hpx` looks superficially similar but does its own handling (it migrates `BOOST_ROOT` to `Boost_ROOT` and explicitly falls back to `MODULE` mode in `HPX_SetupBoost.cmake`), so it is not affected and needs no change.

### Verification

Both installables install cleanly via `ce_install --dest`:

```
libraries/c++/systemc: 3 packages installed OK, 0 skipped, and 0 failed installation
libraries/c++/quantlib: 1 packages installed OK, 0 skipped, and 0 failed installation
```

Both were then built for real with these exact cmake args and exercised end to end.

SystemC 3.0.2 produced `libsystemc.a` (4.5 MB); a clocked `SC_MODULE` linked against it and ran:

```
        SystemC 3.0.2-Accellera --- Aug  4 2026 17:41:54
tick 3 at 10 ns
tick 4 at 20 ns
tick 5 at 30 ns
```

3.0.0 and 3.0.1 build to `libsystemc.a` with the same recipe. `sc_main` works because the archive supplies `main`, which the linker pulls in to satisfy crt1.o.

QuantLib 1.43 was built against the genuine `ce_install`ed `libraries/c++/boost 1.84.0` tree rather than a system boost, producing `libQuantLib.a` (138 MB). A Black-Scholes European call priced correctly:

```
QuantLib 1.43
NPV   = 9.8263
delta = 0.611763
vega  = 37.7593
```

### Notes for reviewers

- SystemC 3.0 hard-errors below C++17 with upstream's own `#error **** SystemC requires a C++ standard version of at least C++17 ****`, so older compilers will fail to build it. That is expected, and the failure tracking will record it.
- `#include <ql/quantlib.hpp>` costs about 12.7s to compile; targeted `ql/` headers cost about 1.9s.
- SystemC 2.3.4 is still widely used and could follow if there is demand, but its build predates the current cmake support so it is not a copy of this recipe.

Companion PR: compiler-explorer/compiler-explorer#8992

🤖 Generated with [Claude Code](https://claude.com/claude-code)
