### PR TITLE
Fix clang-cuda library builds

### DIFF
--- a/bin/lib/library_builder.py
+++ b/bin/lib/library_builder.py
@@ -409,6 +409,11 @@ def is_nvhpc_compiler(exe: str) -> bool:
     return os.path.basename(exe) in ("nvc", "nvc++", "nvc.exe", "nvc++.exe")
 
 
+def is_clang_variant(compiler_type: str) -> bool:
+    """Clang under a compilerType of its own: the cuda, hip and mingw drivers are all clang."""
+    return compiler_type in ("clang", "win32-mingw-clang") or compiler_type.startswith("clang-")
+
+
 @contextlib.contextmanager
 def open_script(script: Path) -> Generator[TextIO, None, None]:
     with script.open("w", encoding="utf-8") as f:
@@ -912,7 +917,7 @@ class LibraryBuilder:
                 stdverflag = f"-std={stdver}"
 
             stdlibflag = ""
-            if stdlib and compilerType == "clang":
+            if stdlib and is_clang_variant(compilerType):
                 libcxx = stdlib
                 stdlibflag = f"-stdlib={stdlib}"
                 if stdlibflag in compileroptions:
@@ -966,9 +971,12 @@ class LibraryBuilder:
                 extracmakeargs = " ".join(expanded_cmake_args)
                 # CMake turns EXTERNAL_TOOLCHAIN into --gcc-toolchain= for clang and nvhpc. Both locate
                 # their own gcc -- nvhpc's is baked into its localrc by makelocalrc at install time --
-                # and the toolchain we derive for nvc++ is its own install root, which holds no gcc.
-                # Only pass one when the compiler options name a specific one.
-                picks_own_gcc = compilerTypeOrGcc == "clang" or is_nvhpc_compiler(compilerexe)
+                # and the toolchain we derive for them is their own install root, which holds no gcc.
+                # Only pass one when the compiler options name a specific one. win32-mingw-clang is
+                # the exception: its install root is the mingw toolchain, so the derived path is right.
+                picks_own_gcc = (
+                    is_clang_variant(compilerTypeOrGcc) and compilerTypeOrGcc != "win32-mingw-clang"
+                ) or is_nvhpc_compiler(compilerexe)
                 if picks_own_gcc and "--gcc-toolchain=" not in compileroptions:
                     toolchainparam = ""
                 else:

--- a/bin/test/library_builder_test.py
+++ b/bin/test/library_builder_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import io
 import os
+import re
 from logging import Logger
 from pathlib import Path
 from subprocess import TimeoutExpired
