### PR TITLE
Skip compilers that can never build Catch2 in the nightly library build

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1623,6 +1623,15 @@ libraries:
         - Catch2WithMain
         method: nightlyclone
         repo: catchorg/Catch2
+        # Catch2 v3 needs C++14 and a hosted standard library, so these can never
+        # build it and only add noise to the nightly build log.
+        skip_compilers:
+        - g485
+        - g510
+        - g550
+        - avrg1610
+        - m68kg1610
+        - shg1610
         targets:
         - trunk
         type: github


### PR DESCRIPTION
The `nightly/catch2` job fails every day upstream Catch2 has new commits (e.g. runs on 21, 23, 24, 25 Aug: `217 packages built OK, 0 skipped, and 57 failed build`) and "passes" with `0 built, 270 skipped` on days it doesn't. The first errors in the log are always gcc 4.8.5 failing on `operator"" _sr`, which is what the daily audit has been reporting as a catch2/compiler compatibility problem. It isn't one: Catch2 v3 requires C++14 (`target_compile_features(Catch2 PUBLIC cxx_std_14)`), and `_sr` is an ordinary constexpr UDL that hasn't changed upstream since 2025.

This adds `skip_compilers` (precedent: spdlog) for the compilers that cannot build Catch2 for reasons intrinsic to Catch2, i.e. the ones that fail on every one of their configs and always will:

| compiler | why |
|---|---|
| `g485`, `g510`, `g550` | no usable C++14: `operator"" _sr`, `std::remove_reference_t`, `operator>>` errors |
| `avrg1610`, `m68kg1610`, `shg1610` | freestanding: `fatal error: ctime: No such file or directory`, `type_traits` likewise |

That's 9 of the 57 failures. I deliberately left the rest alone because they are not about Catch2 and hiding them per library would be the wrong place:

- **33 failures are the `x86` + `libc++` config** on every clang 13 to 22, trunk, the assertion builds, armv7/armv8 clang: `fatal error: '__config_site' file not found`. The x86_64 libc++ and both libstdc++ configs of the same compilers build fine, so `skip_compilers` can't express it (`disable_clang_32bit`/`disable_clang_libcpp` are per compiler, not per combination). `fmt` fails the same way. A generic "does this compiler have a 32-bit libc++" probe in `library_builder.py` would fix it for every library.
- `g63`, `g72` (`gcc_ld-fix` builds): cmake's compiler test can't find `crt1.o`/`crti.o`. Environment.
- `arm1031_10`, `armug1520`, `armug1610`: cmake compiler test fails at link. Cross toolchains without a sysroot set up for cmake.
- `aocc520`: 32-bit configs only, `lib32/libstdc++.so is incompatible with elf64-x86-64`.
- `edg-6_8-default-15`: cmake rejects `target_compile_features`; `edg-experimental-reflection`: `eccp: cannot open object file`.

So the job will still go red on rebuild days after this; the noise it removes is the misleading part at the top of the log. Happy to follow up on the libc++/x86 probe separately if that's wanted, since it accounts for most of what's left.

Checked with `bin/ce_install --enable nightly list libraries/c++/nightly/catch2` that the entry still loads; I have no local conan setup to run the build itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)