### PR TITLE
Add Boost 1.92.0

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -443,6 +443,7 @@ libraries:
       - 1.88.0
       - 1.89.0
       - 1.90.0
+      - 1.92.0
       type: tarballs
       untar_dir: boost-{{name}}
       url: https://github.com/boostorg/boost/releases/download/boost-{{name}}/boost-{{name}}-cmake.tar.xz


### PR DESCRIPTION
Adds Boost 1.92.0 to `boost_bin`. The standard templates resolve as-is:
`https://github.com/boostorg/boost/releases/download/boost-1.92.0/boost-1.92.0-cmake.tar.xz`
(verified 200, top-level dir `boost-1.92.0`).

1.91.0 is added separately in #2343, since it needs URL overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK4DRn5EjGM2K7gV7VCrf8