### PR TITLE
Exit non-zero when a blue-green deploy is cancelled non-interactively

### DIFF
--- a/bin/lib/cli/blue_green.py
+++ b/bin/lib/cli/blue_green.py
@@ -387,10 +387,11 @@ def blue_green_deploy(
                     print("No target commit hash available - skipping notifications.")
 
     except DeploymentCancelledException as e:
-        # An interactive cancellation is a deliberate human choice, so exit cleanly.
-        # With --skip-confirmation there is no human to have chosen: the deployment was
-        # refused, and non-interactive callers (notably the release.yml workflow) must see
-        # a non-zero exit rather than a misleading green tick.
+        # Interactively, the caller was shown the problem and answered the prompt, so the
+        # cancellation is an outcome they already know about: exit cleanly. With
+        # --skip-confirmation no prompt was shown, so nothing announced that the deploy
+        # did not happen and the exit code is the only signal. Without this, release.yml
+        # reports a green tick for a deployment that was refused.
         if skip_confirmation:
             raise click.ClickException(str(e)) from e
         return

--- a/bin/lib/cli/blue_green.py
+++ b/bin/lib/cli/blue_green.py
@@ -386,8 +386,13 @@ def blue_green_deploy(
                 if target_commit_hash is None:
                     print("No target commit hash available - skipping notifications.")
 
-    except DeploymentCancelledException:
-        # Deployment was cancelled - don't show success message or raise
+    except DeploymentCancelledException as e:
+        # An interactive cancellation is a deliberate human choice, so exit cleanly.
+        # With --skip-confirmation there is no human to have chosen: the deployment was
+        # refused, and non-interactive callers (notably the release.yml workflow) must see
+        # a non-zero exit rather than a misleading green tick.
+        if skip_confirmation:
+            raise click.ClickException(str(e)) from e
         return
     except ClientError as e:
         print(f"\nDeployment failed: {e}")

--- a/bin/test/cli/blue_green_test.py
+++ b/bin/test/cli/blue_green_test.py
@@ -38,7 +38,7 @@ class TestBlueGreenDeployCancellation(unittest.TestCase):
         self.assertIn("existing instances found", result.output)
 
     def test_interactive_cancellation_exits_zero(self):
-        # Without --skip-confirmation a cancellation is a deliberate human choice.
+        # Interactively the caller answered the prompt, so they already know it stopped.
         result = self._invoke([])
         self.assertEqual(result.exit_code, 0)
 

--- a/bin/test/cli/blue_green_test.py
+++ b/bin/test/cli/blue_green_test.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+from lib.cli.blue_green import DeploymentCancelledException, blue_green_deploy
+from lib.env import Config, Environment
+
+
+class TestBlueGreenDeployCancellation(unittest.TestCase):
+    """A cancelled deployment must not look like a successful one to automation.
+
+    The release.yml workflow runs `ce ... blue-green deploy --skip-confirmation`; if the
+    deployment is refused (e.g. the inactive ASG still has instances) and the CLI exits 0,
+    the workflow reports success while the environment still serves the old build.
+    """
+
+    def setUp(self):
+        self.runner = CliRunner()
+        self.cfg = Config(env=Environment.STAGING)
+
+    def _invoke(self, args):
+        with (
+            patch("lib.cli.blue_green.BlueGreenDeployment") as mock_deployment,
+            patch("lib.cli.blue_green.are_you_sure", return_value=True),
+        ):
+            instance = MagicMock()
+            instance.deploy.side_effect = DeploymentCancelledException(
+                "Deployment cancelled: existing instances found with --skip-confirmation"
+            )
+            mock_deployment.return_value = instance
+            return self.runner.invoke(blue_green_deploy, args, obj=self.cfg)
+
+    def test_cancellation_with_skip_confirmation_exits_non_zero(self):
+        result = self._invoke(["--skip-confirmation"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("existing instances found", result.output)
+
+    def test_interactive_cancellation_exits_zero(self):
+        # Without --skip-confirmation a cancellation is a deliberate human choice.
+        result = self._invoke([])
+        self.assertEqual(result.exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The problem

`ce --env <env> blue-green deploy --skip-confirmation` refuses to deploy when the inactive ASG already has instances running. It logs an error and prints advice, and then **exits 0**:

```
WARNING: The green ASG already has 1 instance(s) running!
ERROR: Deployment cancelled (--skip-confirmation prevents deploying to existing instances).
ERROR: Use one of the commands above instead.
```

`bin/lib/cli/blue_green.py` swallowed the exception and returned normally:

```python
except DeploymentCancelledException:
    # Deployment was cancelled - don't show success message or raise
    return
```

So `release.yml` reports **SUCCESS** for a deployment that never happened, and the environment quietly carries on serving the old build.

## How it showed up

Today, deploying gh-18882 to staging. A `staging-green` instance left over from 2026-08-09 (launched outside `release.yml`) blocked the deploy. [The workflow run](https://github.com/compiler-explorer/infra/actions/runs/31516324152) is green, but staging was still on gh-18866 afterwards. It was only caught because the smoke test asserts the release id; without that check it would have been very easy to "verify" a staging deploy that had not occurred and then promote to prod on the strength of it.

Fixed by `-f command=staging-cleanup` and re-deploying, which worked. But the silent success is the dangerous part.

## The change

Interactively, the caller was shown the problem and answered the prompt, so the cancellation is an outcome they already know about and exiting 0 is right. With `--skip-confirmation` no prompt was shown, so nothing announced that the deploy did not happen and the exit code is the only signal — raise a `ClickException` so the caller sees it. (`--skip-confirmation` is of course usable interactively too; the distinction is whether the caller was told, not whether one exists.)

## Testing

New `bin/test/cli/blue_green_test.py` covers both branches. Verified it is a real regression test by reverting the fix, at which point `test_cancellation_with_skip_confirmation_exits_non_zero` fails with `AssertionError: 0 == 0`.

`make test` (805 passed, 1 skipped) and `make static-checks` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
