### PR TITLE
LLVM + Clang 23.1.0

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -1182,6 +1182,8 @@ compilers:
           - assertions-22.1.0
           - 22.1.6
           - assertions-22.1.6
+          - 23.1.0
+          - assertions-23.1.0
     clang-hexagon:
       - type: tarballs
         check_exe: x86_64-linux-gnu/bin/clang++ --version

--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1334,6 +1334,7 @@ libraries:
       - 21.1.0
       - 22.1.0
       - 22.1.6
+      - 23.1.0
       type: s3tarballs
     magic_enum:
       check_file: include/magic_enum.hpp


### PR DESCRIPTION
Make the newly released LLVM and Clang 23.1.0 available in Compiler Explorer