### PR TITLE
Run the builder on pyenv's Python, not whatever python resolves to

### DIFF
--- a/init/start-builder.sh
+++ b/init/start-builder.sh
@@ -21,7 +21,10 @@ if [ "$LIBRARYTOBUILD" != "all" ]; then
 fi
 
 PYENV_ROOT="/opt/pyenv"
-PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PYENV_ROOT/versions/3.10.16/bin:/home/ubuntu/.local/bin:/opt/compiler-explorer/cmake/bin:$PATH"
+# The version is pinned, so address its bin directly rather than going through
+# pyenv's shims: a shim re-runs `pyenv rehash` after pip, which wants to write
+# to $PYENV_ROOT/shims, and the image ships that tree read-only.
+PATH="$PYENV_ROOT/versions/3.10.16/bin:$PYENV_ROOT/bin:/home/ubuntu/.local/bin:/opt/compiler-explorer/cmake/bin:$PATH"
 
 # conan 1.59 pins PyYAML<=6.0, which has no wheel for the 3.12 that Ubuntu
 # 24.04 ships, so the build must run on pyenv's 3.10. Fail loudly rather than

--- a/init/start-builder.sh
+++ b/init/start-builder.sh
@@ -20,8 +20,17 @@ if [ "$LIBRARYTOBUILD" != "all" ]; then
   LIBRARYPARAM="libraries/$LANGUAGE/$LIBRARYTOBUILD"
 fi
 
-PYENV_ROOT="/root/.pyenv"
+PYENV_ROOT="/opt/pyenv"
 PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PYENV_ROOT/versions/3.10.16/bin:/home/ubuntu/.local/bin:/opt/compiler-explorer/cmake/bin:$PATH"
+
+# conan 1.59 pins PyYAML<=6.0, which has no wheel for the 3.12 that Ubuntu
+# 24.04 ships, so the build must run on pyenv's 3.10. Fail loudly rather than
+# falling through to the system python, which is how this broke silently
+# before: pyenv lived under /root and was unreadable to the ubuntu user.
+if ! command -v python >/dev/null || [[ "$(command -v python)" != "$PYENV_ROOT"/* ]]; then
+  echo "Expected python from $PYENV_ROOT, got '$(command -v python || echo none)'" >&2
+  exit 1
+fi
 
 git config --global --add safe.directory '*'
 


### PR DESCRIPTION
conan 1.59 pins PyYAML<=6.0, which has no wheel for the Python 3.12 that
Ubuntu 24.04 ships and fails to build from source against modern Cython. With
the CI builder image moving to 24.04, the build has to run on the pyenv 3.10.16
baked into that image.

It never actually did. pyenv was installed under `/root`, which the
`ubuntu`-run build job cannot traverse, so those PATH entries were silently
skipped and `python` fell through to the system one. Invisible on jammy, where
the system Python was also 3.10; fatal on noble.

- point `PYENV_ROOT` at `/opt/pyenv` (ce-ci moves the install to match)
- address `versions/3.10.16/bin` directly rather than via shims, which re-run
  `pyenv rehash` after pip and want to write to a read-only tree
- fail loudly if `python` still isn't pyenv's, so the next breakage says so
  instead of quietly changing interpreter

Verified end to end on the noble builder: `fmt` built with `g151`, run
31039439850.

Conan version itself is untouched; see #2271. The awkward branch-testing dance
this needed is #2273.