### PR TITLE
Add maven, and the Kotlin artifacts installed beside each compiler

### DIFF
--- a/bin/resources/maven/prime-kotlin.sh
+++ b/bin/resources/maven/prime-kotlin.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+
+# Maven builds Kotlin with kotlin-maven-plugin, which drives a compiler it resolves from a repository rather than
+# whatever is installed on the machine. Almost everything it resolves, a Kotlin installation already carries -- its
+# jars are those artifacts, byte for byte -- and Compiler Explorer links those in at build time, which is how the
+# compiler you select is the one that runs. What is left over is what this fetches, beside the compiler it belongs
+# to: the plugin itself, the poms, and from Kotlin 2.2 the embeddable compiler, a repackaging with everything
+# relocated inside it that no distribution ships.
+#
+# Kept per version rather than inside maven so that installing a new Kotlin costs one small install of its own,
+# instead of repriming maven from scratch.
+
+set -euo pipefail
+
+VERSION="$1"
+# Where to leave the repository, relative to the staging root this is run from.
+OUT="$2"
+MAVEN_HOME="$3"
+KOTLIN_HOME="$4"
+# The JDKs to try building under. They have to be named rather than discovered: an install may be sandboxed to its
+# declared dependencies, with nothing else of /opt/compiler-explorer visible.
+shift 4
+JDKS="$*"
+
+MVN="$MAVEN_HOME/bin/mvn"
+# Everything maven itself needs is already there, and reading through to it is what keeps this install small.
+SHARED_REPO="$MAVEN_HOME/repository"
+REPO="$(pwd)/$OUT"
+PROBE="$(pwd)/ce-prime-kotlin"
+HEAD="$(pwd)/ce-verify-head"
+# Where maven's own noise goes: a successful install should say one line, not a stack trace from an attempt that was
+# never expected to work.
+LOG="$(pwd)/ce-maven-output.log"
+# What the build is to link in from the installation, which is this repository's half of the bargain.
+SUPPLIED="$REPO/.ce-supplied-by-installation"
+
+# What a Kotlin installation carries, and so what does not need keeping: Compiler Explorer supplies these from the
+# selected compiler. Anything else a build resolves stays -- the plugin's own dependencies are pinned to old
+# versions, kotlin-reflect 1.6.10 and trove4j among them, that no distribution has.
+DISTRIBUTED_ARTIFACTS="kotlin-compiler kotlin-reflect kotlin-script-runtime kotlin-scripting-common
+    kotlin-scripting-compiler kotlin-scripting-compiler-impl kotlin-scripting-jvm kotlin-stdlib kotlin-stdlib-jdk7
+    kotlin-stdlib-jdk8 kotlin-daemon-client"
+
+export JAVA_HOME="${JDKS%% *}"
+
+# A project that uses the plugin the way a user's would, so that resolving it fetches what a real build needs.
+mkdir -p "$PROBE/src/main/kotlin"
+sed "s/@KOTLIN_VERSION@/$VERSION/" > "$PROBE/pom.xml" <<'POM'
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.compiler-explorer</groupId>
+  <artifactId>prime-kotlin</artifactId>
+  <version>1.0</version>
+  <properties><kotlin.version>@KOTLIN_VERSION@</kotlin.version></properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>${kotlin.version}</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <sourceDirectory>src/main/kotlin</sourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <version>${kotlin.version}</version>
+        <executions>
+          <execution><id>compile</id><phase>compile</phase><goals><goal>compile</goal></goals></execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+POM
+echo 'fun main() { println(1) }' > "$PROBE/src/main/kotlin/Prime.kt"
+
+# Where a distribution keeps the jar for an artifact: named after it, or without the leading `kotlin-`.
+installation_jar() {
+    local artifact="$1" candidate
+    for candidate in "$KOTLIN_HOME/lib/$artifact.jar" "$KOTLIN_HOME/lib/${artifact#kotlin-}.jar"; do
+        if [ -f "$candidate" ]; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+prime() {
+    # Never failing, and quiet: the compilation may not manage it under this JDK -- an old Kotlin under a new one
+    # cannot -- which says nothing about whether everything was fetched, and fetching is all this is for. The output
+    # is kept rather than discarded, to be shown if it turns out something was not.
+    (cd "$PROBE" && "$MVN" -B -q --fail-never -Dkotlin.version="$VERSION" \
+        -Dmaven.repo.local="$REPO" -Dmaven.repo.local.tail="$SHARED_REPO" "$@") >> "$LOG" 2>&1 || true
+}
+
+mkdir -p "$REPO"
+prime package
+# Running a Kotlin program needs its standard library beside the classes, which is how a build gets at it.
+prime dependency:copy-dependencies
+
+# No plugin, no Kotlin: fail the install rather than leave a directory that looks like support for this version.
+PLUGIN_JAR="$REPO/org/jetbrains/kotlin/kotlin-maven-plugin/$VERSION/kotlin-maven-plugin-$VERSION.jar"
+if [ ! -f "$PLUGIN_JAR" ]; then
+    cat "$LOG"
+    echo "Kotlin $VERSION has no maven plugin to build with"
+    exit 1
+fi
+
+# Take back out what the installation supplies, at this version only, and say which those were: guessing at it later
+# from what has a pom is not good enough, because an artifact maven itself already had -- the Java plugins drag in a
+# Kotlin standard library of their own -- is resolved from there and leaves no pom here to notice.
+: > "$SUPPLIED"
+for artifact in $DISTRIBUTED_ARTIFACTS; do
+    jar="$REPO/org/jetbrains/kotlin/$artifact/$VERSION/$artifact-$VERSION.jar"
+    test -f "$jar" || continue
+    # Only ever remove what the installation demonstrably has, so that what is recorded here can always be answered.
+    installation_jar "$artifact" > /dev/null || continue
+    rm -f "$jar" "$jar.sha1"
+    echo "$artifact" >> "$SUPPLIED"
+done
+
+# Linked the way Compiler Explorer will link it, from that same record.
+rm -rf "$HEAD"
+while read -r artifact; do
+    mkdir -p "$HEAD/org/jetbrains/kotlin/$artifact/$VERSION"
+    ln -s "$(installation_jar "$artifact")" "$HEAD/org/jetbrains/kotlin/$artifact/$VERSION/$artifact-$VERSION.jar"
+done < "$SUPPLIED"
+
+# Prove it offline against the chain a build will use, under whichever JDK manages it: Compiler Explorer pairs each
+# Kotlin with a JDK of its era -- 1.4 with 15, 2.1 with 23 -- so an old compiler failing under a new JDK says nothing.
+# Where the machine is not sandboxed, anything else installed is worth trying too.
+built_with=""
+for jdk in $JDKS $(ls -d /opt/compiler-explorer/jdk-* 2>/dev/null | sort -Vr); do
+    test -x "$jdk/bin/java" || continue
+    rm -rf ce-verify
+    cp -r "$PROBE" ce-verify
+    rm -rf ce-verify/target
+    : > "$LOG"
+    if (cd ce-verify && JAVA_HOME="$jdk" "$MVN" -o -B -q -Dkotlin.version="$VERSION" \
+            -Dmaven.repo.local="$HEAD" -Dmaven.repo.local.tail="$REPO,$SHARED_REPO" package) >> "$LOG" 2>&1; then
+        built_with="$(basename "$jdk")"
+        break
+    fi
+done
+rm -rf "$PROBE" "$HEAD" ce-verify
+
+if [ -z "$built_with" ]; then
+    # The last attempt's output, so that a version being dropped comes with the reason it was.
+    cat "$LOG"
+    echo "Kotlin $VERSION cannot build under any JDK here"
+    exit 1
+fi
+rm -f "$LOG"
+echo "Verified an offline Kotlin $VERSION build against the installed compiler, under $built_with"

--- a/bin/resources/maven/prime-repository.sh
+++ b/bin/resources/maven/prime-repository.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Maven cannot do anything without its plugins, and build nodes have no network to fetch them: even a hello world
+# needs the resources, compiler and jar plugins. So prime a repository here, while we still have a network, by running
+# each plugin against a throwaway project -- a plugin only downloads what it needs when actually invoked. Builds then
+# point maven.repo.local at the result; it is only read, so all compilations share this one copy.
+#
+# This is the Java half, and it is all of it: what a Kotlin version needs on top is installed beside that compiler
+# instead, by prime-kotlin.sh, so that adding a Kotlin never means priming this again. See tools/kotlin-maven in
+# kotlin.yaml.
+
+set -euo pipefail
+
+# The unpacked maven, relative to the staging root this is run from, and the JDK to run it with.
+MVN_DIR="$1"
+export JAVA_HOME="$2"
+
+REPO="$(pwd)/$MVN_DIR/repository"
+MVN="$(pwd)/$MVN_DIR/bin/mvn"
+
+prime() {
+    # Never failing: some of these exit non-zero by design -- checkstyle on a style violation -- while still having
+    # fetched everything they need.
+    "$MVN" -B -q --fail-never -Dmaven.repo.local="$REPO" "$@" || true
+}
+
+verify_offline() {
+    # Priming is best-effort, so prove the result actually serves an offline build before shipping it.
+    "$MVN" -o -B -Dmaven.repo.local="$REPO" clean package
+}
+
+mkdir -p ce-prime/src/main/java
+cat > ce-prime/pom.xml <<'POM'
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.compiler-explorer</groupId>
+  <artifactId>prime</artifactId>
+  <version>1.0</version>
+  <build><plugins>
+    <plugin><groupId>org.codehaus.mojo</groupId><artifactId>exec-maven-plugin</artifactId><version>3.5.0</version></plugin>
+    <plugin><groupId>org.codehaus.mojo</groupId><artifactId>build-helper-maven-plugin</artifactId><version>3.6.0</version></plugin>
+    <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-checkstyle-plugin</artifactId><version>3.6.0</version></plugin>
+    <plugin><groupId>com.diffplug.spotless</groupId><artifactId>spotless-maven-plugin</artifactId><version>2.44.4</version></plugin>
+    <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-javadoc-plugin</artifactId><version>3.11.2</version></plugin>
+    <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-source-plugin</artifactId><version>3.3.1</version></plugin>
+    <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-dependency-plugin</artifactId><version>3.8.1</version></plugin>
+    <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-antrun-plugin</artifactId><version>3.1.0</version></plugin>
+  </plugins></build>
+</project>
+POM
+echo 'public class Prime { public static void main(String[] a) { System.out.println(1); } }' > ce-prime/src/main/java/Prime.java
+
+pushd ce-prime > /dev/null
+# One at a time: a plugin that stops the chain leaves everything after it unfetched.
+prime clean install
+prime javadoc:jar
+prime source:jar
+prime exec:java -Dexec.mainClass=Prime
+prime spotless:check
+prime checkstyle:check
+prime antrun:run
+prime build-helper:add-source
+prime dependency:list
+prime dependency:copy-dependencies
+# A plugin that runs inside maven drags in a maven API of its own era, and kotlin-maven-plugin does: three of them
+# across the versions Compiler Explorer offers, at some 13 MiB each. They have nothing to do with which Kotlin asked
+# for them, so they belong here rather than in every per-version repository, which would each carry a copy.
+for maven_api in 2.2.1 3.0 3.0.5; do
+    prime org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get -Dartifact="org.apache.maven:maven-core:$maven_api"
+done
+verify_offline
+popd > /dev/null
+rm -rf ce-prime
+
+# Last, so that a prime that fell over never looks finished. Bump the number when what is primed here changes: it is
+# what tells an install predating that change to redo itself.
+touch "$REPO/.ce-primed-2"

--- a/bin/yaml/kotlin.yaml
+++ b/bin/yaml/kotlin.yaml
@@ -9,7 +9,6 @@ compilers:
       - JAVA_HOME=%DEP0%
     check_exe: bin/kotlinc-jvm -version
     url: https://github.com/JetBrains/kotlin/releases/download/v{{name}}/kotlin-compiler-{{name}}.zip
-    # Adding a version here is all it takes: tools/kotlin-maven below builds from the same list.
     targets: &kotlin_versions
       - 1.4.0
       - 1.4.10
@@ -47,24 +46,17 @@ compilers:
       - 2.2.20
 
 tools:
-  # Maven builds Kotlin with a compiler kotlin-maven-plugin resolves from a repository, not with whatever is
-  # installed, so each version needs the few artifacts its own distribution does not carry -- the plugin above all.
-  # They live beside the compiler rather than inside maven so that a new Kotlin costs one small install of its own.
   kotlin-maven:
     type: script
     dir: kotlin-jvm-{{name}}-maven
     depends:
-      - tools/maven 3.9.16         # %DEP0%: the mvn to run, and the repository everything else reads through to
-      - compilers/kotlin {{name}}  # %DEP1%: the jars this is the complement of, and what it is verified against
-      - compilers/java 21.0.2      # %DEP2%
-      - compilers/java 15.0.2      # %DEP3%: Kotlin 1.4.20 to 1.4.32 only build under a JDK of their own era
-    # Copied into staging rather than run where it lies: this installs inside a sandbox that replaces
-    # /opt/compiler-explorer with an empty tmpfs, and the infra checkout is under there too.
+      - tools/maven 3.9.16
+      - compilers/kotlin {{name}}
+      - compilers/java 21.0.2
+      - compilers/java 15.0.2  # Kotlin 1.4.20 to 1.4.32 only build under a JDK of their own era
     fetch:
       - '{{resource_dir}}/maven/prime-kotlin.sh prime-kotlin.sh'
     script: |
       bash prime-kotlin.sh "{{name}}" "kotlin-jvm-{{name}}-maven" "%DEP0%" "%DEP1%" "%DEP2%" "%DEP3%"
-    # The record of what the installation has to supply: what a build actually reads, and so what says this was
-    # primed the way builds now expect. An install predating it redoes itself.
     check_file: .ce-supplied-by-installation
     targets: *kotlin_versions

--- a/bin/yaml/kotlin.yaml
+++ b/bin/yaml/kotlin.yaml
@@ -9,7 +9,8 @@ compilers:
       - JAVA_HOME=%DEP0%
     check_exe: bin/kotlinc-jvm -version
     url: https://github.com/JetBrains/kotlin/releases/download/v{{name}}/kotlin-compiler-{{name}}.zip
-    targets:
+    # Adding a version here is all it takes: tools/kotlin-maven below builds from the same list.
+    targets: &kotlin_versions
       - 1.4.0
       - 1.4.10
       - 1.4.20
@@ -44,3 +45,26 @@ compilers:
       - 2.2.0
       - 2.2.10
       - 2.2.20
+
+tools:
+  # Maven builds Kotlin with a compiler kotlin-maven-plugin resolves from a repository, not with whatever is
+  # installed, so each version needs the few artifacts its own distribution does not carry -- the plugin above all.
+  # They live beside the compiler rather than inside maven so that a new Kotlin costs one small install of its own.
+  kotlin-maven:
+    type: script
+    dir: kotlin-jvm-{{name}}-maven
+    depends:
+      - tools/maven 3.9.16         # %DEP0%: the mvn to run, and the repository everything else reads through to
+      - compilers/kotlin {{name}}  # %DEP1%: the jars this is the complement of, and what it is verified against
+      - compilers/java 21.0.2      # %DEP2%
+      - compilers/java 15.0.2      # %DEP3%: Kotlin 1.4.20 to 1.4.32 only build under a JDK of their own era
+    # Copied into staging rather than run where it lies: this installs inside a sandbox that replaces
+    # /opt/compiler-explorer with an empty tmpfs, and the infra checkout is under there too.
+    fetch:
+      - '{{resource_dir}}/maven/prime-kotlin.sh prime-kotlin.sh'
+    script: |
+      bash prime-kotlin.sh "{{name}}" "kotlin-jvm-{{name}}-maven" "%DEP0%" "%DEP1%" "%DEP2%" "%DEP3%"
+    # The record of what the installation has to supply: what a build actually reads, and so what says this was
+    # primed the way builds now expect. An install predating it redoes itself.
+    check_file: .ce-supplied-by-installation
+    targets: *kotlin_versions

--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -35,18 +35,14 @@ tools:
     url: https://archive.apache.org/dist/maven/maven-3/{{name}}/binaries/apache-maven-{{name}}-bin.tar.gz
     dir: maven-{{name}}
     untar_dir: apache-maven-{{name}}
-    # Needed to run maven during the install below; at build time the JDK is whichever the user picked.
     depends:
       - compilers/java 21.0.2
-    # The repository maven builds read is primed at install time, while there is still a network; see the script.
     after_stage_script:
       - '"{{resource_dir}}/maven/prime-repository.sh" apache-maven-{{name}} %DEP0%'
-    # A marker the priming writes last, rather than bin/mvn or any one artifact: it is the only thing that can say
-    # "primed the way we prime it now", so an install predating a change to that is redone.
     check_file: repository/.ce-primed-2
     targets:
       - name: 3.9.16
-        symlink: maven  # The one distinguished maven we use for "maven" on the site
+        symlink: maven
   ninja:
     type: ziparchive
     extract_into_folder: true

--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -29,6 +29,62 @@ tools:
       check_exe: bin/cmake --help
       targets:
         - 3.29.20240506-g1ea8fa8
+  maven:
+    type: tarballs
+    compression: gz
+    url: https://archive.apache.org/dist/maven/maven-3/{{name}}/binaries/apache-maven-{{name}}-bin.tar.gz
+    dir: maven-{{name}}
+    untar_dir: apache-maven-{{name}}
+    # Needed to run maven during the install below; at build time the JDK is whichever the user picked.
+    depends:
+      - compilers/java 21.0.2
+    # Maven cannot do anything without its plugins, and build nodes have no network to fetch them: even a hello world
+    # needs the resources, compiler and jar plugins. So prime a repository here, while we still have a network, by
+    # running each plugin against a throwaway project -- a plugin only downloads what it needs when actually invoked.
+    # Builds then point maven.repo.local at it; it is only read, so all compilations share this one copy.
+    after_stage_script:
+      - |
+        # This runs in the staging root, with the unpacked maven one level down.
+        MVN_DIR="apache-maven-{{name}}"
+        REPO="$(pwd)/$MVN_DIR/repository"
+        MVN="$(pwd)/$MVN_DIR/bin/mvn"
+        export JAVA_HOME=%DEP0%
+        mkdir -p ce-prime/src/main/java
+        cat > ce-prime/pom.xml <<'POM'
+        <project xmlns="http://maven.apache.org/POM/4.0.0">
+          <modelVersion>4.0.0</modelVersion>
+          <groupId>org.compiler-explorer</groupId>
+          <artifactId>prime</artifactId>
+          <version>1.0</version>
+          <build><plugins>
+            <plugin><groupId>org.codehaus.mojo</groupId><artifactId>exec-maven-plugin</artifactId><version>3.5.0</version></plugin>
+            <plugin><groupId>org.codehaus.mojo</groupId><artifactId>build-helper-maven-plugin</artifactId><version>3.6.0</version></plugin>
+            <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-checkstyle-plugin</artifactId><version>3.6.0</version></plugin>
+            <plugin><groupId>com.diffplug.spotless</groupId><artifactId>spotless-maven-plugin</artifactId><version>2.44.4</version></plugin>
+            <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-javadoc-plugin</artifactId><version>3.11.2</version></plugin>
+            <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-source-plugin</artifactId><version>3.3.1</version></plugin>
+            <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-dependency-plugin</artifactId><version>3.8.1</version></plugin>
+            <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-antrun-plugin</artifactId><version>3.1.0</version></plugin>
+          </plugins></build>
+        </project>
+        POM
+        echo 'public class Prime { public static void main(String[] a) { System.out.println(1); } }' > ce-prime/src/main/java/Prime.java
+        cd ce-prime
+        # Independently, and never failing: a plugin that stops the chain leaves everything after it unfetched, and
+        # some of these exit non-zero by design (checkstyle on a style violation) while still having fetched fine.
+        for goal in "clean install" "javadoc:jar" "source:jar" "exec:java -Dexec.mainClass=Prime" \
+                    "spotless:check" "checkstyle:check" "antrun:run" "build-helper:add-source" "dependency:list"; do
+          "$MVN" -B -q --fail-never -Dmaven.repo.local="$REPO" $goal || true
+        done
+        # Priming is best-effort above, so prove the result actually serves an offline build before shipping it.
+        "$MVN" -o -B -Dmaven.repo.local="$REPO" clean package
+        cd ..
+        rm -rf ce-prime
+    # Anchored in the primed repository rather than on bin/mvn, so an install predating the priming is redone.
+    check_file: repository/org/apache/maven/plugins/maven-jar-plugin/3.5.0/maven-jar-plugin-3.5.0.jar
+    targets:
+      - name: 3.9.16
+        symlink: maven  # The one distinguished maven we use for "maven" on the site
   ninja:
     type: ziparchive
     extract_into_folder: true

--- a/bin/yaml/tools.yaml
+++ b/bin/yaml/tools.yaml
@@ -38,50 +38,12 @@ tools:
     # Needed to run maven during the install below; at build time the JDK is whichever the user picked.
     depends:
       - compilers/java 21.0.2
-    # Maven cannot do anything without its plugins, and build nodes have no network to fetch them: even a hello world
-    # needs the resources, compiler and jar plugins. So prime a repository here, while we still have a network, by
-    # running each plugin against a throwaway project -- a plugin only downloads what it needs when actually invoked.
-    # Builds then point maven.repo.local at it; it is only read, so all compilations share this one copy.
+    # The repository maven builds read is primed at install time, while there is still a network; see the script.
     after_stage_script:
-      - |
-        # This runs in the staging root, with the unpacked maven one level down.
-        MVN_DIR="apache-maven-{{name}}"
-        REPO="$(pwd)/$MVN_DIR/repository"
-        MVN="$(pwd)/$MVN_DIR/bin/mvn"
-        export JAVA_HOME=%DEP0%
-        mkdir -p ce-prime/src/main/java
-        cat > ce-prime/pom.xml <<'POM'
-        <project xmlns="http://maven.apache.org/POM/4.0.0">
-          <modelVersion>4.0.0</modelVersion>
-          <groupId>org.compiler-explorer</groupId>
-          <artifactId>prime</artifactId>
-          <version>1.0</version>
-          <build><plugins>
-            <plugin><groupId>org.codehaus.mojo</groupId><artifactId>exec-maven-plugin</artifactId><version>3.5.0</version></plugin>
-            <plugin><groupId>org.codehaus.mojo</groupId><artifactId>build-helper-maven-plugin</artifactId><version>3.6.0</version></plugin>
-            <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-checkstyle-plugin</artifactId><version>3.6.0</version></plugin>
-            <plugin><groupId>com.diffplug.spotless</groupId><artifactId>spotless-maven-plugin</artifactId><version>2.44.4</version></plugin>
-            <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-javadoc-plugin</artifactId><version>3.11.2</version></plugin>
-            <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-source-plugin</artifactId><version>3.3.1</version></plugin>
-            <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-dependency-plugin</artifactId><version>3.8.1</version></plugin>
-            <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-antrun-plugin</artifactId><version>3.1.0</version></plugin>
-          </plugins></build>
-        </project>
-        POM
-        echo 'public class Prime { public static void main(String[] a) { System.out.println(1); } }' > ce-prime/src/main/java/Prime.java
-        cd ce-prime
-        # Independently, and never failing: a plugin that stops the chain leaves everything after it unfetched, and
-        # some of these exit non-zero by design (checkstyle on a style violation) while still having fetched fine.
-        for goal in "clean install" "javadoc:jar" "source:jar" "exec:java -Dexec.mainClass=Prime" \
-                    "spotless:check" "checkstyle:check" "antrun:run" "build-helper:add-source" "dependency:list"; do
-          "$MVN" -B -q --fail-never -Dmaven.repo.local="$REPO" $goal || true
-        done
-        # Priming is best-effort above, so prove the result actually serves an offline build before shipping it.
-        "$MVN" -o -B -Dmaven.repo.local="$REPO" clean package
-        cd ..
-        rm -rf ce-prime
-    # Anchored in the primed repository rather than on bin/mvn, so an install predating the priming is redone.
-    check_file: repository/org/apache/maven/plugins/maven-jar-plugin/3.5.0/maven-jar-plugin-3.5.0.jar
+      - '"{{resource_dir}}/maven/prime-repository.sh" apache-maven-{{name}} %DEP0%'
+    # A marker the priming writes last, rather than bin/mvn or any one artifact: it is the only thing that can say
+    # "primed the way we prime it now", so an install predating a change to that is redone.
+    check_file: repository/.ce-primed-2
     targets:
       - name: 3.9.16
         symlink: maven  # The one distinguished maven we use for "maven" on the site


### PR DESCRIPTION
Adds maven as a tool, and the per-Kotlin-version artifacts a Maven build of Kotlin needs, for the build system support in compiler-explorer#8994.

## tools/maven

Maven cannot build anything without its lifecycle plugins, and build nodes have no network to fetch them: an empty local repository fails even for a hello world. The install builds a throwaway project while it still has a network, leaving what it fetched in a repository inside the install. Compiler Explorer points `maven.repo.local` at that; it is only read, so all compilations share one copy rather than each taking a copy of its own.

Each goal runs separately and with `--fail-never`:

- A plugin only fetches what it needs when it is actually invoked. Resolving plugins is not enough — checkstyle still failed offline until its goal had been run once.
- Chaining the goals does not work: checkstyle exits non-zero on a style violation, which leaves everything after it in the chain unfetched.

The install then builds offline against what it produced and fails if that does not work, since the priming itself is best-effort. It is ~96MB and takes about 40 seconds.

`check_file` is a marker the priming writes last, `repository/.ce-primed-2`, rather than any one artifact: it is the only thing that can say "primed the way we prime it now", so an install predating a change to that is redone. Bump the number when what is primed changes.

## tools/kotlin-maven

kotlin-maven-plugin compiles with a compiler it resolves from a repository rather than with anything installed on the machine. Almost everything it resolves, a Kotlin installation already carries — its jars **are** those artifacts, byte for byte, down to the sha1 — and Compiler Explorer links those in at build time, which is how the compiler selected on the site is the one that runs.

What is left over is what this installs, beside the compiler it belongs to as `kotlin-jvm-<version>-maven`: the plugin itself (80KB), the poms, and from Kotlin 2.2 the embeddable compiler, a repackaging with everything relocated inside it that no distribution ships.

**Kept per version rather than inside maven**, because otherwise installing a new Kotlin means repriming maven from scratch — eight minutes and 2GB fetched to be mostly thrown away again. Now a Kotlin version is one line in `kotlin.yaml`, shared between the compiler and this through a YAML anchor, and one small install of its own.

Each version, in turn:

- primed online into its own directory with the shared repository as tail, so only what maven does not already have is downloaded
- pruned of what the installation supplies, **recording what those were** in `.ce-supplied-by-installation` — guessing at it later from what has a pom is not good enough, because the Java plugins drag in a Kotlin standard library of their own and an artifact resolved from there leaves no pom to notice
- verified offline against the installed compiler, under each JDK given until one manages it: Compiler Explorer pairs each Kotlin with a JDK of its era, so an old compiler failing under a new JDK says nothing. A version that cannot build is not offered.

The script is copied into staging rather than run where it lies, because the install sandbox replaces `/opt/compiler-explorer` with an empty tmpfs and the infra checkout is under there too.

## Ordering

The maven marker forces its Java-only reprime, and `tools/kotlin-maven` depends on `tools/maven`, so a plain `ce_install install tools/kotlin-maven` does both in the right order. That order matters: the per-version repositories are primed against the slim maven and would silently lack the plugin's cross-version pins if maven were shrunk afterwards.

## Verified

34 Kotlin versions, 1.4.0 through 2.2.20, each primed, pruned and then built offline against its own installation — 1.4.20 to 1.4.32 under jdk-15.0.2, the rest under 21. Then driven from Compiler Explorer, where the bytecode's metadata version follows the compiler picked on the site: `mv=[1,9,0]`, `mv=[2,1,0]`, `mv=[2,2,0]`.
