### PR TITLE
Fix alert value templating and the staging-instances signal

### DIFF
--- a/terraform/grafana/alerts_cost.tf
+++ b/terraform/grafana/alerts_cost.tf
@@ -1,10 +1,11 @@
 # Cost-control alerts.
 
-# Staging (and beta) environments cost money while up and are usually only
-# needed around a deploy. Replaces the hand-made "Staging instances alert"
-# (uid o0kBVyX4k, folder "General Alerting"). Relies on the
-# instance:node_num_cpu:sum recording rule from the Grafana Cloud linux-node
-# integration pack, which is one reason that pack is left unmanaged.
+# Staging environments cost money while up and are usually only needed around
+# a deploy. Replaces the hand-made "Staging instances alert" (uid o0kBVyX4k,
+# folder "General Alerting"), which counted CPUs with env=staging and so fired
+# forever once ce-router-staging (a 24/7 t4g.medium tagged env=staging) came
+# along. Counting CE app processes instead sees only real staging nodes; the
+# router does not run the app.
 resource "grafana_rule_group" "staging_instances" {
   name             = "Staging Instances"
   folder_uid       = grafana_folder.ce_alerts.uid
@@ -19,7 +20,7 @@ resource "grafana_rule_group" "staging_instances" {
     exec_err_state = "Error"
 
     annotations = {
-      summary     = "Staging has had {{ printf \"%.0f\" $values.A }} CPUs up for over 2 hours"
+      summary     = "Staging has had {{ printf \"%.0f\" $values.A.Value }} CE node(s) up for over 2 hours"
       description = "Instances with env=staging have been running for a while; if nobody is mid-deploy they should be shut down (ce --env staging environment stop)."
     }
     labels = {
@@ -41,7 +42,7 @@ resource "grafana_rule_group" "staging_instances" {
       model = jsonencode({
         refId         = "A"
         datasource    = { type = "prometheus", uid = local.prom_datasource_uid }
-        expr          = "sum(instance:node_num_cpu:sum{env=\"staging\"})"
+        expr          = "count(process_start_time_seconds{job=\"compiler_explorer\", env=\"staging\"})"
         instant       = true
         range         = false
         intervalMs    = 1000
@@ -60,7 +61,7 @@ resource "grafana_rule_group" "staging_instances" {
         type          = "threshold"
         datasource    = { type = "__expr__", uid = "__expr__" }
         expression    = "A"
-        conditions    = [{ evaluator = { type = "gt", params = [1] } }]
+        conditions    = [{ evaluator = { type = "gt", params = [0] } }]
         intervalMs    = 1000
         maxDataPoints = 43200
       })

--- a/terraform/grafana/alerts_hosts.tf
+++ b/terraform/grafana/alerts_hosts.tf
@@ -21,7 +21,7 @@ resource "grafana_rule_group" "host_disk" {
     exec_err_state = "Error"
 
     annotations = {
-      summary     = "/ has {{ printf \"%.1f\" $values.A }}% free on {{ $labels.agent_hostname }} ({{ $labels.env }})"
+      summary     = "/ has {{ printf \"%.1f\" $values.A.Value }}% free on {{ $labels.agent_hostname }} ({{ $labels.env }})"
       description = "node_filesystem_avail_bytes / node_filesystem_size_bytes for mountpoint=/ has been below 10% for 10 minutes (infra#2310)."
     }
     labels = {
@@ -80,7 +80,7 @@ resource "grafana_rule_group" "host_disk" {
     exec_err_state = "Error"
 
     annotations = {
-      summary     = "Conan server disk has {{ printf \"%.1f\" $values.A }}% free"
+      summary     = "Conan server disk has {{ printf \"%.1f\" $values.A.Value }}% free"
       description = "/home/ce/.conan_server is below 10% free. See docs/resizing_conan_disk.md in infra for the resize procedure."
     }
     labels = {


### PR DESCRIPTION
Follow-up to #2315; this commit just missed the merge.

Two problems found when the adopted staging alert fired its first notification:

* `$values.A` in Grafana annotation templates is a struct, so `printf "%.1f" $values.A` rendered `{map[] 2 %!f(bool=true)}`. All three value-bearing summaries now use `$values.A.Value`.
* The staging rule (faithfully adopted from the hand-made original) counted CPUs with `env=staging`. `ce-router-staging` is a 24/7 t4g.medium whose agent carries that label, so the sum has been 2 (threshold 1) permanently -- the original had been firing since October without anyone noticing, and the adopted copy alerted two hours after creation with staging genuinely down. It now counts CE app processes (`count(process_start_time_seconds{job="compiler_explorer", env="staging"}) > 0`), which the router does not run; verified empty with staging down and correct per-env counts elsewhere.

Already applied to Grafana (plan is clean against this branch); all four managed rules evaluate healthy and the staging rule is Normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)