### PR TITLE
Restart compiler-explorer.service on failure

### DIFF
--- a/init/compiler-explorer.service
+++ b/init/compiler-explorer.service
@@ -7,6 +7,10 @@ Requires=remote-fs.target
 # but needs After=cloud-init.target, and cloud-init.target is also WantedBy=multi-user.target
 # See: https://serverfault.com/questions/871328/start-service-after-aws-user-data-has-run
 DefaultDependencies=no
+# Allow a few quick restarts but give up if the app is crash-looping, so the
+# ALB health check can take the instance out rather than us thrashing.
+StartLimitIntervalSec=600
+StartLimitBurst=3
 
 [Service]
 Type=simple
@@ -16,6 +20,12 @@ WorkingDirectory=/infra
 ExecStart=/infra/init/start.sh
 StandardOutput=journal
 StandardError=journal
+# Bring the app back if it dies (e.g. a Node heap OOM, compiler-explorer#9035).
+# Without this the process stays dead until the ALB health check fails three
+# times and the ASG replaces the whole instance, which costs a fresh boot plus
+# discovery. start.sh is safe to re-run.
+Restart=on-failure
+RestartSec=5
 # Keep CPU controller enabled during daemon-reload to prevent cgroup setup race - see #1761
 CPUAccounting=yes
 CPUQuota=100%

--- a/start-support.sh
+++ b/start-support.sh
@@ -144,6 +144,8 @@ setup_cgroups() {
 
 mount_nosym() {
     mkdir -p /nosym
+    # Idempotent so a service restart doesn't stack another bind mount.
+    mountpoint -q /nosym && return
     mount -onosymfollow --bind / /nosym
     # seems to need a remount to pick it up properly on our version of Ubuntu (but not 23.10)
     mount -oremount,nosymfollow --bind / /nosym


### PR DESCRIPTION
When the app process dies, nothing restarts it: the node sits dead until the ALB health check fails three times and the ASG replaces the instance, which means a fresh boot plus discovery. On 2026-08-14 two prod nodes died of a Node heap OOM (compiler-explorer/compiler-explorer#9035) and were dead for 30-70 s before the ASG even acted, then replaced wholesale.

This adds `Restart=on-failure` / `RestartSec=5` with `StartLimitIntervalSec=600` / `StartLimitBurst=3`, so a one-off crash recovers in seconds but a genuine crash loop still ends with the instance being pulled by the health check rather than us thrashing. `mount_nosym` becomes idempotent so a re-run of `start.sh` doesn't stack another bind mount on `/nosym`; the rest of `start.sh` (cgroups, EFS binds, `update_code`, asm-parser/ninja copies) already tolerates re-running.

The unit file is copied into the image by `setup-node.sh`, so this takes effect on the next AMI bake (could ride along with #2312). Matt notes previous attempts at auto-restart haven't gone well, so treat this as an experiment; the start limit is the safety valve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

