### PR TITLE
Adopt three orphaned nightly families so their tarballs are not pruned

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1637,6 +1637,13 @@ compilers:
           - notadragon-contracts-p3850
           - thephd.dev
           - ilazaric-enclosing_cast
+          # No longer built or installed, but still serving live compilers from an old
+          # install. Listed so the S3 pruner counts their tarballs as owned;
+          # 'daily-but-archived' is never passed to --enable, so they are never installed.
+          - name: embed-trunk
+            if: daily-but-archived
+          - name: static-analysis-trunk
+            if: daily-but-archived
       clang:
         type: nightly
         check_exe: bin/clang++ --version
@@ -1719,12 +1726,15 @@ compilers:
         check_exe: bin/6502-c++ --help
         targets:
           - trunk
-      # https://github.com/compiler-explorer/misc-builder/issues/102
-      #vast:
-      #  type: nightly
-      #  check_exe: bin/vast-front --version
-      #  targets:
-      #    - trunk
+      vast:
+        type: nightly
+        check_exe: bin/vast-front --version
+        # Install disabled since 2025-01: vast-front cannot find libclang-cpp.so, see
+        # compiler-explorer/misc-builder#102. Listed rather than commented out so the S3
+        # pruner counts its tarballs as owned; restore 'if: nightly' once #102 is fixed.
+        if: daily-but-archived
+        targets:
+          - trunk
       llvmmos:
         type: nightlytarballs
         compression: xz

--- a/docs/ce_install_yaml.md
+++ b/docs/ce_install_yaml.md
@@ -189,6 +189,17 @@ ce_install --enable nightly install
 Common condition flags include:
 - `nightly` - For nightly/trunk builds
 - `non-free` - For proprietary compilers
+- `windows` - For Windows compilers installed to the SMB share
+- `daily-but-archived` - Deliberately never enabled, so the target is never installed.
+  Use it to keep an entry that no longer builds or installs, but whose dated S3 tarballs
+  must not be pruned: the nightly pruner reads every installable regardless of its `if:`,
+  so listing the target here is what marks its artifacts as owned. Commenting the entry
+  out instead makes the artifacts look unowned. Always add a same-line or preceding
+  comment saying why it is archived, and what would have to happen to restore it.
+
+Conditions are ANDed down the tree: a target inside a group with `if: nightly` needs that
+flag *as well as* its own. So reinstating an archived nightly by hand takes both, e.g.
+`ce_install --enable nightly --enable daily-but-archived install '<filter>'`.
 
 ## Dependencies
 

--- a/docs/ce_install_yaml.md
+++ b/docs/ce_install_yaml.md
@@ -190,16 +190,18 @@ Common condition flags include:
 - `nightly` - For nightly/trunk builds
 - `non-free` - For proprietary compilers
 - `windows` - For Windows compilers installed to the SMB share
-- `daily-but-archived` - Deliberately never enabled, so the target is never installed.
-  Use it to keep an entry that no longer builds or installs, but whose dated S3 tarballs
-  must not be pruned: the nightly pruner reads every installable regardless of its `if:`,
-  so listing the target here is what marks its artifacts as owned. Commenting the entry
-  out instead makes the artifacts look unowned. Always add a same-line or preceding
-  comment saying why it is archived, and what would have to happen to restore it.
+- `daily-but-archived` - A marker, not a toggle. It is **never enabled anywhere** — no
+  job, cron or human passes it to `--enable` — so the target is never installed. Its only
+  purpose is to keep an entry *present* rather than commented out, for something that no
+  longer builds or installs but whose dated S3 tarballs must not be pruned: the nightly
+  pruner reads every installable regardless of its `if:`, so a listed target marks its
+  artifacts as owned, while a commented-out one makes them look unowned. Always add a
+  comment saying why it is archived and what would restore it (usually: put `if: nightly`
+  back once some upstream bug is fixed).
 
-Conditions are ANDed down the tree: a target inside a group with `if: nightly` needs that
-flag *as well as* its own. So reinstating an archived nightly by hand takes both, e.g.
-`ce_install --enable nightly --enable daily-but-archived install '<filter>'`.
+Conditions are ANDed down the tree, so a target inside a group with `if: nightly` would
+need that flag as well as its own — academic for `daily-but-archived`, which is not meant
+to be enabled at all.
 
 ## Dependencies
 


### PR DESCRIPTION
Follows #2295, which reports 12 dated S3 families that no installable owns. Three of them still back **live compilers on prod**, and their S3 tarballs are the only copy left — nothing builds them and nothing installs them, so if the prod install were ever lost the compiler would be gone for good.

| Family | Live compilers it backs | Why it went unclaimed |
|---|---|---|
| `gcc-static-analysis-trunk` | `gcc-static-analysis-trunk`, `cgstatic-analysis`, `gimplegstatic-analysis` | no builder, no installable |
| `gcc-embed-trunk` | `gcc-embed-trunk` | no builder, no installable |
| `vast-trunk` | `vast-trunk`, `cvast-trunk` | installable commented out since 2025-01, see compiler-explorer/misc-builder#102 |

## The mechanism

They are listed with a never-enabled `if: daily-but-archived`. The nightly pruner reads **every** installable regardless of its `if:`, so listing a target is what marks its artifacts as owned; the flag is never passed to `--enable`, so the target is never installed. Behaviour on prod is therefore unchanged.

This is also why vast being *commented out* was the problem rather than the solution: a commented entry claims nothing, which is exactly how a compiler that is live on the site ended up on the unclaimed list.

Each entry carries a comment saying why it is archived and what would restore it. vast's says to put `if: nightly` back once misc-builder#102 is fixed — worth noting that its daily build is still wired up and merely gated on upstream activity, and #102 itself looks tractable (`vast-front` can't find `libclang-cpp.so.19.1`; the tarball doesn't ship its runtime deps, the same shape as the aburi fix in misc-builder#142).

## Verified

```
# normal nightly install — absent, so nothing changes on prod
$ ce_install --enable nightly list 'compilers/c++/nightly' | grep -E 'gcc embed-trunk|static-analysis|vast'
(nothing)

# both flags — present, so they can still be reinstated by hand
$ ce_install --enable nightly --enable daily-but-archived list 'compilers/c++/nightly'
compilers/c++/nightly/gcc embed-trunk
compilers/c++/nightly/gcc static-analysis-trunk
compilers/c++/nightly/vast trunk
```

The existing 17 gcc nightly targets are unaffected.

To be clear about intent: `daily-but-archived` is a **marker, not a toggle** — nothing enables it, and nothing is meant to. It exists purely so the entry can stay *present* rather than commented out. `docs/ce_install_yaml.md` documents it on those terms.

## The other nine

Not touched here. They are relics with nothing live behind them — `clang-cppx` (7.51 GiB, newest 2017; the live cppx compilers use `clang-cppx-pinned-20180922` and `clang-cppx-ext-trunk`), `SPIRV-Tools-master` and `clspv-master` (both superseded by `-main`), `carbon-trunk` (carbon now comes from the GitHub releases API, not S3), plus `rustc-cg-gcc-master`, `clang-trunk-aarch64`, `gcc-ga68-master` and `ispc-templates_new-trunk`. Roughly 15 GiB, and deleting them is a judgement call for a human rather than something to bundle in here.

Separately, `clad-trunk-clang-20.1.0` is built daily by the `clad` entry in compiler-workflows (`args: trunk`) while infra only installs `trunk-clang-21.1.0` — a live build feeding nothing. Worth fixing in compiler-workflows rather than adopting.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
