### PR TITLE
Windows: bump AMI cmake to 4.4.2, drop unused share installables

### DIFF
--- a/bin/yaml/windows.yaml
+++ b/bin/yaml/windows.yaml
@@ -51,28 +51,3 @@ windows:
           url: https://github.com/GPUOpen-Tools/radeon_gpu_analyzer/releases/download/2.10/rga-windows-x64-2.10.zip
         - name: "2.9.1"
           url: https://github.com/GPUOpen-Tools/radeon_gpu_analyzer/releases/download/2.9.1/rga-windows-x64-2.9.1.zip
-  tools:
-    cmake:
-      type: ziparchive
-      url: https://github.com/Kitware/CMake/releases/download/v{{name}}/cmake-{{name}}-windows-x86_64.zip
-      dir: cmake-v{{name}}
-      check_file: "bin/cmake.exe"
-      folder: "cmake-{{name}}-windows-x86_64"
-      targets:
-        - 3.27.6
-        - 3.27.9
-        - 3.28.4
-        - 3.29.2
-        - 3.30.7
-        - 3.31.5
-        - 4.1.2
-        - 4.4.2
-    ninja:
-      type: ziparchive
-      url: https://github.com/compiler-explorer/ninja/releases/download/v{{name}}/ninja-win.zip
-      dir: ninja-v{{name}}
-      folder: "bin"
-      extract_into_folder: true
-      check_file: "ninja.exe"
-      targets:
-        - 1.12.1

--- a/docs/windows_architecture.md
+++ b/docs/windows_architecture.md
@@ -36,18 +36,27 @@ CMake and Ninja are not `ce_install` installables on Windows. They are baked int
 * `packer/InstallTools.ps1` for the node image. This is what the site runs: CE's
   `compiler-explorer.amazonwin.properties` names them outright as
   `cmake=C:/BuildTools/CMake/bin/cmake.exe` and `ninjaPath=C:/BuildTools/Ninja`.
-* `packer/InstallBuilderTools.ps1` for the library builder image, on its own version.
-  `init/start-builder.ps1` puts it on PATH and `library_builder.py` invokes bare `cmake`. It affects
-  library builds rather than the site, and moves independently.
+* `packer/InstallBuilderTools.ps1` for the library builder image. `init/start-builder.ps1` puts it on
+  PATH and `library_builder.py` invokes bare `cmake`, so this one decides what library builds get.
 
-To bump the node image:
+The two are separate knobs and have drifted apart before. Keep them on the same version unless you
+have a reason not to, and remember the Linux builder is a third: it takes whichever cmake carries the
+`symlink: cmake` marker in `bin/yaml/tools.yaml`, via `init/start-builder.sh`.
 
-1. Update the download URL and the `Rename-Item` source directory in `InstallBuildTools`
-2. `make packer-win`
-3. Put the new AMI id in `winstaging_image_id` in `terraform/lc.tf`, apply, and restart winstaging
-4. Once it's proven, point `winprod_image_id` at it and restart winprod
+Both scripts bump the same way: edit the download URL and the `Rename-Item` source directory in
+`InstallBuildTools`. Getting the result deployed differs.
+
+For the node image:
+
+1. `make packer-win`
+2. Put the new AMI id in `winstaging_image_id` in `terraform/lc.tf`, apply, and restart winstaging
+3. Once it's proven, point `winprod_image_id` at it and restart winprod
 
 `ec2.tf` derives the win-runner image from `winstaging_image_id`, so that follows along.
+
+The builder image has no packer HCL -- nothing references `InstallBuilderTools.ps1` -- and its
+security group is a terraform `data` lookup rather than a managed resource. It is built by hand, so
+a bump there means rebuilding it yourself.
 
 The compiler share used to carry `cmake-v*` and `ninja-v*` installables as well. Nothing ever read
 them -- both images use their own `C:\BuildTools` copy -- so they were dropped from

