### PR TITLE
Kokkos: adding version for the latest release 5.2.0

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1102,6 +1102,7 @@ libraries:
       - 5.0.2
       - 5.1.0
       - 5.1.1
+      - 5.2.0
       type: github
     kumi:
       check_file: README.md
@@ -3098,6 +3099,7 @@ libraries:
       targets:
       - 4.7.04
       - 5.1.1
+      - 5.2.0
       type: github
     matx:
       check_file: README.md


### PR DESCRIPTION
@JBludau 
Bumping the version for both regular and cuda builds.
[Kokkos 5.2.0](https://github.com/kokkos/kokkos/releases/tag/5.2.0)