### PR TITLE
Add clang profiles-init and profiles-core-ub compilers

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1678,6 +1678,8 @@ compilers:
           - p3776-trunk
           - p3822-trunk
           - p3951-trunk
+          - profiles-init-trunk
+          - profiles-core-ub-trunk
           - barry-clang-trunk
           - hana-clang-trunk
           - implicit-constexpr-trunk


### PR DESCRIPTION
Companion to https://github.com/compiler-explorer/clang-builder/pull/118 — installs the two nightlies built there.