### PR TITLE
Manage the useful Athena saved queries in terraform

### DIFF
--- a/terraform/athena.tf
+++ b/terraform/athena.tf
@@ -686,3 +686,64 @@ moved {
   from = aws_glue_catalog_table.compile_stats_table
   to   = aws_glue_catalog_table.compile_stats
 }
+
+locals {
+  athena_queries = {
+    posts_by_ip            = <<-SQL
+      SELECT request_ip, COUNT(*) count
+      FROM cloudfront_logs
+      WHERE method = 'POST' AND host != 'd357rrqhqvdcrj.cloudfront.net' AND status = 200
+      GROUP BY request_ip
+      ORDER BY count DESC
+    SQL
+    pageloads_by_day       = <<-SQL
+      SELECT date, COUNT(*) page_views
+      FROM stats
+      WHERE type = 'PageLoad'
+      GROUP BY date
+      ORDER BY date DESC
+    SQL
+    unique_ips_by_week     = <<-SQL
+      SELECT DATE_TRUNC('week', date) week, COUNT(DISTINCT request_ip) unique_ips
+      FROM cloudfront_logs
+      GROUP BY 1
+      ORDER BY week
+    SQL
+    api_unique_ips_by_week = <<-SQL
+      SELECT DATE_TRUNC('week', date) week, COUNT(DISTINCT request_ip) unique_ips
+      FROM cloudfront_logs
+      WHERE uri LIKE '/api/%'
+      GROUP BY 1
+      ORDER BY week
+    SQL
+    root_page_by_week      = <<-SQL
+      SELECT DATE_TRUNC('week', date) week, COUNT(*) count
+      FROM cloudfront_logs
+      WHERE uri = '/'
+      GROUP BY 1
+      ORDER BY week
+    SQL
+    recent_errors          = <<-SQL
+      SELECT date, time, status, host_header, uri, referrer
+      FROM cloudfront_logs
+      WHERE status >= 500 AND NOT uri LIKE '%beta%'
+      ORDER BY date DESC, time DESC
+      LIMIT 50
+    SQL
+    sponsor_views          = <<-SQL
+      SELECT value, COUNT(*) count
+      FROM stats
+      WHERE type = 'SponsorView' AND date >= current_date - interval '7' day
+      GROUP BY value
+      ORDER BY count DESC
+    SQL
+  }
+}
+
+resource "aws_athena_named_query" "queries" {
+  for_each  = local.athena_queries
+  name      = each.key
+  workgroup = aws_athena_workgroup.primary.name
+  database  = aws_glue_catalog_database.default.name
+  query     = each.value
+}


### PR DESCRIPTION
Refs #2330, last piece.

Seven `aws_athena_named_query` resources in the `primary` workgroup, recreated rather than imported. All seven run successfully against the current tables.

From the 20 existing saved queries: `posts_by_ip`, `pageloads_by_day`, `unique_ips_by_week` (one of four copies), `api_unique_ips_by_week`, `root_page_by_week`, `recent_errors` (the `RecentErrorsNoBetaFixed` one: excludes beta, newest first), `sponsor_views` (last 7 days instead of a hardcoded date).

Dropped: `python-by-day`, `TestQuery` (nonexistent `wbc` database), `Library Usage` (what `ce library_stats` does), the six `sampledb` samples, three duplicate `unique-ip-bweek`.

Plan: `7 to add, 0 to change, 0 to destroy`. After applying, the old queries can go: `for id in $(aws athena list-named-queries --work-group primary --query NamedQueryIds --output text); do aws athena delete-named-query --named-query-id $id; done` (run before apply, or the loop will delete the new ones too; filter by name otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)