### PR TITLE
Bump x86 node AMI root volume to 16 GiB

### DIFF
--- a/packer/node.pkr.hcl
+++ b/packer/node.pkr.hcl
@@ -46,7 +46,7 @@ source "amazon-ebs" "ubuntu" {
   launch_block_device_mappings {
     delete_on_termination = true
     device_name           = "/dev/sda1"
-    volume_size           = 8
+    volume_size           = 16
     volume_type           = "gp2"
   }
   region = "us-east-1"


### PR DESCRIPTION
Prod x86 nodes currently boot with a 6.9 GiB root filesystem, ~4.6 GiB used and ~2.2 GiB available (`df` across all 10 prod-green nodes today). The `/healthcheck` free-space floor is 2048 MiB, so roughly 175 MiB of temp usage is enough to fail the ALB health check, and three consecutive failures get the instance replaced. Papertrail shows this accounts for 163 of 170 ELB health-check replacements on prod-green between 14 and 19 Aug (~40/day, median instance lifetime ~65 min, some killed 5 minutes after boot), and the rate stepped up with the 5 Aug AMI refresh that pushed baseline root usage to the floor. Details in #2310.

This doubles the root volume for the x86 node AMI (aarch64 nodes already use 20 GiB). Needs a rebake and the usual AMI roll (`terraform/lc.tf` image ids); I have not done that here. Cost is about $0.80/instance-month extra on gp2. Switching to gp3 at the same time would be cheaper and faster but is left out to keep this to one change.

The per-request temp-dir cleanup leaks that make headroom matter more than it should are being fixed separately in compiler-explorer.

Refs #2310

🤖 Generated with [Claude Code](https://claude.com/claude-code)

