### PR TITLE
Add Boost 1.91.0

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -443,6 +443,9 @@ libraries:
       - 1.88.0
       - 1.89.0
       - 1.90.0
+      - name: 1.91.0
+        untar_dir: boost-1.91.0-1
+        url: https://github.com/boostorg/boost/releases/download/boost-1.91.0-1/boost-1.91.0-1-cmake.tar.xz
       type: tarballs
       untar_dir: boost-{{name}}
       url: https://github.com/boostorg/boost/releases/download/boost-{{name}}/boost-{{name}}-cmake.tar.xz


### PR DESCRIPTION
Adds Boost 1.91.0 to `boost_bin`.

Boost re-tagged this release as `boost-1.91.0-1`, so the templated
`url`/`untar_dir` (`boost-{{name}}`) don't resolve. This target therefore
overrides both:

- url: `https://github.com/boostorg/boost/releases/download/boost-1.91.0-1/boost-1.91.0-1-cmake.tar.xz` (verified 200)
- untar_dir: `boost-1.91.0-1` (verified to be the tarball's top-level directory)

The install dir stays `libs/boost-1.91.0`, so the version is exposed as 1.91.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK4DRn5EjGM2K7gV7VCrf8