### PR TITLE
ALB: route /api/compiler/*/build/* to CE Router

### DIFF
--- a/bin/lib/cli/ce_router_killswitch.py
+++ b/bin/lib/cli/ce_router_killswitch.py
@@ -188,15 +188,29 @@ def _find_or_create_ce_router_rules(alb_client, listener_arn: str, target_groups
     return rules
 
 
+def compilation_path_patterns(env: str) -> list[str]:
+    """Path patterns for the compilation endpoints CE Router overrides."""
+    prefix = "" if env == "prod" else f"/{env}"
+    return [
+        f"{prefix}/api/compiler/*/compile",
+        f"{prefix}/api/compiler/*/cmake",
+        f"{prefix}/api/compiler/*/build/*",
+    ]
+
+
+def get_rule_path_patterns(rule) -> list[str]:
+    """Return the path patterns currently configured on a rule."""
+    patterns = []
+    for condition in rule.get("Conditions", []):
+        if condition.get("Field") == "path-pattern":
+            patterns.extend(condition.get("Values", []))
+    return patterns
+
+
 def _enable_ce_router_rule(alb_client, env: str, rule_arn: str) -> bool:
     """Enable ce-router rule to route compilation traffic for specific environment."""
     try:
-        # Set path patterns based on environment
-        if env == "prod":
-            path_patterns = ["/api/compiler/*/compile", "/api/compiler/*/cmake"]
-        else:
-            path_patterns = [f"/{env}/api/compiler/*/compile", f"/{env}/api/compiler/*/cmake"]
-
+        path_patterns = compilation_path_patterns(env)
         alb_client.modify_rule(RuleArn=rule_arn, Conditions=[{"Field": "path-pattern", "Values": path_patterns}])
         return True
     except ClientError as e:
@@ -257,11 +271,7 @@ def enable(cfg: Config, environment: str, skip_confirmation: bool):
     click.echo("🔧 CE ROUTER ROUTING CONTROL")
     click.echo("")
 
-    # Show correct paths for the environment
-    if environment == "prod":
-        paths = "/api/compiler/*/compile, /api/compiler/*/cmake"
-    else:
-        paths = f"/{environment}/api/compiler/*/compile, /{environment}/api/compiler/*/cmake"
+    paths = ", ".join(compilation_path_patterns(environment))
 
     click.echo(f"This will route {environment} compilation traffic to CE Router instances.")
     click.echo(f"Affected paths: {paths}")
@@ -305,10 +315,12 @@ def enable(cfg: Config, environment: str, skip_confirmation: bool):
         current_status = _get_ce_router_rule_status(rule)
 
         if current_status == "ENABLED":
-            click.echo(f"⚠️  CE Router routing for {env} is already enabled")
-            continue
-
-        click.echo(f"🔧 Enabling ce-router ALB routing for {env}...")
+            if set(get_rule_path_patterns(rule)) == set(compilation_path_patterns(env)):
+                click.echo(f"⚠️  CE Router routing for {env} is already enabled")
+                continue
+            click.echo(f"🔧 Updating ce-router ALB path patterns for {env}...")
+        else:
+            click.echo(f"🔧 Enabling ce-router ALB routing for {env}...")
         if _enable_ce_router_rule(alb_client, env, rule_arn):
             click.echo(f"✅ {env.upper()} ce-router routing enabled")
             success_count += 1

--- a/bin/test/cli/ce_router_killswitch_test.py
+++ b/bin/test/cli/ce_router_killswitch_test.py
@@ -4,7 +4,13 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
-from lib.cli.ce_router_killswitch import exec_all, version
+from lib.cli.ce_router_killswitch import (
+    compilation_path_patterns,
+    enable,
+    exec_all,
+    get_rule_path_patterns,
+    version,
+)
 from lib.env import Config, Environment
 
 
