### PR TITLE
Add bubblewrap to CI runner setup

### DIFF
--- a/setup-ci.sh
+++ b/setup-ci.sh
@@ -40,6 +40,7 @@ apt-get -y install \
     cmake \
     ninja-build \
     elfutils \
+    bubblewrap \
     python-is-python3 \
     python3-pip \
     python3-venv \


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

`bwrap` (bubblewrap) is used by script-type installables (tiarmclang, dex2oat, etc.) to sandbox installer runs, but it was missing from `setup-ci.sh`, causing installs to fail with:

```
[Errno 2] No such file or directory: 'bwrap'
```

It's already present in `setup-admin.sh` — this just adds it to the CI runner image too. After merging, the runner images will need to be rebuilt for the fix to take effect.

Fixes recurring failures seen in tiarmclang (all LTS versions) and dex2oat install runs.