### PR TITLE
Make the dex2oat nightly install script fail at the first broken step

### DIFF
--- a/bin/yaml/android-java.yaml
+++ b/bin/yaml/android-java.yaml
@@ -68,6 +68,9 @@ compilers:
       if: nightly
       type: script
       script: |
+        # Fail at the first broken step: without this a failed fetch cascades into
+        # unzip/rm errors and a misleading "exit 127" from create_boot_images.sh.
+        set -euo pipefail
         mkdir dex2oat-{{name}}
         cd dex2oat-{{name}}
         {{yaml_dir}}/android-java/fetch_art_release_from_head.sh


### PR DESCRIPTION
Follow-up to #2324 / #2300.

When ci.android.com stopped serving the legacy API, `fetch_art_release_from_head.sh` exited 1 but the yaml `script:` block carried on: `unzip` and `rm` failed, then `create_boot_images.sh` tried to exec `x86_64/bin/dex2oat64`, which had never been extracted, and the whole install reported `bwrap ... returned non-zero exit status 127`. That got read (by humans and by the daily audit) as "bwrap missing", which sent us looking at the runner images rather than at the fetch.

This adds `set -euo pipefail` at the top of the dex2oat script so the first failing step is the one reported, following the precedent of `cutedsl`'s inline `set -eux`.

I looked at doing this systematically in `ScriptInstallable` (`bash -eo pipefail -c`) and don't think it's safe without auditing each of the 15 `script:` installables: the TI ones end with `rm installer.bin {{dir}}/*.log {{dir}}/*.run {{dir}}/*.dat`, which fails when a glob doesn't match; the Intel and NVIDIA installers exit non-zero on warnings; and `verify()` re-runs `stage()`, so a newly strict script could also start failing verification of already-installed compilers. Opt-in per script seems the right shape for now.

Test-installed `compilers/dex2oat` with `--enable nightly --force-traditional` into a scratch dest: `18 packages installed OK, 0 skipped, and 0 failed installation`, including `compilers/dex2oat/nightly latest`, with `boot.art`/`boot.oat`/`boot.vdex` produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)