### PR TITLE
Add aburi as a nightly on the godbolt branch

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1697,6 +1697,11 @@ compilers:
         check_exe: bin/mlir-opt --version
         targets:
           - trunk
+      aburi:
+        type: nightly
+        check_exe: bin/aburi --version
+        targets:
+          - godbolt
       tinycc:
         type: nightly
         check_exe: bin/tcc -v

--- a/remove_old_compilers.sh
+++ b/remove_old_compilers.sh
@@ -3,7 +3,7 @@
 KEEP_LAST=5
 S3=s3://compiler-explorer/opt/
 
-for compiler_prefix in $(aws s3 ls ${S3} | grep -oE '[-a-zA-Z0-9_]+-(main|trunk|master)-' | sort -u); do
+for compiler_prefix in $(aws s3 ls ${S3} | grep -oE '[-a-zA-Z0-9_]+-(main|trunk|master|godbolt)-' | sort -u); do
   echo "Considering prefix ${compiler_prefix}"
   aws s3 ls "${S3}${compiler_prefix}"
   # Look for anything with a datelike bit going on for extra safety.

--- a/remove_old_compilers.sh
+++ b/remove_old_compilers.sh
@@ -3,7 +3,7 @@
 KEEP_LAST=5
 S3=s3://compiler-explorer/opt/
 
-for compiler_prefix in $(aws s3 ls ${S3} | grep -oE '[-a-zA-Z0-9_]+-(main|trunk|master|godbolt)-' | sort -u); do
+for compiler_prefix in $(aws s3 ls ${S3} | grep -oE '[-a-zA-Z0-9_]+-(main|trunk|master)-' | sort -u); do
   echo "Considering prefix ${compiler_prefix}"
   aws s3 ls "${S3}${compiler_prefix}"
   # Look for anything with a datelike bit going on for extra safety.


### PR DESCRIPTION
Supersedes #2202. Thanks to @likecrazy1 for that one — the reason this is a new PR rather than an edit is that almost nothing survives the change of approach.

## Why not the pinned entry

#2202 installs `atta-mills` as a pinned `s3tarballs`. Upstream has since moved on: @serjective has [confirmed](https://github.com/compiler-explorer/compiler-explorer/pull/8872) that `godbolt` is the live branch and that the classic version is abandoned. A moving branch wired as a pinned entry is a latent bug — it drifts silently and its fixed `semver` becomes a lie — so this makes it a `nightly` instead.

The builder side landed in compiler-explorer/misc-builder#142 and #143.

## Testing

Test-installed for real against the artifact now on S3:

```
Most recent aburi-godbolt is 20260814
compilers/c++/nightly/aburi godbolt installed OK
1 packages installed OK, 0 skipped, and 0 failed installation
```

`check_exe` passes, and it resolves to the path the properties will reference:

```
aburi-godbolt -> aburi-godbolt-20260814
/opt/compiler-explorer/aburi-godbolt/bin/aburi
```

I also pulled that S3 artifact down separately and compiled and ran a C++ TU using `<vector>`, `<string>` and a thrown-and-caught exception, which is the case the old `--sysroot` used to break.

`make static-checks` clean.

## S3 pruning

`aburi-godbolt-YYYYMMDD.tar.xz` won't be culled by `remove_old_compilers.sh`, whose pattern only catches `-(main|trunk|master)-`. I had added `godbolt` to that alternation and then removed it again: #2289 already tracks this and explicitly calls out widening the pattern as repeating the mistake that caused the problem. I've [recorded aburi there](https://github.com/compiler-explorer/infra/issues/2289#issuecomment-5288397356) as one of eleven affected families instead, so this PR is now purely the installable.

## Note on the daily build

`godbolt`'s last commit is 2026-08-05, so the daily build's activity gate (`STALE_DAYS=7`) will skip it as idle until upstream pushes again. That's the gate working as intended and nothing is blocked by it: the 20260814 artifact exists, so this installs today, and a future push simply produces a fresher one.

Companions: compiler-explorer/compiler-workflows#76, compiler-explorer/compiler-explorer#9019.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)