### PR TITLE
Give app restarts time to recover before the ALB pulls the node

### DIFF
--- a/terraform/modules/blue_green/main.tf
+++ b/terraform/modules/blue_green/main.tf
@@ -37,9 +37,13 @@ resource "aws_alb_target_group" "color" {
   load_balancing_algorithm_type = "least_outstanding_requests"
 
   health_check {
-    path                = "/healthcheck"
-    timeout             = 8
-    unhealthy_threshold = 3
+    path    = "/healthcheck"
+    timeout = 8
+    # 5x10s of failures before a target is marked unhealthy: an in-place app
+    # restart (Restart=on-failure, ~20s to serving) must never trip the ASG
+    # replacement path. Verified 2026-08-20: with the old threshold of 3 a
+    # kill -9 test lost the race by seconds and the node was replaced.
+    unhealthy_threshold = 5
     healthy_threshold   = 2
     interval            = 10
     protocol            = "HTTP"

--- a/terraform/tg.tf
+++ b/terraform/tg.tf
@@ -21,9 +21,13 @@ resource "aws_alb_target_group" "ce" {
   deregistration_delay          = 20
   load_balancing_algorithm_type = "least_outstanding_requests"
   health_check {
-    path                = "/healthcheck"
-    timeout             = 8
-    unhealthy_threshold = 3
+    path    = "/healthcheck"
+    timeout = 8
+    # 5x10s of failures before a target is marked unhealthy: an in-place app
+    # restart (Restart=on-failure, ~20s to serving) must never trip the ASG
+    # replacement path. Verified 2026-08-20: with the old threshold of 3 a
+    # kill -9 test lost the race by seconds and the node was replaced.
+    unhealthy_threshold = 5
     healthy_threshold   = 2
     interval            = 10
     protocol            = "HTTP"


### PR DESCRIPTION
Follow-up to #2313, from today's live test: `kill -9` of the app on a prod node at 17:45:55. `Restart=on-failure` restarted it in 5s and the app was serving again at 17:46:14 (`Startup duration: 20514ms` -- restarts are much faster than the ~35-50s cold boot because discovery is prediscovered). But three 10s health-check failures had already accumulated by 17:46:22, the target was marked unhealthy, and the ASG terminated the instance at 17:46:39 -- seconds before the target would have re-earned healthy. So as shipped, the restart loses the race and the node gets replaced anyway.

This raises `unhealthy_threshold` from 3 to 5 (30s -> 50s of consecutive failures) on the app target groups (blue_green module + the legacy tg.tf map), so a ~20s in-place restart never becomes unhealthy and the ASG never gets involved. Trade-off: a genuinely dead node serves its 1/N of traffic for up to 20 seconds longer before being pulled; with restarts now recovering most crashes, and the restart alert (from #2315) telling us when they happen, that trade seems right.

The restart alert fired correctly during the test (~2min after the kill, per-host labels).

Suggest re-running the kill test after apply to confirm a node survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)