### PR TITLE
Install `dumb-init` on Linux x86_64 and aarch64 nodes

### DIFF
--- a/setup-aarch64-node.sh
+++ b/setup-aarch64-node.sh
@@ -71,6 +71,13 @@ EOF
 apparmor_parser -r /etc/apparmor.d/usr.local.bin.nsjail
 popd
 
+pushd /tmp
+git clone --branch ce https://github.com/narpfel/dumb-init
+cd dumb-init
+make
+cp dumb-init /usr/local/bin/dumb-init
+popd
+
 
 pushd /opt
 # node.js

--- a/setup-node.sh
+++ b/setup-node.sh
@@ -82,6 +82,13 @@ EOF
 fi
 popd
 
+pushd /tmp
+git clone --branch ce https://github.com/narpfel/dumb-init
+cd dumb-init
+make
+cp dumb-init /usr/local/bin/dumb-init
+popd
+
 
 pushd /opt
 # node.js


### PR DESCRIPTION
This enables CE to properly report signals raised during execution.

Corresponding CE PR: https://github.com/compiler-explorer/compiler-explorer/pull/9074