### PR TITLE
Add library dispenso

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -647,6 +647,26 @@ libraries:
       targets:
       - 2.9.11
       type: github
+    dispenso:
+      build_type: cmake
+      check_file: CMakeLists.txt
+      extra_cmake_arg:
+      - -DDISPENSO_WERROR=OFF
+      - -DDISPENSO_SHARED_LIB=OFF
+      - -DDISPENSO_BUILD_TESTS=OFF
+      - -DDISPENSO_BUILD_BENCHMARKS=OFF
+      - -DDISPENSO_BUILD_EXAMPLES=OFF
+      - -DCMAKE_INSTALL_LIBDIR=lib
+      lib_type: static
+      make_utility: ninja
+      package_install: true
+      repo: facebookincubator/dispenso
+      staticliblink:
+      - dispenso
+      target_prefix: v
+      targets:
+      - 1.6.2
+      type: github
     dlib:
       build_type: cmake
       method: clone_branch


### PR DESCRIPTION
[dispenso](https://github.com/facebookincubator/dispenso) is a C++ library for
parallel programming — thread pools, `parallel_for`, futures, task graphs and
concurrent containers. MIT licensed, C++14 baseline, C++20 supported. I'm one of
its maintainers.

This adds v1.6.1. dispenso is a compiled library rather than header-only, so it
uses the build-recipe path with `staticliblink: dispenso`.

Companion PR adding the properties entry:
compiler-explorer/compiler-explorer#9032

### Why the non-obvious cmake args

- `-DDISPENSO_WERROR=OFF` — dispenso compiles itself with
  `-Wall -Wextra -pedantic -Wconversion -Werror`. Across dozens of GCC and Clang
  versions at `-m32` and `-m64` against two standard libraries, a warning from
  any single one of them would fail the build. This option exists as of 1.6.1
  specifically so it does not have to be a patch against dispenso's
  `CMakeLists.txt`.
- `-DDISPENSO_SHARED_LIB=OFF` — dispenso defaults this **ON**; the static path
  is what's wanted here.
- `-DCMAKE_INSTALL_LIBDIR=lib` — `GNUInstallDirs` picks `lib64` on some hosts,
  while the binary validator looks in `<install>/lib`.

### What is verified

I built 1.6.1 on Linux from these exact cmake args (checked programmatically to
match the recipe, not retyped), with Ninja and a private install prefix, for
GCC 11.5 x86_64, GCC 11.5 `-m32`, and Clang 19 x86_64 at C++20. For each one, a
consumer translation unit calling `dispenso::parallel_for` compiled, linked and
produced the right answer with nothing but
`-I<prefix>/include -L<prefix>/lib -ldispenso`:

- `<prefix>/lib/libdispenso.a` is produced, so `staticliblink` and
  `CMAKE_INSTALL_LIBDIR=lib` are both right.
- The install prefix contains exactly `include/` and `lib/`, which is what
  `packagedheaders` needs in order to add a working `-I`.
- Linking **without** `-pthread` works and runs — glibc 2.34 folds libpthread
  into libc — and the 32-bit leg links **without** `-latomic`. So no
  `dependencies` entry and no `build_fixed_arch` are needed.
- All 34 public headers compile standalone under g++ and clang at C++14 and
  C++20.

`bin/ce_install list` and `bin/ce_install install 'libraries/c++/dispenso'` both
work, the latter resolving `target_prefix`/`targets` and unpacking the genuine
v1.6.1 tag.

### What is not

`ce_install build` itself. The Linux machine I have access to has no network
egress to GitHub, so I could exercise the cmake arguments directly but not CE's
own staging and validation. Since `check-build-requirements.yml` excludes
`bin/yaml/libraries.yaml`, nothing here builds on the PR either — I'd rather
flag that up front than have it surface on failedbuilds.html. For the same
reason I could not test against libc++; none was available on that machine.

Happy to iterate quickly on anything the first build turns up. If someone with
the right permissions could run `lin-lib-build.yaml` for
`libraries/c++/dispenso` once this merges, that would shorten the loop.

