### PR TITLE
Add all missing CE compiler types to Conan settings.yml

### DIFF
--- a/init/settings.yml
+++ b/init/settings.yml
@@ -39,6 +39,9 @@ compiler:
     clang-hexagon:
         version: ANY
         libcxx: ANY
+    ticlang:
+        version: ANY
+        libcxx: ANY
     edg:
         version: ANY
         libcxx: ANY

--- a/init/settings.yml
+++ b/init/settings.yml
@@ -15,13 +15,34 @@ compiler:
     clang:
         version: ANY
         libcxx: ANY
+    clang-intel:
+        version: ANY
+        libcxx: ANY
     ellcc:
         version: ANY
         libcxx: ANY
     zigcxx:
         version: ANY
         libcxx: ANY
+    zig:
+        version: ANY
+        libcxx: ANY
+    zigcc:
+        version: ANY
+        libcxx: ANY
     rust:
+        version: ANY
+        libcxx: ANY
+    mrustc:
+        version: ANY
+        libcxx: ANY
+    rustc-cg-gcc:
+        version: ANY
+        libcxx: ANY
+    rustc-cg-cranelift:
+        version: ANY
+        libcxx: ANY
+    c2rust:
         version: ANY
         libcxx: ANY
     gccrs:
@@ -48,10 +69,19 @@ compiler:
     nvcc:
         version: ANY
         libcxx: ANY
+    nvrtc:
+        version: ANY
+        libcxx: ANY
     scale-nvcc-nvidia:
         version: ANY
         libcxx: ANY
     scale-nvcc-amd:
+        version: ANY
+        libcxx: ANY
+    clang-cuda:
+        version: ANY
+        libcxx: ANY
+    clang-hip:
         version: ANY
         libcxx: ANY
     fortran:
@@ -87,7 +117,61 @@ compiler:
     tinygo:
         version: ANY
         libcxx: ANY
+    dmd:
+        version: ANY
+        libcxx: ANY
+    ldc:
+        version: ANY
+        libcxx: ANY
+    sway-compiler:
+        version: ANY
+        libcxx: ANY
     m68k:
+        version: ANY
+        libcxx: ANY
+    cc65:
+        version: ANY
+        libcxx: ANY
+    avrgcc6502:
+        version: ANY
+        libcxx: ANY
+    orca:
+        version: ANY
+        libcxx: ANY
+    z88dk:
+        version: ANY
+        libcxx: ANY
+    sdcc:
+        version: ANY
+        libcxx: ANY
+    cl430:
+        version: ANY
+        libcxx: ANY
+    msp430:
+        version: ANY
+        libcxx: ANY
+    tinyc:
+        version: ANY
+        libcxx: ANY
+    cproc:
+        version: ANY
+        libcxx: ANY
+    compcert:
+        version: ANY
+        libcxx: ANY
+    tendra:
+        version: ANY
+        libcxx: ANY
+    norcroft:
+        version: ANY
+        libcxx: ANY
+    ppci:
+        version: ANY
+        libcxx: ANY
+    movfuscator:
+        version: ANY
+        libcxx: ANY
+    co2cc:
         version: ANY
         libcxx: ANY
 


### PR DESCRIPTION
Declares every `compilerType` that Compiler Explorer's config references but `init/settings.yml` was missing: 29 values in total, adding to the 26 already present.

### What triggered this

The `check-infra-settings` bot flagged compiler-explorer/compiler-explorer#8946 (TI Arm Clang, now merged) for adding `compilerType=ticlang` with no matching entry here. Auditing the rest of the file showed `ticlang` was one of 29 such gaps rather than a one-off, so this closes the gap entirely instead of just unblocking that PR.

### Why the vocabulary does not match

The bot talks about `compilerType`, which does not appear anywhere in this file. `init/settings.yml` is a **Conan** settings file, so CE's `compilerType` property values are what land in Conan's top-level `compiler` map. `etc/scripts/check_infra_settings.py` in the compiler-explorer repo compares against exactly that map's keys, which is why the two names have to line up even though they are spelled differently on each side.

### Failure mode

`init/start-builder.sh` copies this file to `${CONAN_HOME}/settings.yml` on the library builder (`conan/switch-to-ce.sh` does the same locally). Conan validates the `compiler` setting against it and errors on any value not listed, so a library build targeting an undeclared compiler fails rather than degrading.

This was long-standing rather than a new regression. Most of the missing values predate the checker by years: `zigcc` and `clang-cuda` since 2021, `avrgcc6502` and `cl430` since 2022. The bot is new, not the gap.

### Notes on the change

Derived by running the checker's own regex and file list over `compiler-explorer` main, then subtracting the keys already here. After the change that computation reports zero missing `compilerType` values (and zero missing `stdver` values). All 29 were confirmed to resolve to a real compiler class under `lib/compilers/`, so none is dead or mistyped config.

Every entry uses the standard `version: ANY` / `libcxx: ANY` shape, including the C-only and non-C++ compilers. `build_target_settings` in `bin/lib/library_builder.py` always emits `compiler.libcxx`, and Conan rejects a subsetting the compiler does not declare, so omitting it would break those builds rather than tidy them. The existing `golang` entry already relies on this, passing an empty value against `libcxx: ANY`.

New entries sit next to their relatives (`cl430` with `msp430`, `ldc` with `dmd`, the `rustc-cg-*` pair with `rust`, the clang variants with `clang`, `nvrtc` and the HIP/CUDA clangs with `nvcc`) rather than in sorted order, matching how the file already groups by family. No existing entry moved.

Companion to compiler-explorer/compiler-explorer#8946.

🤖 Generated with [Claude Code](https://claude.com/claude-code)