### PR TITLE
Add vast to the bespoke-build image choices

### DIFF
--- a/.github/workflows/bespoke-build.yaml
+++ b/.github/workflows/bespoke-build.yaml
@@ -46,6 +46,7 @@ on:
         - rust-linux
         - sfpi
         - vala
+        - vast
       version:
         description: The version to build (or architecture and version for cross)
         required: true


### PR DESCRIPTION
One line: `vast` was missing from `bespoke-build.yaml`'s `image` choice list, so on-demand builds fail with

```
HTTP 422: Provided value 'vast' for input 'image' not in the list of allowed values
```

## Why it matters now

vast has a builder image and a `build-daily-vast.yml`, but no way to build it on demand:

- the daily is gated on upstream activity, and **trailofbits/vast has had no commit since 2026-02-13, 181 days ago**, so it always skips
- `bespoke-build` refuses the dispatch

Between them, there is currently no route to a new vast artifact at all. That blocks compiler-explorer/misc-builder#144, which fixes the rpath bug that has kept vast uninstallable since January 2025 — the fix lives in `build.sh`, so it only takes effect when something actually builds.

Related: compiler-explorer/infra#2296 currently lists vast as `if: daily-but-archived` so the S3 pruner does not treat its tarballs as unowned. Once a fixed artifact exists and installs, that goes back to `if: nightly`.

`make static-checks` clean, actionlint included.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)