### PR TITLE
Resolve the AOSP build via status.json for dex2oat

### DIFF
--- a/bin/yaml/android-java/fetch_art_release_from_head.sh
+++ b/bin/yaml/android-java/fetch_art_release_from_head.sh
@@ -5,12 +5,17 @@
 
 set -euo pipefail
 
-URL=https://ci.android.com/builds/latest/branches/aosp-android-latest-release/targets/aosp_cf_x86_64_only_phone-userdebug/view/BUILD_INFO
-PATTERN="(.*\/submitted\/([0-9]+)\/.*)/view/BUILD_INFO$"
+BRANCH=aosp-android-latest-release
+TARGET=aosp_cf_x86_64_only_phone-userdebug
 
-RURL=$(curl -Ls -o /dev/null -w "%{url_effective}" "${URL}")
-if ! [[ "$RURL" =~ $PATTERN ]]; then
-  echo "Got expected URL $RURL"
-  exit 1
-fi
-curl "${BASH_REMATCH[1]}/raw/art_release.zip" --location --output art_release.zip
+# ci.android.com's legacy API no longer serves unauthenticated requests: the
+# /builds/latest/... endpoint we used to follow a redirect from now answers 403
+# "You must migrate to Build API v4". status.json still works, so resolve the
+# build number from there instead.
+BUILD=$(curl -sS --fail "https://ci.android.com/builds/branches/${BRANCH}/status.json" |
+    python3 -c 'import json, sys; print(next(t["last_known_good_build"] for t in json.load(sys.stdin)["targets"] if t["name"] == sys.argv[1]))' "${TARGET}")
+echo "Fetching ART release from ${BRANCH} build ${BUILD}"
+
+# Only GET works here; a HEAD request on this path 404s.
+curl -sS --fail --location --output art_release.zip \
+    "https://ci.android.com/builds/submitted/${BUILD}/${TARGET}/latest/raw/art_release.zip"


### PR DESCRIPTION
Fixes #2300.

`ci.android.com`'s legacy API stopped serving unauthenticated requests. The endpoint the script relied on now returns **403** instead of redirecting:

```
$ curl -Ls -o /dev/null -w "%{http_code}" \
    https://ci.android.com/builds/latest/branches/aosp-android-latest-release/targets/aosp_cf_x86_64_only_phone-userdebug/view/BUILD_INFO
403
Application error: generic::permission_denied: googleapi: Error 403:
Rate limit exceeded for legacy API. You must to migrate to Build API v4
```

With no redirect, `RURL` came back equal to the input URL, the `submitted/<id>` pattern did not match, and the script exited 1. Broken since **2026-08-05**; the site has been serving a frozen Android build 15885347 against a current head of 16102939.

### Why the reported error said "exit status 127"

Worth recording, because it sent the original report in the wrong direction. The `script:` block in `android-java.yaml` has no `set -e`, so the failed fetch did not stop it: `unzip` then failed on a file that was never downloaded, and the 127 came from `create_boot_images.sh` looking for a `dex2oat64` that had never been extracted. The fetch failure was the real cause and was invisible.

### The fix

Resolve the build number from `status.json`, which still serves unauthenticated, taking `last_known_good_build` for our target. Also `--fail` on both curls so an HTTP error is an error rather than a zero-length file.

One oddity worth the comment it has in the script: the artifact URL answers **GET but 404s on HEAD**, so it cannot be probed with `--head`.

### Verified end to end

```
$ ./fetch_art_release_from_head.sh
Fetching ART release from aosp-android-latest-release build 16102939
$ ls -l art_release.zip     # 234343625 bytes
$ unzip -q art_release.zip && ./create_boot_images.sh && echo $?
0
$ ls app/system/framework/
arm  arm64  riscv64  x86  x86_64
```

That last step is exactly the one that was failing, and `check_file: x86_64/bin/dex2oat64` is satisfied.

### Suggested follow-up, deliberately not in this PR

The missing `set -e` in the `script:` block at `bin/yaml/android-java.yaml:69` is what turned a clear fetch failure into a misleading 127. Fixing that is a robustness change to how the installable runs rather than part of this break, so I have left it out. Happy to do it separately if wanted.

The companion glslang failure, the other half of the daily red job, is #2323.
