### PR TITLE
Re-enable the vast nightly install

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1729,10 +1729,6 @@ compilers:
       vast:
         type: nightly
         check_exe: bin/vast-front --version
-        # Install disabled since 2025-01: vast-front cannot find libclang-cpp.so, see
-        # compiler-explorer/misc-builder#102. Listed rather than commented out so the S3
-        # pruner counts its tarballs as owned; restore 'if: nightly' once #102 is fixed.
-        if: daily-but-archived
         targets:
           - trunk
       llvmmos:


### PR DESCRIPTION
Closes the loop on compiler-explorer/misc-builder#102, which has had vast uninstallable since January 2025.

## The chain

1. **misc-builder#144** — the actual bug. Not a missing library: every dependency was already in the tarball, but the executables' RUNPATH came out as a literal `/../lib` (the `$ORIGIN` expanded away), so they couldn't see the `lib/` staged beside them. `build.sh` patched the libraries' rpath but never the binaries'.
2. **infra#2297** — vast had no route to a build at all: the daily is activity-gated and trailofbits/vast has had no commit since 2026-02-13, while `bespoke-build` didn't list `vast` as an image. So #144's fix could never reach an artifact.
3. **This PR** — `vast-trunk-20260814` now exists and installs, so vast no longer needs the `if: daily-but-archived` holding position from #2296.

## Verified

The new artifact, all six binaries:

```
RUNPATH: $ORIGIN/../lib     (was /../lib)
unresolved deps: 0          (was 2)
```

Test-installed for real:

```
compilers/c++/nightly/vast trunk installed OK
1 packages installed OK, 0 skipped, and 0 failed installation
```

`check_exe` passes — that's the step that produced `installed OK, but doesn't appear as installed after` for the last 19 months. And from the install path with no `LD_LIBRARY_PATH`, on a real input:

```
$ vast-trunk/bin/vast-front -vast-emit-mlir=hl -x c v.c -o -
module {
  core.module @"v.c" attributes {... vast.core.lang = #core<lang c> ...} {
    hl.func @square external (%arg0: !hl.lvalue<!hl.int>) -> !hl.int {
```

One quirk worth recording: `vast-repl` is an interactive REPL that doesn't understand `--version` and loops on it. It starts and resolves its libraries fine, it just isn't testable that way. CE only invokes `bin/vast-front`, and `check_exe` targets it, so nothing on our side touches `vast-repl`.

## Note

Upstream has been dormant for six months, so the daily will keep skipping on the activity gate and this artifact will stay current until trailofbits/vast moves again. That is the gate working as intended.

`make static-checks` clean.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)