### PR TITLE
Add MicroPython v1.28.0 and v1.29.0.

### DIFF
--- a/bin/yaml/micropython.yaml
+++ b/bin/yaml/micropython.yaml
@@ -16,6 +16,7 @@ compilers:
       - 1.26.0
       - 1.26.1
       - 1.27.0
+      - 1.28.0
     nightly:
       if: nightly
       micropython:

--- a/bin/yaml/micropython.yaml
+++ b/bin/yaml/micropython.yaml
@@ -17,6 +17,7 @@ compilers:
       - 1.26.1
       - 1.27.0
       - 1.28.0
+      - 1.29.0
     nightly:
       if: nightly
       micropython:


### PR DESCRIPTION
- Add release MicroPython [v1.28.0](https://github.com/micropython/micropython/releases/tag/v1.28.0) from a few months ago.
- Add release MicroPython [v1.29.0](https://github.com/micropython/micropython/releases/tag/v1.29.0) from 2 weeks ago.
- Needed for https://github.com/compiler-explorer/compiler-explorer/pull/9113