--- a/docs/windows_architecture.md
+++ b/docs/windows_architecture.md
@@ -28,6 +28,31 @@ winprod` and is uploaded to whichever environment is asked for.
 Windows instances are reachable over ssh as `Administrator` (see Bootstrapping), which is what
 the runner commands use.
 
+## Updating CMake and Ninja
+
+CMake and Ninja are not `ce_install` installables on Windows. They are baked into the images as
+`C:\BuildTools\CMake` and `C:\BuildTools\Ninja`, one copy per image:
+
+* `packer/InstallTools.ps1` for the node image. This is what the site runs: CE's
+  `compiler-explorer.amazonwin.properties` names them outright as
+  `cmake=C:/BuildTools/CMake/bin/cmake.exe` and `ninjaPath=C:/BuildTools/Ninja`.
+* `packer/InstallBuilderTools.ps1` for the library builder image, on its own version.
+  `init/start-builder.ps1` puts it on PATH and `library_builder.py` invokes bare `cmake`. It affects
+  library builds rather than the site, and moves independently.
+
+To bump the node image:
+
+1. Update the download URL and the `Rename-Item` source directory in `InstallBuildTools`
+2. `make packer-win`
+3. Put the new AMI id in `winstaging_image_id` in `terraform/lc.tf`, apply, and restart winstaging
+4. Once it's proven, point `winprod_image_id` at it and restart winprod
+
+`ec2.tf` derives the win-runner image from `winstaging_image_id`, so that follows along.
+
+The compiler share used to carry `cmake-v*` and `ninja-v*` installables as well. Nothing ever read
+them -- both images use their own `C:\BuildTools` copy -- so they were dropped from
+`bin/yaml/windows.yaml`. Don't add them back without a consumer.
+
 ## User code execution restrictions
 
 User code Executions runs through cewrapper. It creates an appcontainer environment and adds the user's temporary directory as the only directory where things can be executed within. The appcontainer also enables firewall rules and registry restrictions.

--- a/docs/windows_architecture.md
+++ b/docs/windows_architecture.md
@@ -54,9 +54,15 @@ For the node image:
 
 `ec2.tf` derives the win-runner image from `winstaging_image_id`, so that follows along.
 
-The builder image has no packer HCL -- nothing references `InstallBuilderTools.ps1` -- and its
-security group is a terraform `data` lookup rather than a managed resource. It is built by hand, so
-a bump there means rebuilding it yourself.
+The builder image is built in the ce-ci repo, not here. Its `packer/windows-provisioner.ps1` fetches
+`InstallBuilderTools.ps1` from this repo's main branch by raw URL, so a change only takes effect once
+it is merged and someone runs `./build-image-win-builder.sh` over there. Nothing needs an AMI id
+updating afterwards: `templates/runner-configs/windows-x64-win-builder.yaml` selects the image by the
+`github-runner-win-builder-*` name filter, and `win-lib-build.yaml` runs on whichever runner the
+ce-ci scaler hands it.
+
+`init/start-builder.ps1` behaves differently again. `win-lib-build.yaml` downloads it from main at job
+time, so changes to it land on the next build with no image rebuild at all.
 
 The compiler share used to carry `cmake-v*` and `ninja-v*` installables as well. Nothing ever read
 them -- both images use their own `C:\BuildTools` copy -- so they were dropped from

--- a/docs/windows_library_builder.md
+++ b/docs/windows_library_builder.md
@@ -6,11 +6,11 @@ Note: do not do any of this unless you know what you're doing. It does not refle
 
 * Create a directory where the compilers and tools will end up (e.g. `D:/efs/winshared`)
 * Make a drive out of the directory with `subst Z: D:\efs\winshared`
-* `pwsh .\ce_install.ps1 --staging-dir "Z:/staging" --dest "Z:/compilers" --enable windows install 'windows/tools/cmake'`
-* `pwsh .\ce_install.ps1 --staging-dir "Z:/staging" --dest "Z:/compilers" --enable windows install 'windows/tools/ninja'`
+* Install CMake and Ninja under `C:\BuildTools\CMake` and `C:\BuildTools\Ninja`, as
+  `packer/InstallBuilderTools.ps1` does on the real builder
 * `pwsh .\ce_install.ps1 --staging-dir "Z:/staging" --dest "Z:/compilers" --enable windows install 'mingw-w64 13.1.0-16.0.2-11.0.0-ucrt-r1'`
 * `pwsh .\ce_install.ps1 --staging-dir "Z:/staging" --dest "Z:/staging" --enable windows install 'fmt 11.0.0'`
-* `$env:PATH = "C:\Program Files\7-Zip;C:\BuildTools\Python;C:\BuildTools\Python\Scripts;Z:\compilers\windows-kits-10\bin;Z:\compilers\cmake-v3.29.2\bin;Z:\compilers\mingw-w64-13.1.0-16.0.5-11.0.0-ucrt-r5\bin;Z:\compilers\ninja-v1.12.1;$env:PATH"`
+* `$env:PATH = "C:\Program Files\7-Zip;C:\BuildTools\Python;C:\BuildTools\Python\Scripts;C:\BuildTools\CMake\bin;C:\BuildTools\Ninja;Z:\compilers\windows-kits-10\bin;Z:\compilers\mingw-w64-13.1.0-16.0.2-11.0.0-ucrt-r1\bin;$env:PATH"`
 * `pwsh .\ce_install.ps1 --keep-staging --dry-run --staging-dir "Z:/staging" --dest "Z:/staging" --enable windows build --temp-install --buildfor mingw64_ucrt_gcc_1130 'fmt 11.0.0'`
 * `pwsh .\ce_install.ps1 --keep-staging --dry-run --staging-dir "Z:/staging" --dest "Z:/staging" --enable windows build --temp-install --buildfor vcpp_v19_40_VS17_10_x64 'fmt 11.0.0'`
 

--- a/packer/InstallBuilderTools.ps1
+++ b/packer/InstallBuilderTools.ps1
@@ -53,9 +53,9 @@ function InstallBuildTools {
     New-Item -Path "/BuildTools" -ItemType Directory
 
     Write-Host "Installing CMake"
-    Invoke-WebRequest -Uri "https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-windows-x86_64.zip" -OutFile "/tmp/cmake-win.zip"
+    Invoke-WebRequest -Uri "https://github.com/Kitware/CMake/releases/download/v4.4.2/cmake-4.4.2-windows-x86_64.zip" -OutFile "/tmp/cmake-win.zip"
     Expand-Archive -Path "/tmp/cmake-win.zip" -DestinationPath "/BuildTools"
-    Rename-Item -Path "/BuildTools/cmake-3.28.3-windows-x86_64" -NewName "CMake"
+    Rename-Item -Path "/BuildTools/cmake-4.4.2-windows-x86_64" -NewName "CMake"
     Remove-Item -Path "/tmp/cmake-win.zip"
 
     AllowAppContainerRXAccess -Path "C:\BuildTools\CMake"

--- a/packer/InstallTools.ps1
+++ b/packer/InstallTools.ps1
@@ -156,9 +156,9 @@ function InstallBuildTools {
     New-Item -Path "/BuildTools" -ItemType Directory
 
     Write-Host "Installing CMake"
-    Invoke-WebRequest -Uri "https://github.com/Kitware/CMake/releases/download/v4.1.2/cmake-4.1.2-windows-x86_64.zip" -OutFile "/tmp/cmake-win.zip"
+    Invoke-WebRequest -Uri "https://github.com/Kitware/CMake/releases/download/v4.4.2/cmake-4.4.2-windows-x86_64.zip" -OutFile "/tmp/cmake-win.zip"
     Expand-Archive -Path "/tmp/cmake-win.zip" -DestinationPath "/BuildTools"
-    Rename-Item -Path "/BuildTools/cmake-4.1.2-windows-x86_64" -NewName "CMake"
+    Rename-Item -Path "/BuildTools/cmake-4.4.2-windows-x86_64" -NewName "CMake"
     Remove-Item -Path "/tmp/cmake-win.zip"
 
     AllowAppContainerRXAccess -Path "C:\BuildTools\CMake"


### PR DESCRIPTION
#2261 added cmake 4.4.2 to `windows/tools/cmake`, which installs onto the compiler share as `Z:\compilers\cmake-v4.4.2`. The Windows site does not read that. It runs `C:/BuildTools/CMake/bin/cmake.exe`, baked into the node AMI by `packer/InstallTools.ps1`, which was still on 4.1.2.

Checking what does read the share copies turned up nothing:

- `compiler-explorer.amazonwin.properties` sets `cmake=C:/BuildTools/CMake/bin/cmake.exe` and `ninjaPath=C:/BuildTools/Ninja`
- the library builder gets `C:\BuildTools\CMake\bin` and `C:\BuildTools\Ninja` on PATH from `init/start-builder.ps1`, and `library_builder.py` invokes bare `cmake`
- there is no `cmakescript.amazonwin.properties`, so the CMake language does not exist on Windows at all
- `Z:\compilers\cmake-v*` appears nowhere in infra, the CE config, or ce-win-file-cache's `compilers.json`

The only reference in the tree was a hand-run local mimic in `windows_library_builder.md`, pinned to 3.29.2. The share meanwhile carries seven cmake versions at ~130-146MB each, roughly 950MB rsynced on every `ce smb sync`. This dates back to 6a0d2fa9a (Sep 2023): the packer script grew its own copy separately, the AMI copy won, and the share copy has been version-bumped on autopilot since.

So bump the packer scripts, drop the `tools:` block from `windows.yaml`, and document which copy is which.

Both Windows images go to 4.4.2. The library builder was on 3.28.3, but the Linux builder has been on cmake 4 since 5044c90ee moved the `symlink: cmake` marker to 4.1.2 in October 2025, so library builds already live with the 4.x policy removals.

Also fixes a stale mingw path in the local-mimic PATH line, which named `-16.0.5-...-r5` while the step above it installs `-16.0.2-...-r1`.

## Follow-ups, not in this PR

- 4.4.2 does not reach the site until `make packer-win` and a `winstaging_image_id` / `winprod_image_id` update in `terraform/lc.tf`
- the builder image is built in ce-ci: this must be merged first, then `./build-image-win-builder.sh` run there. No AMI id to update, the runner config matches `github-runner-win-builder-*`
- `/efs/winshared/compilers/cmake-v*` and `ninja-v1.12.1` need deleting by hand, then `ce smb sync`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