@@ -19,6 +20,7 @@ from lib.library_builder import (
     build_timeout,
     fetch_all_annotations,
     fetch_failed_builds,
+    is_clang_variant,
     is_nvhpc_compiler,
     match_conan_settings,
     match_failed_build,
@@ -406,8 +408,20 @@ def test_writebuildscript_nvcc_without_wrapper_uses_native_cuda(tmp_path, reques
     assert "nvcc_wrapper" not in script
 
 
-def _write_buildscript_for(tmp_path, requests_mock, *, compiler, exe, compiler_type, toolchain):
+def _write_buildscript_for(
+    tmp_path,
+    requests_mock,
+    *,
+    compiler,
+    exe,
+    compiler_type,
+    toolchain,
+    options="",
+    stdlib="",
+    platform=LibraryPlatform.Linux,
+):
     requests_mock.get(f"{BASE}cpp.amazon.properties", text="")
+    requests_mock.get(f"{BASE}cpp.amazonwin.properties", text="")
     logger = mock.Mock(spec_set=Logger)
     install_context = mock.Mock(spec_set=InstallationContext)
     build_config = create_test_build_config()
@@ -421,14 +435,14 @@ def _write_buildscript_for(tmp_path, requests_mock, *, compiler, exe, compiler_t
         install_context,
         build_config,
         False,
-        LibraryPlatform.Linux,
+        platform,
     )
     builder.writebuildscript(
         str(tmp_path),
         str(tmp_path / "install"),
         "/src/googletest",
         compiler,
-        "",
+        options,
         exe,
         compiler_type,
         toolchain,
@@ -436,16 +450,16 @@ def _write_buildscript_for(tmp_path, requests_mock, *, compiler, exe, compiler_t
         "Debug",
         "x86_64",
         "",
-        "",
+        stdlib,
         [""],
         "",
         {},
     )
-    return (tmp_path / "cebuild.sh").read_text(encoding="utf-8")
+    return builder, (tmp_path / builder.script_filename).read_text(encoding="utf-8")
 
 
 def test_writebuildscript_edg_leaves_c_compiler_undefined(tmp_path, requests_mock):
-    script = _write_buildscript_for(
+    _, script = _write_buildscript_for(
         tmp_path,
         requests_mock,
         compiler="edg69",
@@ -458,7 +472,7 @@ def test_writebuildscript_edg_leaves_c_compiler_undefined(tmp_path, requests_moc
 
 
 def test_writebuildscript_gcc_defines_c_compiler(tmp_path, requests_mock):
-    script = _write_buildscript_for(
+    _, script = _write_buildscript_for(
         tmp_path,
         requests_mock,
         compiler="g151",
@@ -471,7 +485,7 @@ def test_writebuildscript_gcc_defines_c_compiler(tmp_path, requests_mock):
 
 
 def test_writebuildscript_nvhpc_omits_external_toolchain(tmp_path, requests_mock):
-    script = _write_buildscript_for(
+    _, script = _write_buildscript_for(
         tmp_path,
         requests_mock,
         compiler="nvcxx_x86_cxx26_5",
@@ -484,7 +498,7 @@ def test_writebuildscript_nvhpc_omits_external_toolchain(tmp_path, requests_mock
 
 
 def test_writebuildscript_gcc_keeps_external_toolchain(tmp_path, requests_mock):
-    script = _write_buildscript_for(
+    _, script = _write_buildscript_for(
         tmp_path,
         requests_mock,
         compiler="g151",
@@ -494,6 +508,63 @@ def test_writebuildscript_gcc_keeps_external_toolchain(tmp_path, requests_mock):
     )
     assert '"-DCMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN=/opt/compiler-explorer/gcc-15.1.0"' in script
     assert '"-DCMAKE_C_COMPILER_EXTERNAL_TOOLCHAIN=/opt/compiler-explorer/gcc-15.1.0"' in script
+
+
+def test_writebuildscript_clang_cuda_omits_external_toolchain(tmp_path, requests_mock):
+    _, script = _write_buildscript_for(
+        tmp_path,
+        requests_mock,
+        compiler="cuclang1910",
+        exe="/opt/compiler-explorer/clang-19.1.0/bin/clang++",
+        compiler_type="clang-cuda",
+        toolchain="/opt/compiler-explorer/clang-19.1.0",
+        options="--cuda-path=/opt/compiler-explorer/cuda/12.5.1 --cuda-gpu-arch=sm_90 --cuda-device-only",
+    )
+    assert "COMPILER_EXTERNAL_TOOLCHAIN" not in script
+
+
+def test_writebuildscript_clang_cuda_keeps_explicit_external_toolchain(tmp_path, requests_mock):
+    _, script = _write_buildscript_for(
+        tmp_path,
+        requests_mock,
+        compiler="cuclang900",
+        exe="/opt/compiler-explorer/clang-9.0.0/bin/clang++",
+        compiler_type="clang-cuda",
+        toolchain="/opt/compiler-explorer/gcc-9.2.0",
+        options="--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 --cuda-gpu-arch=sm_75 --cuda-device-only",
+    )
+    assert '"-DCMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN=/opt/compiler-explorer/gcc-9.2.0"' in script
+    assert '"-DCMAKE_C_COMPILER_EXTERNAL_TOOLCHAIN=/opt/compiler-explorer/gcc-9.2.0"' in script
+
+
+def test_writebuildscript_clang_cuda_fixed_libcxx_is_tagged_libcxx(tmp_path, requests_mock):
+    # Runtime reads -stdlib= straight out of the compiler options with no compilerType check, so a
+    # clang-cuda built against libc++ must be uploaded as libcxx=libc++ or the lookup never matches.
+    builder, script = _write_buildscript_for(
+        tmp_path,
+        requests_mock,
+        compiler="cuclang1810",
+        exe="/opt/compiler-explorer/clang-18.1.0/bin/clang++",
+        compiler_type="clang-cuda",
+        toolchain="/opt/compiler-explorer/clang-18.1.0",
+        options="--cuda-device-only -stdlib=libc++ -D_ALLOW_UNSUPPORTED_LIBCPP",
+        stdlib="libc++",
+    )
+    assert builder.current_buildparameters_obj["libcxx"] == "libc++"
+    assert "-s compiler.libcxx=libc++" in " ".join(builder.current_buildparameters)
+    # -stdlib is already in the compiler options, so it must not be appended a second time.
+    cxx_flags = re.search(r'-DCMAKE_CXX_FLAGS_DEBUG=([^"]*)', script).group(1)
+    assert cxx_flags.count("-stdlib=libc++") == 1
+
+
+def test_is_clang_variant():
+    assert is_clang_variant("clang")
+    assert is_clang_variant("clang-cuda")
+    assert is_clang_variant("clang-hip")
+    assert is_clang_variant("win32-mingw-clang")
+    assert not is_clang_variant("gcc")
+    assert not is_clang_variant("nvcc")
+    assert not is_clang_variant("win32-mingw-gcc")
 
 
 def test_is_nvhpc_compiler():


### PR DESCRIPTION
Two `compilerType == "clang"` checks in `library_builder` missed the cuda clang compilers, which carry `compilerType=clang-cuda`.

**The toolchain one (#2302).** CMake got `EXTERNAL_TOOLCHAIN` set to the clang install root, which it turns into `--gcc-toolchain=/opt/compiler-explorer/clang-19.1.0`. There is no gcc there, so clang stopped looking for a real one and every build failed in CMake's compiler check with `cannot find crtbeginS.o` / `cannot find -lstdc++`. Only the compilers whose options name a toolchain (`cuclang700`-`900`, `cltrunk`) took the other branch and escaped. The conan server currently holds zero clang-cuda kokkos-cuda packages, consistent with all of them failing.

**The libcxx one.** `stdlibflag`/`libcxx` forced `libstdc++` for anything not exactly `clang`, so `cuclang1701` and `cuclang1810` -- which fix `-stdlib=libc++` in their options and are built against libc++ -- were uploaded tagged `libcxx=libstdc++`. Runtime's `getLibcxx` reads `-stdlib=` out of the compiler options with no compilerType check, so it asks for `libc++` and never matched.

`is_clang_variant` covers `clang`, `clang-*` and `win32-mingw-clang`. The toolchain guard keeps mingw excluded: `mingw64_ucrt_clang_1602` lives in the same install root as `mingw64_ucrt_gcc_1310`, so there the derived path really is a gcc toolchain and dropping it would regress.

Not included: the same blind spot exists in `get_compiler_support_output` and the `-m32` archflag, which leave clang-cuda at `arch=""`. CE's `hasSupportForArch` has the identical blind spot, so both sides agree on `""` today and fixing infra alone would break package lookup. That needs a paired change in the main repo.

Fixes #2302

🤖 Generated with [Claude Code](https://claude.com/claude-code)