### PR TITLE
install instructions for cython

### DIFF
--- a/bin/yaml/cython.yaml
+++ b/bin/yaml/cython.yaml
@@ -1,0 +1,12 @@
+compilers:
+  cython:
+    depends:
+      - compilers/python 3.13.0
+    type: pip
+    dir: cython/v{{name}}
+    python: "%DEP0%/bin/python3.13"
+    package:
+      - cython=={{name}}
+    check_exe: bin/cython --version
+    targets:
+      - 3.3.0


### PR DESCRIPTION
Cython install instructions. In a separate file, following convention of `mojo`, `numba`, `vyper`, etc., even though this is meant to be run under "Python" language mode. I debated putting it in python.yaml. I can easily move it there if you think it makes more sense.

pip works for recent versions, but if you ever want to add older ones (that require older versions of python), it would take some additional configuration.

Preparing for https://github.com/compiler-explorer/compiler-explorer/issues/503