### PR TITLE
Point find_package(CUDAToolkit) at the cuda root for clang

### DIFF
--- a/bin/lib/library_builder.py
+++ b/bin/lib/library_builder.py
@@ -568,6 +568,12 @@ class LibraryBuilder:
             return match[1]
         return False
 
+    def getCudaPathFromOptions(self, options):
+        match = re.search(r"--cuda-path=(\S*)", options)
+        if match:
+            return match[1]
+        return False
+
     def getStdVerFromOptions(self, options):
         match = re.search(r"-std=(\S*)", options)
         if match:
@@ -1023,9 +1029,17 @@ class LibraryBuilder:
                 cudaflagsparam = ""
                 if compilerType == "nvcc" and not self.buildconfig.cxx_compiler_wrapper:
                     cudaflagsparam = f'"-DCMAKE_CUDA_FLAGS{cmake_flags_suffix}={cuda_flags}"'
+
+                # clang finds the toolkit through --cuda-path, which find_package(CUDAToolkit) does
+                # not read, so name the root for it. nvcc builds don't need this: their toolkit is
+                # already on PATH because nvcc itself lives in it.
+                cuda_path = self.getCudaPathFromOptions(compileroptions)
+                cudatoolkitparam = f'"-DCUDAToolkit_ROOT={cuda_path}"' if cuda_path else ""
+
                 cmakecmd = (
                     f'cmake --install-prefix "{installfolder}" {generator} "-DCMAKE_VERBOSE_MAKEFILE=ON" '
                     f'{targetparams} "-DCMAKE_BUILD_TYPE={buildtype}" {toolchainparam} {sysrootparam} '
+                    f"{cudatoolkitparam} "
                     f'"-DCMAKE_CXX_FLAGS{cmake_flags_suffix}={cxx_flags}" "-DCMAKE_C_FLAGS{cmake_flags_suffix}={c_flags}" '
                     f'"-DCMAKE_ASM_FLAGS{cmake_flags_suffix}={asm_flags}" {cudaflagsparam} {extracmakeargs} {sourcefolder}'
                 )

--- a/bin/test/library_builder_test.py
+++ b/bin/test/library_builder_test.py
@@ -557,6 +557,51 @@ def test_writebuildscript_clang_cuda_fixed_libcxx_is_tagged_libcxx(tmp_path, req
     assert cxx_flags.count("-stdlib=libc++") == 1
 
 
+def test_writebuildscript_clang_cuda_names_the_cuda_toolkit_root(tmp_path, requests_mock):
+    # find_package(CUDAToolkit) does not look at --cuda-path, so it needs the root spelled out.
+    _, script = _write_buildscript_for(
+        tmp_path,
+        requests_mock,
+        compiler="cuclang1910",
+        exe="/opt/compiler-explorer/clang-19.1.0/bin/clang++",
+        compiler_type="clang-cuda",
+        toolchain="/opt/compiler-explorer/clang-19.1.0",
+        options="--cuda-path=/opt/compiler-explorer/cuda/12.5.1 --cuda-gpu-arch=sm_90 --cuda-device-only",
+    )
+    assert '"-DCUDAToolkit_ROOT=/opt/compiler-explorer/cuda/12.5.1"' in script
+
+
+def test_writebuildscript_without_cuda_path_omits_the_toolkit_root(tmp_path, requests_mock):
+    _, script = _write_buildscript_for(
+        tmp_path,
+        requests_mock,
+        compiler="g151",
+        exe="/opt/compiler-explorer/gcc-15.1.0/bin/g++",
+        compiler_type="",
+        toolchain="/opt/compiler-explorer/gcc-15.1.0",
+    )
+    assert "CUDAToolkit_ROOT" not in script
+
+
+def test_get_cuda_path_from_options(requests_mock):
+    requests_mock.get(f"{BASE}cuda.amazon.properties", text="")
+    logger = mock.Mock(spec_set=Logger)
+    install_context = mock.Mock(spec_set=InstallationContext)
+    builder = LibraryBuilder(
+        logger,
+        "cuda",
+        "testlib",
+        "1.0.0",
+        "/tmp/source",
+        install_context,
+        create_test_build_config(),
+        False,
+        LibraryPlatform.Linux,
+    )
+    assert builder.getCudaPathFromOptions("--cuda-path=/opt/cuda/12.5.1 --cuda-device-only") == "/opt/cuda/12.5.1"
+    assert builder.getCudaPathFromOptions("--compiler-bindir /opt/gcc/bin") is False
+
+
 def test_is_clang_variant():
     assert is_clang_variant("clang")
     assert is_clang_variant("clang-cuda")


### PR DESCRIPTION
Follow-up to #2303. With the toolchain bug fixed, `kokkos-cuda` gets past CMake's compiler check for `cuclang1910` and fails later instead ([run 31882583214](https://github.com/compiler-explorer/infra/actions/runs/31882583214)):

```
CMake Error at .../FindCUDAToolkit.cmake:965 (message):
  Could not find `nvcc` executable in any searched paths, please set
  CUDAToolkit_ROOT
```

Kokkos with `Kokkos_ENABLE_CUDA=ON` calls `find_package(CUDAToolkit)`, which looks for nvcc on `PATH` or under `CUDAToolkit_ROOT`. The nvcc builds satisfy that by accident -- nvcc lives inside the toolkit, so `library_builder.py:813` putting nvcc on `PATH` puts the whole toolkit there. Clang finds cuda through `--cuda-path` instead, and `FindCUDAToolkit` doesn't read compiler flags, so nothing pointed CMake at it.

`getCudaPathFromOptions` pulls the root out of `--cuda-path=` and passes it as `-DCUDAToolkit_ROOT`. It's the same directory clang is already using, and `cuda.yaml` installs every version with `--toolkit` (its `check_exe` is `bin/nvcc --version`), so the root does hold the nvcc that FindCUDAToolkit wants to stat. The param keys off `--cuda-path=` being present, which no nvcc compiler's options carry, so nvcc builds are untouched.

Nothing compiles with nvcc as a result: `CMAKE_CXX_COMPILER` stays clang++ and no CUDA language is enabled -- Kokkos wants the toolkit for its headers and runtime libs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)