@@ -102,6 +108,89 @@ class TestCERouterExecAll(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertIn("Running 'uptime' on 2 CE Router instances", result.output)
         mock_exec_remote_all.assert_called_once_with([mock_instance1, mock_instance2], ("uptime",))
+
+
+class TestCompilationPathPatterns(unittest.TestCase):
+    def test_prod_patterns_are_unprefixed(self):
+        self.assertEqual(
+            compilation_path_patterns("prod"),
+            ["/api/compiler/*/compile", "/api/compiler/*/cmake", "/api/compiler/*/build/*"],
+        )
+
+    def test_non_prod_patterns_are_prefixed(self):
+        self.assertEqual(
+            compilation_path_patterns("beta"),
+            ["/beta/api/compiler/*/compile", "/beta/api/compiler/*/cmake", "/beta/api/compiler/*/build/*"],
+        )
+
+    def test_patterns_fit_alb_limits(self):
+        for env in ("prod", "staging", "beta"):
+            patterns = compilation_path_patterns(env)
+            self.assertLessEqual(len(patterns), 5, f"{env} exceeds the ALB match evaluations per rule limit")
+            for pattern in patterns:
+                self.assertLessEqual(len(pattern), 128, f"{pattern} exceeds the ALB path pattern length limit")
+
+    def test_get_rule_path_patterns(self):
+        rule = {
+            "Conditions": [
+                {"Field": "host-header", "Values": ["godbolt.org"]},
+                {"Field": "path-pattern", "Values": ["/api/compiler/*/compile", "/api/compiler/*/cmake"]},
+            ]
+        }
+        self.assertEqual(get_rule_path_patterns(rule), ["/api/compiler/*/compile", "/api/compiler/*/cmake"])
+
+    def test_get_rule_path_patterns_without_conditions(self):
+        self.assertEqual(get_rule_path_patterns({}), [])
+
+
+class TestCERouterEnable(unittest.TestCase):
+    def setUp(self):
+        self.runner = CliRunner()
+        self.cfg = Config(env=Environment.PROD)
+        self.alb_client = MagicMock()
+
+    def _invoke(self, rule_conditions):
+        rule = {"RuleArn": "rule-arn", "Priority": "70", "Conditions": rule_conditions}
+        with (
+            patch("lib.cli.ce_router_killswitch._get_alb_client", return_value=self.alb_client),
+            patch(
+                "lib.cli.ce_router_killswitch._find_ce_router_target_groups",
+                return_value={"prod": {"arn": "tg-arn", "name": "ce-router-prod"}},
+            ),
+            patch("lib.cli.ce_router_killswitch._find_compiler_explorer_listener", return_value="listener-arn"),
+            patch("lib.cli.ce_router_killswitch._find_or_create_ce_router_rules", return_value={"prod": rule}),
+        ):
+            return self.runner.invoke(enable, ["-e", "prod", "--skip-confirmation"], obj=self.cfg)
+
+    def test_enable_sets_all_patterns(self):
+        result = self._invoke([{"Field": "path-pattern", "Values": ["/killswitch-disabled-prod-*"]}])
+
+        self.assertEqual(result.exit_code, 0)
+        self.alb_client.modify_rule.assert_called_once_with(
+            RuleArn="rule-arn",
+            Conditions=[
+                {
+                    "Field": "path-pattern",
+                    "Values": ["/api/compiler/*/compile", "/api/compiler/*/cmake", "/api/compiler/*/build/*"],
+                }
+            ],
+        )
+
+    def test_enable_updates_rule_missing_build_pattern(self):
+        result = self._invoke([
+            {"Field": "path-pattern", "Values": ["/api/compiler/*/compile", "/api/compiler/*/cmake"]}
+        ])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Updating ce-router ALB path patterns", result.output)
+        self.alb_client.modify_rule.assert_called_once()
+
+    def test_enable_leaves_up_to_date_rule_alone(self):
+        result = self._invoke([{"Field": "path-pattern", "Values": compilation_path_patterns("prod")}])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("already enabled", result.output)
+        self.alb_client.modify_rule.assert_not_called()
 
 
 class TestCERouterVersion(unittest.TestCase):

--- a/docs/aws_architecture_current.md
+++ b/docs/aws_architecture_current.md
@@ -32,6 +32,7 @@ graph TB
 
             CompileRule["'/*/api/compiler/*/compile*' - CE Router TGs"]
             CMakeRule["'/*/api/compiler/*/cmake*' - CE Router TGs"]
+            BuildRule["'/*/api/compiler/*/build/*' - CE Router TGs"]
         end
     end
 
@@ -223,6 +224,7 @@ graph TB
 | **Compilation Endpoints** | | | | |
 | 10       | `/api/compiler/*/compile*` | CE Router | All envs | **Smart routing via CE Router** |
 | 11       | `/api/compiler/*/cmake*`   | CE Router | All envs | **Smart routing via CE Router** |
+| 11       | `/api/compiler/*/build/*`  | CE Router | All envs | **Generic build-system endpoint (same rule as cmake)** |
 | 12       | `/beta/api/compiler/*/compile*` | CE Router Beta | Beta | **Beta-specific routing** |
 | 13       | `/staging/api/compiler/*/compile*` | CE Router Staging | Staging | **Staging-specific routing** |
 | **General Routing** | | | | |
@@ -236,7 +238,7 @@ graph TB
 
 ### CE Router Architecture (Compilation Endpoints)
 
-The CE Router provides intelligent routing for compilation endpoints (`/api/compiler/*/compile` and `/api/compiler/*/cmake`) across all environments:
+The CE Router provides intelligent routing for compilation endpoints (`/api/compiler/*/compile`, `/api/compiler/*/cmake` and `/api/compiler/*/build/*`) across all environments:
 
 #### CE Router Components
 - **CE Router ASGs**: Dedicated Auto Scaling Groups per environment (prod, beta, staging)

--- a/docs/lambda_compilation_workflow.md
+++ b/docs/lambda_compilation_workflow.md
@@ -319,7 +319,8 @@ resource "aws_alb_listener_rule" "compilation_beta" {
     path_pattern {
       values = [
         "/beta/api/compiler/*/compile",
-        "/beta/api/compiler/*/cmake"
+        "/beta/api/compiler/*/cmake",
+        "/beta/api/compiler/*/build/*"
       ]
     }
   }
@@ -781,7 +782,7 @@ ce ce-router status beta   # Shows specific environment
 The disable command modifies ALB listener rules directly (bypassing Terraform) for immediate effect:
 
 1. **Disable**: Changes path pattern to `/killswitch-disabled-*` (never matches)
-2. **Enable**: Restores original path patterns (`/api/compiler/*/compile`, `/api/compiler/*/cmake`)
+2. **Enable**: Restores original path patterns (`/api/compiler/*/compile`, `/api/compiler/*/cmake`, `/api/compiler/*/build/*`)
 3. **Status**: Shows actual ALB rule state with indicators:
    - 🟢 ENABLED: CE Router routing active
    - 🚨 DISABLED: Using instance routing

--- a/terraform/ce-router.tf
+++ b/terraform/ce-router.tf
@@ -55,7 +55,8 @@ module "ce_router_beta" {
 #     path_pattern {
 #       values = [
 #         "/api/compiler/*/compile",
-#         "/api/compiler/*/cmake"
+#         "/api/compiler/*/cmake",
+#         "/api/compiler/*/build/*"
 #       ]
 #     }
 #   }
@@ -76,7 +77,8 @@ module "ce_router_beta" {
 #     path_pattern {
 #       values = [
 #         "/staging/api/compiler/*/compile",
-#         "/staging/api/compiler/*/cmake"
+#         "/staging/api/compiler/*/cmake",
+#         "/staging/api/compiler/*/build/*"
 #       ]
 #     }
 #   }
@@ -97,7 +99,8 @@ module "ce_router_beta" {
 #     path_pattern {
 #       values = [
 #         "/beta/api/compiler/*/compile",
-#         "/beta/api/compiler/*/cmake"
+#         "/beta/api/compiler/*/cmake",
+#         "/beta/api/compiler/*/build/*"
 #       ]
 #     }
 #   }


### PR DESCRIPTION
Fixes #2269.

Adds the generic build-system path pattern alongside the existing `/compile` and `/cmake` ones:

| Env | Added |
| --- | --- |
| prod | `/api/compiler/*/build/*` |
| staging | `/staging/api/compiler/*/build/*` |
| beta | `/beta/api/compiler/*/build/*` |

The live rules are managed by `ce ce-router enable`, not terraform (those blocks are commented out), so the change is mostly in the killswitch code. The pattern list moves into `compilation_path_patterns(env)`, which the confirmation message now shares instead of duplicating.

`enable` previously skipped any rule already in the ENABLED state, which meant a pattern change could never be rolled out to an environment that was already routing. It now compares the live patterns against the desired set and modifies the rule when they differ, skipping only when they match. Rolling this out is `ce ce-router enable -e prod` (and staging/beta).

On the ALB limits the issue asked about: one path-pattern condition with 3 values per rule, against limits of 5 conditions and 5 match evaluations; longest pattern is 34 chars against the 128-char cap. A test asserts both.

Terraform's commented-out rules and the two docs that list the patterns are updated to match.

Out of scope but needed before the frontend switches over: ce-router must parse the compiler id out of `/api/compiler/<id>/build/<system>`, and `compiler_routing.construct_environment_url` only builds `/compile` and `/cmake` targets for the URL-routed environments (winprod, gpu, aarch64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)