### PR TITLE
Add gcc 16.2.0

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -113,6 +113,8 @@ compilers:
           - assertions-15.3.0
           - 16.1.0
           - assertions-16.1.0
+          - 16.2.0
+          - assertions-16.2.0
     cross:
       type: s3tarballs
       arch_prefix:


### PR DESCRIPTION
Installs `gcc-16.2.0` and `gcc-assertions-16.2.0` for x86-64.

Scope matches the 15.3.0 / 14.4.0 point releases: native only. No cross-compiler tarballs are being built for 16.2.0, so the cross target lists are untouched.

Depends on the S3 artifacts landing (build in progress at time of writing).

Companion PR: compiler-explorer/compiler-explorer#8998

🤖 Generated with [Claude Code](https://claude.com/claude-code)