### PR TITLE
Fetch glslang trunk from the main-tot .tar.gz rather than the .zip

### DIFF
--- a/bin/yaml/glsl.yaml
+++ b/bin/yaml/glsl.yaml
@@ -1,12 +1,15 @@
 compilers:
   glsl:
     glslang:
-      type: ziparchive
+      type: tarballs
       dir: glslang-{{name}}
       if: nightly
       install_always: true
-      url: https://github.com/KhronosGroup/glslang/releases/download/main-tot/glslang-main-linux-x86_64-release.zip
-      folder: bin
+      # Upstream's main-tot release publishes both .zip and .tar.gz per platform,
+      # but the linux release .zip is not reliably present (infra#2299).
+      url: https://github.com/KhronosGroup/glslang/releases/download/main-tot/glslang-main-linux-x86_64-release.tar.gz
+      compression: gz
+      untar_dir: bin
       check_exe: glslang --version
       targets:
         - trunk


### PR DESCRIPTION
Refs #2299. Follow-up to #2323.

The nightly install of \`compilers/glsl/glslang trunk\` still 404s after #2323: upstream's \`main-tot\` release is meant to carry both a \`.zip\` and a \`.tar.gz\` for each platform ([continuous_deployment.yml](https://github.com/KhronosGroup/glslang/blob/main/.github/workflows/continuous_deployment.yml)), but the linux release \`.zip\` is not reliably there. Today's assets (all re-uploaded 2026-08-24 ~23:20 UTC):

```
glslang-main-linux-x86_64-debug.tar.gz
glslang-main-linux-x86_64-debug.zip
glslang-main-linux-x86_64-release.tar.gz     <- no .zip
glslang-main-macos-universal-release.tar.gz
glslang-main-macos-universal-release.zip
...
```

This switches the entry to \`tarballs\` with \`untar_dir: bin\`, the direct equivalent of the old \`folder: bin\`.

Test-installed into a scratch dest with \`--enable nightly --force-traditional\`:

```
Piping to tar zxf -
Moving from staging (.../bin) to final destination (.../glslang-trunk)
compilers/glsl/glslang trunk installed OK
1 packages installed OK, 0 skipped, and 0 failed installation
```

\`glslang-trunk/glslang --version\` reports 16.5.0 and the \`glslangValidator -> glslang\` symlink survives, so \`glsl.amazon.properties\` needs no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)