### PR TITLE
Fix the glslang trunk download URL

### DIFF
--- a/bin/yaml/glsl.yaml
+++ b/bin/yaml/glsl.yaml
@@ -5,7 +5,7 @@ compilers:
       dir: glslang-{{name}}
       if: nightly
       install_always: true
-      url: https://github.com/KhronosGroup/glslang/releases/download/main-tot/glslang-main-linux-Release.zip
+      url: https://github.com/KhronosGroup/glslang/releases/download/main-tot/glslang-main-linux-x86_64-release.zip
       folder: bin
       check_exe: glslang --version
       targets:


### PR DESCRIPTION
Fixes #2299.

Khronos renamed the `main-tot` release assets in [KhronosGroup/glslang@04a35a9f](https://github.com/KhronosGroup/glslang/commit/04a35a9f) ("Add builds to release"), which landed on main **2026-07-31**:

```
- glslang-main-linux-Release.zip
+ glslang-main-linux-x86_64-release.zip
```

The nightly install has 404'd every day since **2026-08-01**, so the site has been serving a frozen **16.4.0** while upstream moved to 16.5.0. It is one of the two failures that have made "Install Nightly compilers" red every day.

### Verified by test-install, not just by the URL existing

```
1 packages installed OK, 0 skipped, and 0 failed installation
```

- Archive layout is unchanged, so `folder: bin` still applies (`Staging with mv bin glslang-trunk`).
- The `glslangValidator -> glslang` symlink survives, which matters because `glsl.amazon.properties:11` points at `/opt/compiler-explorer/glslang-trunk/glslangValidator`. **No compiler-explorer-side change is needed.**
- `check_exe` passes: `Glslang Version: 11:16.5.0`.

The companion dex2oat failure is the other half of the red job and is handled separately.
