### PR TITLE
Ask for the `large` runner label explicitly

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,6 +5,7 @@ self-hosted-runner:
     - ce
     - small
     - medium
+    - large
     - admin
     - lin-builder
     - win-builder

--- a/.github/workflows/adhoc-command.yml
+++ b/.github/workflows/adhoc-command.yml
@@ -29,7 +29,7 @@ on:
 jobs:
   adhoc:
     name: Run command on linux-x64
-    runs-on: ${{ inputs.size == 'large' && fromJSON('["self-hosted", "ce", "linux", "x64"]') || fromJSON(format('["self-hosted", "ce", "linux", "x64", "{0}"]', inputs.size)) }}
+    runs-on: ${{ fromJSON(format('["self-hosted", "ce", "linux", "x64", "{0}"]', inputs.size)) }}
     # TODO in future consider github environments for this?
     if: github.actor == 'mattgodbolt' || github.actor == 'partouf'
     timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}

--- a/.github/workflows/bespoke-build.yaml
+++ b/.github/workflows/bespoke-build.yaml
@@ -65,7 +65,7 @@ on:
           - large
 jobs:
   bespoke-build:
-    runs-on: ${{ inputs.size == 'large' && fromJSON('["self-hosted", "ce", "linux", "x64"]') || fromJSON(format('["self-hosted", "ce", "linux", "x64", "{0}"]', inputs.size)) }}
+    runs-on: ${{ fromJSON(format('["self-hosted", "ce", "linux", "x64", "{0}"]', inputs.size)) }}
     steps:
       - name: Clean workspace
         run: find "$GITHUB_WORKSPACE" -mindepth 1 -delete


### PR DESCRIPTION
**Step 5 of the rollout in compiler-explorer/ce-ci#24.**

`bespoke-build.yaml` and `adhoc-command.yml` special-cased `size == 'large'` to emit the bare `[self-hosted, ce, linux, x64]` set:

```yaml
runs-on: ${{ inputs.size == 'large' && fromJSON('["self-hosted", "ce", "linux", "x64"]') || fromJSON(format('["self-hosted", "ce", "linux", "x64", "{0}"]', inputs.size)) }}
```

That special case existed only because the large pool had no label of its own. GitHub reads the bare set as "any runner carrying at least these labels", and the small and medium pools carry supersets of it, so a `size=large` dispatch could be served by a 16 GiB box.

compiler-explorer/ce-ci#25 gives the large pool a `large` label. All three sizes then have one, and the whole conditional collapses to the `format()` branch already used for small and medium:

```yaml
runs-on: ${{ fromJSON(format('["self-hosted", "ce", "linux", "x64", "{0}"]', inputs.size)) }}
```

Both `size` inputs are a `choice` restricted to `small`/`medium`/`large`, so there is no fourth case to fall through. `.github/actionlint.yaml` gains `large` alongside the other self-hosted labels.

Nice side effect: this is a deletion rather than an addition. The special case was a workaround for the missing label, so fixing the label removes the need for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
