### PR TITLE
docs: correct build-script variable table

### DIFF
--- a/docs/library_configuration.md
+++ b/docs/library_configuration.md
@@ -274,12 +274,23 @@ Build-time variable expansion is available in `prebuild_script` and
 
 | Variable | Description |
 |---|---|
-| `%compiler%` | Compiler executable path |
+| `%compiler%` | Compiler id, e.g. `g142`. This is what the Conan download endpoints expect. |
+| `%compilerexe%` | Compiler executable path |
+| `%compilerTypeOrGcc%` | Compiler family, e.g. `gcc`, `clang` |
 | `%arch%` | Target architecture |
 | `%libcxx%` | C++ standard library |
 | `%stdver%` | C++ standard version |
+| `%buildos%` | Build OS (`Linux` or `Windows`) |
 | `%buildtype%` | Build configuration (Release/Debug) |
-| `%DEP0%`, `%DEP1%`, ... | Install paths of entries in `depends` list |
+| `%extraflags%` | Extra flags collection for this build |
+
+Writing a variable as `%name?%` makes the whole line conditional: if the value is
+empty, the line is dropped from the generated build script instead of expanding
+to nothing.
+
+`%DEP0%`, `%DEP1%`, ... (install paths of entries in `depends`) are *not*
+available here. They are substituted at installable level, in `after_stage_script`,
+`check_file`, `check_call` and `check_env`.
 
 ### Miscellaneous Build Properties
 


### PR DESCRIPTION
`docs/library_configuration.md` documented `%compiler%` as "Compiler executable path". It is the compiler id (`g142`) -- `%compilerexe%` is the path. The `boost_bin`/zlib example further down the same file uses it correctly, so only the table was wrong.

`%compiler%` being the id is what makes the Conan download endpoints work from a `prebuild_script`, so the wrong description is actively misleading for the main thing that table is consulted for.

Two adjacent corrections while in there:

- `%DEP0%`, `%DEP1%` were listed as available in `prebuild_script`/`postbuild_script`. They are not. `resolve_deps` in `bin/lib/installable/installable.py:89` only applies them to `after_stage_script`, `check_file`, `check_call` and `check_env`. The row now says where they do work rather than being dropped silently.
- Added the remaining variables `expand_build_script_line` supports (`%compilerexe%`, `%compilerTypeOrGcc%`, `%buildos%`, `%extraflags%`), and the `%name?%` conditional form from `replace_optional_arg` (`bin/lib/library_builder.py:673`), which drops the whole line when the value is empty. That one is undocumented and hard to work out from a failing build.

Docs only, no behaviour change. `make static-checks` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)